### PR TITLE
Set content_type and parent_content_key

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -12,7 +12,12 @@ from enterprise_catalog.apps.catalog.constants import (
     CONTENT_TYPE_CHOICES,
     json_serialized_course_modes,
 )
-from enterprise_catalog.apps.catalog.utils import get_content_filter_hash
+from enterprise_catalog.apps.catalog.utils import (
+    get_content_filter_hash,
+    get_content_key,
+    get_content_type,
+    get_parent_content_key,
+)
 
 
 class CatalogQuery(models.Model):
@@ -224,8 +229,11 @@ def update_contentmetadata_from_discovery(catalog_uuid):
     metadata = client.get_metadata_by_query(catalog.catalog_query.content_filter)
 
     for entry in metadata.get('results', []):
-        # Try to get the course/course run key as the content key, falling back to uuid for programs
-        defaults = {'content_key': entry.get('key') or entry.get('uuid')}
+        defaults = {
+            'content_key': get_content_key(entry),
+            'parent_content_key': get_parent_content_key(entry),
+            'content_type': get_content_type(entry),
+        }
         ContentMetadata.objects.update_or_create(
             json_metadata=entry,
             defaults=defaults,

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -5,6 +5,11 @@ from collections import OrderedDict
 import mock
 from django.test import TestCase
 
+from enterprise_catalog.apps.catalog.constants import (
+    COURSE,
+    COURSE_RUN,
+    PROGRAM,
+)
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     update_contentmetadata_from_discovery,
@@ -15,58 +20,52 @@ from enterprise_catalog.apps.catalog.tests import factories
 class TestModels(TestCase):
     """ Models tests. """
 
-    def _get_content_key(self, metadata):
-        """
-        Helper to get the content key, as it can be stored under either `key` or `uuid`.
-        """
-        return metadata.get('key') or metadata.get('uuid')
-
     @mock.patch('enterprise_catalog.apps.catalog.models.DiscoveryApiClient')
     def test_contentmetadata_update_from_discovery(self, mock_client):
         """
         update_contentmetadata_from_discovery should update or create
         ContentMetadata Objects from the discovery service api call/
         """
-        metadata_list = [
-            OrderedDict([('key', 'course-v1:my+course+1'), ('title', 'course 1')]),
-            OrderedDict([('key', 'course-v1:my+course+2'), ('title', 'course 2')]),
-            OrderedDict([('key', 'course-v1:my+course+3'), ('title', 'course 3')]),
-            OrderedDict([('uuid', 'fake-uuid'), ('title', 'program 1')]),
-        ]
+        course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+testX'),
+            ('key', 'edX+testX'),
+            ('title', 'test course'),
+        ])
+        course_run_metadata = OrderedDict([
+            ('aggregation_key', 'courserun:edX+testX'),
+            ('key', 'course-v1:edX+testX+1'),
+            ('title', 'test course run'),
+        ])
+        program_metadata = OrderedDict([
+            ('aggregation_key', 'program:fake-uuid'),
+            ('title', 'test program'),
+            ('uuid', 'fake-uuid'),
+        ])
         mock_client.return_value.get_metadata_by_query.return_value = {
-            'count': 4,
+            'count': 3,
             'previous': None,
             'next': None,
-            'results': [
-                {
-                    'key': metadata_list[0]['key'],
-                    'title': metadata_list[0]['title'],
-                },
-                {
-                    'key': metadata_list[1]['key'],
-                    'title': metadata_list[1]['title'],
-                },
-                {
-                    'key': metadata_list[2]['key'],
-                    'title': metadata_list[2]['title'],
-                },
-                {
-                    'uuid': metadata_list[3]['uuid'],
-                    'title': metadata_list[3]['title'],
-                },
-            ]
+            'results': [course_metadata, course_run_metadata, program_metadata],
         }
         catalog = factories.EnterpriseCatalogFactory()
 
         self.assertEqual(ContentMetadata.objects.count(), 0)
         update_contentmetadata_from_discovery(catalog.uuid)
         mock_client.assert_called_once()
