### PR TITLE
Explicitly asserting both values in json_metadata are correct in test.

### DIFF
--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -52,8 +52,10 @@ class TestModels(TestCase):
         mock_client.assert_called_once()
         assert ContentMetadata.objects.count() == 3
 
+        # Assert values in json_metadata are correct
         for metadata in metadata_list:
             cm = ContentMetadata.objects.get(
                 content_key=metadata['key']
             )
-            self.assertDictEqual(cm.json_metadata, metadata)
+            assert metadata['key'] == cm.json_metadata['key']
+            assert metadata['title'] == cm.json_metadata['title']


### PR DESCRIPTION
## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
