### PR TITLE
Change oauth2 base route to fix redirect

### DIFF
--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -28,11 +28,11 @@ from enterprise_catalog.apps.core import views as core_views
 admin.autodiscover()
 
 urlpatterns = [
+    url(r'', include(oauth2_urlpatterns)),
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls)),
     url(r'^api-docs/', get_swagger_view(title='Enterprise Catalog API')),
     # Use the same auth views for all logins, including those originating from the browseable API.
-    url(r'', include(oauth2_urlpatterns)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^health/$', core_views.health, name='health'),
 ]

--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     url(r'^api/', include(api_urls)),
     url(r'^api-docs/', get_swagger_view(title='Enterprise Catalog API')),
     # Use the same auth views for all logins, including those originating from the browseable API.
-    url(r'^api-auth/', include(oauth2_urlpatterns)),
+    url(r'', include(oauth2_urlpatterns)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^health/$', core_views.health, name='health'),
 ]


### PR DESCRIPTION
## Description

Our redirect uri in the LMS doesn't expect the `api-auth` part of the path. This removes that part of the path to match the simple `/login` that most other IDAs use (and should hopefully fix the redirect issue)