-        self.assertEqual(ContentMetadata.objects.count(), 4)
+        self.assertEqual(ContentMetadata.objects.count(), 3)
 
-        # Assert values in json_metadata are correct
-        for metadata in metadata_list:
-            metadata_key = self._get_content_key(metadata)
-            cm = ContentMetadata.objects.get(content_key=metadata_key)
-            json_metadata_key = self._get_content_key(cm.json_metadata)
-            self.assertEqual(json_metadata_key, metadata_key)
-            self.assertEqual(cm.json_metadata['title'], metadata['title'])
+        # Assert stored content metadata is correct for each type
+        course_cm = ContentMetadata.objects.get(content_key=course_metadata['key'])
+        self.assertEqual(course_cm.content_type, COURSE)
+        self.assertEqual(course_cm.parent_content_key, None)
+        self.assertEqual(course_cm.json_metadata, course_metadata)
+
+        course_run_cm = ContentMetadata.objects.get(content_key=course_run_metadata['key'])
+        self.assertEqual(course_run_cm.content_type, COURSE_RUN)
+        self.assertEqual(course_run_cm.parent_content_key, course_metadata['key'])
+        self.assertEqual(course_run_cm.json_metadata, course_run_metadata)
+
+        program_cm = ContentMetadata.objects.get(content_key=program_metadata['uuid'])
+        self.assertEqual(program_cm.content_type, PROGRAM)
+        self.assertEqual(program_cm.parent_content_key, None)
+        self.assertEqual(program_cm.json_metadata, program_metadata)

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -26,6 +26,8 @@ def get_content_key(metadata):
 def _partition_aggregation_key(aggregation_key):
     """
     Partitions the aggregation_key field from discovery to return the type and key of the content it represents
+
+    Note that the content_key for a course run refers to a course rather than itself
     """
     content_type, _, content_key = aggregation_key.partition(':')
     return content_type, content_key

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -7,8 +7,48 @@ from __future__ import absolute_import, division, unicode_literals
 import hashlib
 import json
 
+from enterprise_catalog.apps.catalog.constants import COURSE_RUN
+
 
 def get_content_filter_hash(content_filter):
     content_filter_sorted_keys = json.dumps(content_filter, sort_keys=True).encode()
     content_filter_hash = hashlib.md5(content_filter_sorted_keys).hexdigest()
     return content_filter_hash
+
+def get_content_key(metadata):
+    """
+    Returns the content key of a piece of metadata
+
+    Try to get the course/course run key as the content key, falling back to uuid for programs
+    """
+    return metadata.get('key') or metadata.get('uuid')
+
+def _partition_aggregation_key(aggregation_key):
+    """
+    Partitions the aggregation_key field from discovery to return the type and key of the content it represents
+    """
+    content_type, _, content_key = aggregation_key.partition(':')
+    return content_type, content_key
+
+def get_parent_content_key(metadata):
+    """
+    Returns the content key of the parent object from a piece of metadata
+
+    This is meant to be used on metadata from the /search/all discovery endpoint. If the metadata represents a
+    course run, then the parent content key is the key of the course it belongs to. Otherwise, returns None
+    """
+    aggregation_key = metadata.get('aggregation_key', '')
+    content_type, content_key = _partition_aggregation_key(aggregation_key)
+    parent_content_key = None
+    if content_type == COURSE_RUN:
+        parent_content_key = content_key
+
+    return parent_content_key
+
+def get_content_type(metadata):
+    """
+    Returns the content type associated with a piece of metadata
+    """
+    aggregation_key = metadata.get('aggregation_key', '')
+    content_type, _ = _partition_aggregation_key(aggregation_key)
+    return content_type


### PR DESCRIPTION
## Description

Set `content_type` and `parent_content_key` on `ContentMetadata` objects when updating metadata from discovery

## Ticket Link
[ENT-2585](https://openedx.atlassian.net/browse/ENT-2585)

## Post-review

Squash commits into discrete sets of changes
