### PR TITLE
Downgrade inflect to 3.0.2

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ faker==3.0.0
 future==0.18.2
 idna==2.8
 importlib-metadata==1.3.0
-inflect==4.0.0            # via jinja2-pluralize
+inflect==3.0.2            # via jinja2-pluralize
 isort==4.3.21
 itypes==1.1.0
 jinja2-pluralize==0.3.0   # via diff-cover


### PR DESCRIPTION
## Description

Downgrades `inflect` package back to 3.0.2 instead of 4.0.0. 4.0.0 was causing an issue that was causing https://github.com/edx/configuration/pull/5591 to fail:

```
"ERROR: Could not find a version that satisfies the requirement inflect==4.0.0 (from -r /tmp/tmpzipizpy_ (line 18)) (from versions: 0.1, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.2.0, 0.2.1, 0.2.3, 0.2.4, 0.2.5, 0.3.0, 0.3.1, 1.0.0, 1.0.1, 1.0.2, 2.0.0, 2.0.1, 2.1.0, 3.0.1, 3.0.2)\nERROR: No matching distribution found for inflect==4.0.0 (from -r /tmp/tmpzipizpy_ (line 18))\nTraceback (most recent call last):\n
```

This package was upgraded to 4.0.0 earlier today when running `make upgrade`.

## Ticket Link

Link to the associated ticket
[ENT-2446](https://openedx.atlassian.net/browse/ENT-2446)

## Post-review

Squash commits into discrete sets of changes
