### PR TITLE
Add fixtures for catalog app models

### DIFF
--- a/enterprise_catalog/apps/catalog/fixtures/catalogcontentkey.json
+++ b/enterprise_catalog/apps/catalog/fixtures/catalogcontentkey.json
@@ -1,0 +1,12 @@
+[
+    {
+        "model": "catalog.catalogcontentkey",
+        "pk": 1,
+        "fields": {
+            "created": "2019-12-23T15:10:25.957Z",
+            "modified": "2019-12-23T15:10:25.957Z",
+            "catalog_query": 1,
+            "content_key": "course-v1:edX+DemoX+Demo_Course"
+        }
+    }
+]

--- a/enterprise_catalog/apps/catalog/fixtures/catalogquery.json
+++ b/enterprise_catalog/apps/catalog/fixtures/catalogquery.json
@@ -1,0 +1,10 @@
+[
+    {
+        "model": "catalog.catalogquery",
+        "pk": 1,
+        "fields": {
+            "title": "All Course Runs",
+            "content_filter": "{\"content_type\":\"courserun\"}"
+        }
+    }
+]

--- a/enterprise_catalog/apps/catalog/fixtures/contentmetadata.json
+++ b/enterprise_catalog/apps/catalog/fixtures/contentmetadata.json
@@ -1,0 +1,14 @@
+[
+    {
+        "model": "catalog.contentmetadata",
+        "pk": 1,
+        "fields": {
+            "created": "2019-12-23T15:10:19.770Z",
+            "modified": "2019-12-23T15:10:19.770Z",
+            "content_key": "course-v1:edX+DemoX+Demo_Course",
+            "content_type": "course_run",
+            "parent_content_key": null,
+            "json_metadata": "{\"subject_uuids\":[],\"staff_uuids\":[],\"min_effort\":null,\"transcript_languages\":[],\"aggregation_key\":\"courserun:edX+DemoX\",\"published\":true,\"max_effort\":null,\"type\":\"verified\",\"image_url\":\"http://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg\",\"key\":\"course-v1:edX+DemoX+Demo_Course\",\"logo_image_urls\":[null],\"has_enrollable_seats\":true,\"first_enrollable_paid_seat_price\":149,\"org\":\"edX\",\"number\":\"DemoX\",\"level_type\":null,\"first_enrollable_paid_seat_sku\":\"8CF08E5\",\"title\":\"Demonstration Course\",\"go_live_date\":null,\"enrollment_start\":null,\"marketing_url\":\"course/demonstration-course\",\"enrollment_end\":null,\"weeks_to_complete\":null,\"content_type\":\"courserun\",\"partner\":\"edx\",\"seat_types\":[\"verified\",\"audit\"],\"program_types\":[],\"start\":\"2013-02-05T05:00:00Z\",\"end\":null,\"language\":null,\"availability\":\"Current\",\"full_description\":null,\"authoring_organization_uuids\":[\"b61a1979-8875-4956-8419-1822fe9f5373\"],\"short_description\":null,\"pacing_type\":\"instructor_paced\",\"mobile_available\":false}"
+        }
+    }
+]

--- a/enterprise_catalog/apps/catalog/fixtures/enterprisecatalog.json
+++ b/enterprise_catalog/apps/catalog/fixtures/enterprisecatalog.json
@@ -1,0 +1,15 @@
+[
+    {
+        "model": "catalog.enterprisecatalog",
+        "pk": "15adc665-b8a2-4ddc-9987-39452c43be55",
+        "fields": {
+            "created": "2019-12-23T15:06:27.320Z",
+            "modified": "2019-12-23T15:06:27.323Z",
+            "title": "Test Enterprise - All Course Runs",
+            "enterprise_uuid": "a94412c9-f91c-4d0d-87cb-1ca1c0d11457",
+            "catalog_query": 1,
+            "enabled_course_modes": "[\"verified\",\"professional\",\"no-id-professional\",\"audit\",\"honor\"]",
+            "publish_audit_enrollment_urls": false
+        }
+    }
+]


### PR DESCRIPTION
## Description

Adds basic fixtures for the 4 catalog models.

These can be imported into the `enterprise_catalog` database by running `./manage.py loaddata enterprise_catalog/apps/catalog/fixtures/*.json` in the shell.

## Ticket Link

[ENT-2447](https://openedx.atlassian.net/browse/ENT-2447)

## Post-review

Squash commits into discrete sets of changes
