### PR TITLE
Adding tests for incorrect JWT context

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -576,7 +576,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         """
         self.remove_role_assignments()
         base_url = self._get_contains_content_base_url(enterprise_uuid=uuid.uuid4())
-        url =  base_url + '?course_run_ids=fakeX'
+        url = base_url + '?course_run_ids=fakeX'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -130,6 +130,17 @@ class EnterpriseCatalogViewSetTests(APITestMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_detail_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the viewset rejects users that are catalog admins with an invalid
+        context (i.e., enterprise uuid) for the detail route.
+        """
+        enterprise_catalog = EnterpriseCatalogFactory()
+        self.remove_role_assignments()
+        url = reverse('api:v1:enterprise-catalog-detail', kwargs={'uuid': enterprise_catalog.uuid})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @mock.patch('enterprise_catalog.apps.api.v1.serializers.update_catalog_metadata_task.delay')
     @ddt.data(
         (False),
@@ -179,6 +190,18 @@ class EnterpriseCatalogViewSetTests(APITestMixin):
         response = self.client.patch(url, patch_data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_patch_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the viewset rejects patch for users that are catalog admins with an invalid
+        context (i.e., enterprise uuid)
+        """
+        enterprise_catalog = EnterpriseCatalogFactory()
+        self.remove_role_assignments()
+        url = reverse('api:v1:enterprise-catalog-detail', kwargs={'uuid': enterprise_catalog.uuid})
+        patch_data = {'title': 'Patch title'}
+        response = self.client.patch(url, patch_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @mock.patch('enterprise_catalog.apps.api.v1.serializers.update_catalog_metadata_task.delay')
     @ddt.data(
         (False),
@@ -213,6 +236,17 @@ class EnterpriseCatalogViewSetTests(APITestMixin):
         self.set_up_non_catalog_admin()
         self.remove_role_assignments()
         url = reverse('api:v1:enterprise-catalog-detail', kwargs={'uuid': self.enterprise_catalog.uuid})
+        response = self.client.put(url, self.new_catalog_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_put_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the viewset rejects put for users that are catalog admins with an invalid
+        context (i.e., enterprise uuid)
+        """
+        enterprise_catalog = EnterpriseCatalogFactory()
+        self.remove_role_assignments()
+        url = reverse('api:v1:enterprise-catalog-detail', kwargs={'uuid': enterprise_catalog.uuid})
         response = self.client.put(url, self.new_catalog_data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -267,6 +301,24 @@ class EnterpriseCatalogViewSetTests(APITestMixin):
         response = self.client.post(url, self.new_catalog_data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_post_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the viewset rejects post for users that are catalog admins with an invalid
+        context (i.e., enterprise uuid)
+        """
+        catalog_data = {
+            'uuid': self.new_catalog_uuid,
+            'title': 'Test Title',
+            'enterprise_customer': uuid.uuid4(),
+            'enabled_course_modes': '["verified"]',
+            'publish_audit_enrollment_urls': True,
+            'content_filter': '{"content_type":"course"}',
+        }
+        self.remove_role_assignments()
+        url = reverse('api:v1:enterprise-catalog-list')
+        response = self.client.post(url, catalog_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def _get_contains_content_base_url(self, enterprise_catalog):
         """
         Helper to construct the base url for the contains_content_items endpoint
@@ -296,6 +348,17 @@ class EnterpriseCatalogViewSetTests(APITestMixin):
         self.set_up_non_catalog_admin()
         self.remove_role_assignments()
         url = self._get_contains_content_base_url(self.enterprise_catalog) + '?program_uuids=test-uuid'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_contains_content_items_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the contains_content_items endpoint rejects catalog admin user with
+        an invalid JWT context (i.e., enterprise uuid)
+        """
+        enterprise_catalog = EnterpriseCatalogFactory()
+        self.remove_role_assignments()
+        url = self._get_contains_content_base_url(enterprise_catalog) + '?course_run_ids=fakeX'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -374,6 +437,17 @@ class EnterpriseCatalogViewSetTests(APITestMixin):
         self.set_up_non_catalog_admin()
         self.remove_role_assignments()
         url = self._get_content_metadata_url(self.enterprise_catalog)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_content_metadata_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the get_content_metadata endpoint rejects catalog admin users
+        with an incorrect JWT context (i.e., enterprise uuid)
+        """
+        enterprise_catalog = EnterpriseCatalogFactory()
+        self.remove_role_assignments()
+        url = self._get_content_metadata_url(enterprise_catalog)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -464,13 +538,16 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         super(EnterpriseCustomerViewSetTests, self).setUp()
         self.enterprise_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
 
-    def _get_contains_content_base_url(self):
+    def _get_contains_content_base_url(self, enterprise_uuid=None):
         """
         Helper to construct the base url for the contains_content_items endpoint
         """
+        uuid = self.enterprise_uuid
+        if enterprise_uuid:
+            uuid = enterprise_uuid
         return reverse(
             'api:v1:enterprise-customer-contains-content-items',
-            kwargs={'enterprise_uuid': self.enterprise_uuid},
+            kwargs={'enterprise_uuid': uuid},
         )
 
     def test_contains_content_items_unauthorized_non_staff(self):
@@ -489,6 +566,17 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         self.set_up_non_catalog_admin()
         self.remove_role_assignments()
         url = self._get_contains_content_base_url() + '?course_run_ids=fakeX'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_contains_content_items_unauthorized_incorrect_jwt_context(self):
+        """
+        Verify the contains_content_items endpoint rejects users that are catalog admins
+        with an incorrect JWT context (i.e., enterprise uuid)
+        """
+        self.remove_role_assignments()
+        base_url = self._get_contains_content_base_url(enterprise_uuid=uuid.uuid4())
+        url =  base_url + '?course_run_ids=fakeX'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -542,12 +542,9 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         """
         Helper to construct the base url for the contains_content_items endpoint
         """
-        uuid = self.enterprise_uuid
-        if enterprise_uuid:
-            uuid = enterprise_uuid
         return reverse(
             'api:v1:enterprise-customer-contains-content-items',
-            kwargs={'enterprise_uuid': uuid},
+            kwargs={'enterprise_uuid': enterprise_uuid or self.enterprise_uuid},
         )
 
     def test_contains_content_items_unauthorized_non_staff(self):

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -53,7 +53,7 @@ class EnterpriseCatalogViewSet(BaseViewSet, viewsets.ModelViewSet):
         """
         Retrieves the apporpriate object to use during edx-rbac's permission checks.
 
-        This object is passed to the the rule predicate(s).
+        This object is passed to the rule predicate(s).
         """
         request_action = getattr(self, 'action', None)
         if request_action == 'create':
@@ -117,7 +117,7 @@ class EnterpriseCatalogRefreshDataFromDiscovery(BaseViewSet, APIView):
         """
         Retrieves the apporpriate object to use during edx-rbac's permission checks.
 
-        This object is passed to the the rule predicate(s).
+        This object is passed to the rule predicate(s).
         """
         uuid = self.kwargs.get('uuid')
         enterprise_catalog = get_object_or_404(EnterpriseCatalog, uuid=uuid)
@@ -142,7 +142,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
         """
         Retrieves the apporpriate object to use during edx-rbac's permission checks.
 
-        This object is passed to the the rule predicate(s).
+        This object is passed to the rule predicate(s).
         """
         return self.kwargs.get('enterprise_uuid')
 

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -11,7 +11,7 @@ from edx_rest_api_client.client import OAuthAPIClient
 
 class DiscoveryApiClient:
     """
-    Object builds an API client to make calls to the the Discovery Service.
+    Object builds an API client to make calls to the Discovery Service.
     """
     SEARCH_ALL_EXTENSION = 'search/all/'
     SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, SEARCH_ALL_EXTENSION)

--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -67,7 +67,7 @@ class EnterpriseCatalogAdmin(UnchangeableMixin):
 
 
 @admin.register(EnterpriseCatalogRoleAssignment)
-class EnterpriseDataRoleAssignmentAdmin(UnchangeableMixin, UserRoleAssignmentAdmin):
+class EnterpriseDataRoleAssignmentAdmin(UserRoleAssignmentAdmin):
     """
     Django admin for EnterpriseCatalogRoleAssignment Model.
     """

--- a/enterprise_catalog/apps/catalog/tests/test_rules.py
+++ b/enterprise_catalog/apps/catalog/tests/test_rules.py
@@ -2,6 +2,7 @@
 """
 Tests for the edx-rbac rules predicates.
 """
+import uuid
 import ddt
 import mock
 
@@ -53,6 +54,16 @@ class TestCatalogRBACPermissions(APITestMixin):
     @ddt.unpack
     def test_has_implicit_access_no_context(self, permission, system_wide_role, get_current_request_mock):
         get_current_request_mock.return_value = self.get_request_with_jwt_cookie(system_wide_role)
+        assert not self.user.has_perm(permission, TEST_ENTERPRISE_UUID)
+
+    @mock.patch('enterprise_catalog.apps.catalog.rules.crum.get_current_request')
+    @ddt.data(
+        ('catalog.has_admin_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE),
+        ('catalog.has_admin_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE),
+    )
+    @ddt.unpack
+    def test_has_implicit_access_incorrent_context(self, permission, system_wide_role, get_current_request_mock):
+        get_current_request_mock.return_value = self.get_request_with_jwt_cookie(system_wide_role, uuid.uuid4())
         assert not self.user.has_perm(permission, TEST_ENTERPRISE_UUID)
 
     @mock.patch('enterprise_catalog.apps.catalog.rules.crum.get_current_request')

--- a/enterprise_catalog/apps/catalog/tests/test_rules.py
+++ b/enterprise_catalog/apps/catalog/tests/test_rules.py
@@ -62,7 +62,11 @@ class TestCatalogRBACPermissions(APITestMixin):
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE),
     )
     @ddt.unpack
-    def test_has_implicit_access_incorrent_context(self, permission, system_wide_role, get_current_request_mock):
+    def test_has_implicit_access_incorrect_context(self, permission, system_wide_role, get_current_request_mock):
+        """
+        Verify the implicit permissions check fails when the JWT context (i.e., enterprise uuid) does not match
+        the context provided to `self.user.has_perm`.
+        """
         get_current_request_mock.return_value = self.get_request_with_jwt_cookie(system_wide_role, uuid.uuid4())
         assert not self.user.has_perm(permission, TEST_ENTERPRISE_UUID)
 

--- a/enterprise_catalog/apps/catalog/tests/test_rules.py
+++ b/enterprise_catalog/apps/catalog/tests/test_rules.py
@@ -3,6 +3,7 @@
 Tests for the edx-rbac rules predicates.
 """
 import uuid
+
 import ddt
 import mock
 


### PR DESCRIPTION
## Description

Adding tests for incorrect JWT context (i.e., enterprise uuid).

## Post-review

Squash commits into discrete sets of changes
