### PR TITLE
Add release utils to resolve GoCD error

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -39,6 +39,7 @@ THIRD_PARTY_APPS = (
     'rest_framework_swagger',
     'social_django',
     'waffle',
+    'release_util',
 )
 
 PROJECT_APPS = (

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,6 +9,7 @@ django-simple-history
 django-waffle
 djangorestframework
 edx-auth-backends
+edx-django-release-util
 edx-drf-extensions
 edx-rest-api-client==1.9.2
 mysqlclient

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,7 @@ django==1.11.27
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.11.0
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2   # via edx-drf-extensions
 edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
@@ -30,7 +31,7 @@ jinja2==2.10.3            # via coreschema
 jsonfield==2.0.2
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6
-newrelic==5.4.0.132       # via edx-django-utils
+newrelic==5.4.1.134       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.4                # via stevedore
@@ -42,15 +43,16 @@ pymongo==3.10.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3
+pyyaml==5.2               # via edx-django-release-util
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.22.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
-semantic-version==2.8.3   # via edx-drf-extensions
+semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.13.0               # via django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.13.0               # via django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 stevedore==1.31.0         # via edx-opaque-keys
-uritemplate==3.0.0        # via coreapi
+uritemplate==3.0.1        # via coreapi
 urllib3==1.25.7           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ click==7.0
 code-annotations==0.3.3
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0
+coverage==5.0.1
 defusedxml==0.6.0
 diff-cover==2.5.0
 distlib==0.3.0
@@ -32,6 +32,7 @@ django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-i18n-tools==0.5.0
@@ -43,7 +44,7 @@ faker==3.0.0
 future==0.18.2
 idna==2.8
 importlib-metadata==1.3.0
-inflect==3.0.2            # via jinja2-pluralize
+inflect==4.0.0            # via jinja2-pluralize
 isort==4.3.21
 itypes==1.1.0
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -55,7 +56,7 @@ mccabe==0.6.1
 mock==3.0.5
 more-itertools==8.0.2
 mysqlclient==1.4.6
-newrelic==5.4.0.132
+newrelic==5.4.1.134
 oauthlib==3.1.0
 openapi-codec==1.3.2
 packaging==19.2
@@ -66,7 +67,7 @@ pip-tools==4.3.0
 pluggy==0.13.1
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
-py==1.8.0
+py==1.8.1
 pycodestyle==2.5.0
 pycryptodomex==3.9.4
 pydocstyle==5.0.1
@@ -78,7 +79,7 @@ pylint-django==2.0.11
 pylint-plugin-utils==0.6
 pylint==2.4.2
 pymongo==3.10.0
-pyparsing==2.4.5
+pyparsing==2.4.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest==5.3.2
@@ -90,7 +91,7 @@ pyyaml==5.2
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3
-semantic-version==2.8.3
+semantic-version==2.8.4
 simplejson==3.17.0
 six==1.13.0
 slumber==0.7.1
@@ -101,7 +102,7 @@ sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.31.0
 text-unidecode==1.3
 typed-ast==1.4.0
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.7
 wcwidth==0.1.7
 wrapt==1.11.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,7 +16,7 @@ click==7.0
 code-annotations==0.3.3
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0
+coverage==5.0.1
 defusedxml==0.6.0
 django-cors-headers==3.2.0
 django-dynamic-fixture==2.0.0
@@ -31,6 +31,7 @@ djangorestframework==3.11.0
 doc8==0.8.0
 docutils==0.15.2          # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-lint==1.4.1
@@ -41,7 +42,7 @@ factory-boy==2.12.0
 faker==3.0.0
 future==0.18.2
 idna==2.8
-imagesize==1.1.0          # via sphinx
+imagesize==1.2.0          # via sphinx
 importlib-metadata==1.3.0
 isort==4.3.21
 itypes==1.1.0
@@ -53,14 +54,14 @@ mccabe==0.6.1
 mock==3.0.5
 more-itertools==8.0.2
 mysqlclient==1.4.6
-newrelic==5.4.0.132
+newrelic==5.4.1.134
 oauthlib==3.1.0
 openapi-codec==1.3.2
 packaging==19.2
 pbr==5.4.4
 pluggy==0.13.1
 psutil==1.2.1
-py==1.8.0
+py==1.8.1
 pycryptodomex==3.9.4
 pygments==2.5.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
@@ -70,7 +71,7 @@ pylint-django==2.0.11
 pylint-plugin-utils==0.6
 pylint==2.4.2
 pymongo==3.10.0
-pyparsing==2.4.5
+pyparsing==2.4.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest==5.3.2
@@ -84,14 +85,14 @@ requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
-semantic-version==2.8.3
+semantic-version==2.8.4
 simplejson==3.17.0
 six==1.13.0
 slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0
 social-auth-core[openidconnect]==1.7.0
-sphinx==2.3.0
+sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
@@ -101,7 +102,7 @@ sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 stevedore==1.31.0
 text-unidecode==1.3
 typed-ast==1.4.0
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.7
 wcwidth==0.1.7
 webencodings==0.5.1       # via bleach

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,6 +19,7 @@ django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.1
@@ -33,7 +34,7 @@ jinja2==2.10.3
 jsonfield==2.0.2
 markupsafe==1.1.1
 mysqlclient==1.4.6
-newrelic==5.4.0.132
+newrelic==5.4.1.134
 oauthlib==3.1.0
 openapi-codec==1.3.2
 pbr==5.4.4
@@ -49,14 +50,14 @@ pyyaml==5.2
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3
-semantic-version==2.8.3
+semantic-version==2.8.4
 simplejson==3.17.0
 six==1.13.0
 slumber==0.7.1
 social-auth-app-django==1.2.0
 social-auth-core[openidconnect]==1.7.0
 stevedore==1.31.0
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.7
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,6 +26,7 @@ django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-lint==1.4.1
@@ -41,7 +42,7 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mysqlclient==1.4.6
-newrelic==5.4.0.132
+newrelic==5.4.1.134
 oauthlib==3.1.0
 openapi-codec==1.3.2
 packaging==19.2           # via caniusepython3
@@ -57,14 +58,15 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.0
-pyparsing==2.4.5          # via packaging
+pyparsing==2.4.6          # via packaging
 python-dateutil==2.8.1
 python3-openid==3.1.0
 pytz==2019.3
+pyyaml==5.2
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3
-semantic-version==2.8.3
+semantic-version==2.8.4
 simplejson==3.17.0
 six==1.13.0
 slumber==0.7.1
@@ -73,7 +75,7 @@ social-auth-app-django==1.2.0
 social-auth-core[openidconnect]==1.7.0
 stevedore==1.31.0
 typed-ast==1.4.0          # via astroid
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.7
 wrapt==1.11.2             # via astroid
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.3
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0
+coverage==5.0.1
 defusedxml==0.6.0
 django-cors-headers==3.2.0
 django-dynamic-fixture==2.0.0
@@ -26,6 +26,7 @@ django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-lint==1.4.1
@@ -46,14 +47,14 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==8.0.2     # via pytest, zipp
 mysqlclient==1.4.6
-newrelic==5.4.0.132
+newrelic==5.4.1.134
 oauthlib==3.1.0
 openapi-codec==1.3.2
 packaging==19.2           # via pytest
 pbr==5.4.4
 pluggy==0.13.1            # via pytest
 psutil==1.2.1
-py==1.8.0                 # via pytest
+py==1.8.1                 # via pytest
 pycryptodomex==3.9.4
 pyjwkest==1.3.2
 pyjwt==1.7.1
@@ -62,7 +63,7 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.0
-pyparsing==2.4.5          # via packaging
+pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest==5.3.2             # via pytest-cov, pytest-django
@@ -70,11 +71,11 @@ python-dateutil==2.8.1
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0
 pytz==2019.3
-pyyaml==5.2               # via code-annotations
+pyyaml==5.2
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3
-semantic-version==2.8.3
+semantic-version==2.8.4
 simplejson==3.17.0
 six==1.13.0
 slumber==0.7.1
@@ -83,7 +84,7 @@ social-auth-core[openidconnect]==1.7.0
 stevedore==1.31.0
 text-unidecode==1.3       # via faker, python-slugify
 typed-ast==1.4.0          # via astroid
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.7
 wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -16,7 +16,7 @@ click==7.0
 code-annotations==0.3.3
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0
+coverage==5.0.1
 defusedxml==0.6.0
 distlib==0.3.0
 django-cors-headers==3.2.0
@@ -30,6 +30,7 @@ django==1.11.27
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-auth-backends==2.0.2
+edx-django-release-util==0.3.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-lint==1.4.1
@@ -50,14 +51,14 @@ mccabe==0.6.1
 mock==3.0.5
 more-itertools==8.0.2
 mysqlclient==1.4.6
-newrelic==5.4.0.132
+newrelic==5.4.1.134
 oauthlib==3.1.0
 openapi-codec==1.3.2
 packaging==19.2
 pbr==5.4.4
 pluggy==0.13.1
 psutil==1.2.1
-py==1.8.0
+py==1.8.1
 pycodestyle==2.5.0
 pycryptodomex==3.9.4
 pydocstyle==5.0.1
@@ -68,7 +69,7 @@ pylint-django==2.0.11
 pylint-plugin-utils==0.6
 pylint==2.4.2
 pymongo==3.10.0
-pyparsing==2.4.5
+pyparsing==2.4.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest==5.3.2
@@ -80,7 +81,7 @@ pyyaml==5.2
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3
-semantic-version==2.8.3
+semantic-version==2.8.4
 simplejson==3.17.0
 six==1.13.0
 slumber==0.7.1
@@ -90,7 +91,7 @@ social-auth-core[openidconnect]==1.7.0
 stevedore==1.31.0
 text-unidecode==1.3
 typed-ast==1.4.0
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.7
 wcwidth==0.1.7
 wrapt==1.11.2


### PR DESCRIPTION
## Description

Installs the edx-django-release-util package (https://github.com/edx/edx-django-release-util) and adds it to the `INSTALLED_APPS`. This missing package is currently causing GoCD pipeline to fail.

## Post-review

Squash commits into discrete sets of changes
