### PR TITLE
docker app name fix, settings updated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # ports:
     #  - "3307:3306"
 
-  enterprise_catalog:
+  app:
     # Uncomment this line to use the official catalog base image
     # image: edxops/enterprise_catalog:devstack
     build:

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -275,9 +275,6 @@ CELERY_TRACK_STARTED = True
 CELERY_SEND_EVENTS = True
 CELERY_SEND_TASK_SENT_EVENT = True
 
-# let logging work as configured:
-CELERYD_HIJACK_ROOT_LOGGER = True
-
 # Celery task routing configuration.
 # Only the enterprise-catalog worker should receive enterprise-catalog tasks.
 # Explicitly define these to avoid name collisions with other services

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -47,6 +47,7 @@ ALLOWED_HOSTS = ['*']
 
 DISCOVERY_SERVICE_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
 
+CELERYD_HIJACK_ROOT_LOGGER = True
 CELERY_ALWAYS_EAGER = (
     os.environ.get("CELERY_ALWAYS_EAGER", "false").lower() == "true"
 )

--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -50,6 +50,8 @@ DB_OVERRIDES = dict(
     PORT=environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
 )
 
+CELERYD_HIJACK_ROOT_LOGGER = False
+
 BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
     CELERY_BROKER_TRANSPORT,
     CELERY_BROKER_USER,


### PR DESCRIPTION
## Description

The webapp container name was updated in the docker-compose file to simplify the container information (previous name was redundant).

Django logging settings needed in devstack seem to suppress logging in production. The setting was taken out of base.py and replaced in devstack.py and production.py with the appropriate setting for each environment. 

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
