### PR TITLE
BOM-1347: Create Django 2.x Travis workers 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,27 @@
 language: python
-python:
-    - 3.5
+
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=django111
+      script: make test
+    - python: 3.5
+      env: TOXENV=django20
+      script: make test
+    - python: 3.5
+      env: TOXENV=django21
+      script: make test
+    - python: 3.5
+      env: TOXENV=django22
+      script: make test
+    - python: 3.5
+      env: TESTNAME=quality
+      script:
+        - make quality
+        - make pii_check
+    - python: 3.5
+      env: TESTNAME=translations
+      script: make validate_translations
 sudo: false
 branches:
   only:
@@ -10,11 +31,5 @@ cache: pip
 install:
     - pip install -U pip wheel codecov
     - make requirements
-script:
-    - make validate_translations
-    - make validate
-    - make pii_check
-    - make quality
-    - make test
 after_success:
     - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := test
-
+TOX = ''
 .PHONY: help clean piptools requirements dev_requirements \
         doc_requirementsprod_requirements static shell test coverage \
         isort_check isort style lint quality pii_check validate \
@@ -19,6 +19,10 @@ webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
 endef
 export BROWSER_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+ifdef TOXENV
+TOX := tox -- #to isolate each tox environment if TOXENV is defined
+endif
 
 # Generates a help message. Borrowed from https://github.com/pydanny/cookiecutter-djangopackage.
 help: ## display this help message
@@ -52,7 +56,7 @@ shell: ## run Django shell
 	python manage.py shell
 
 test: clean ## run tests and generate coverage report
-	python -Wd -m pytest
+	$(TOX)python -Wd -m pytest
 
 # To be run from CI context
 coverage: clean

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -65,7 +65,6 @@ MIDDLEWARE = (
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,38 +7,38 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-celery==3.1.26.post2      # via -r requirements/base.in (line 23)
+celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.2.1  # via -r requirements/base.in (line 6)
-django-crum==0.7.5        # via -r requirements/base.in (line 7), edx-rbac
-django-extensions==2.2.8  # via -r requirements/base.in (line 8)
-django-model-utils==3.2.0  # via -r requirements/base.in (line 9), edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.in (line 10)
-django-simple-history==2.8.0  # via -r requirements/base.in (line 11)
-django-waffle==0.20.0     # via -r requirements/base.in (line 12), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/base.in (line 5), django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django-cors-headers==3.2.1  # via -r requirements/base.in
+django-crum==0.7.5        # via -r requirements/base.in, edx-rbac
+django-extensions==2.2.8  # via -r requirements/base.in
+django-model-utils==3.2.0  # via -r requirements/base.in, edx-rbac
+django-rest-swagger==2.2.0  # via -r requirements/base.in
+django-simple-history==2.8.0  # via -r requirements/base.in
+django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/base.in (line 14)
-djangorestframework==3.11.0  # via -r requirements/base.in (line 13), django-rest-swagger, edx-drf-extensions, rest-condition
-edx-auth-backends==3.0.2  # via -r requirements/base.in (line 15)
-edx-django-release-util==0.3.6  # via -r requirements/base.in (line 16)
+djangorestframework-xml==1.4.0  # via -r requirements/base.in
+djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, edx-drf-extensions, rest-condition
+edx-auth-backends==3.0.2  # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.in (line 17), edx-rbac
+edx-drf-extensions==3.0.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.in (line 18)
-edx-rest-api-client==1.9.2  # via -r requirements/base.in (line 19)
+edx-rbac==1.1.1           # via -r requirements/base.in
+edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 itypes==1.1.0             # via coreapi
 jinja2==2.11.1            # via coreschema
-jsonfield2==3.0.3         # via -r requirements/base.in (line 22)
+jsonfield2==3.0.3         # via -r requirements/base.in
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
-mysqlclient==1.4.6        # via -r requirements/base.in (line 20)
+mysqlclient==1.4.6        # via -r requirements/base.in
 newrelic==5.8.0.136       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
@@ -50,20 +50,20 @@ pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/base.in (line 21), celery, django
+pytz==2019.3              # via -r requirements/base.in, celery, django
 pyyaml==5.3               # via edx-django-release-util
-redis==2.8                # via -r requirements/base.in (line 24)
+redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
-rules==2.2                # via -r requirements/base.in (line 25)
+rules==2.2                # via -r requirements/base.in
 semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
 six==1.14.0               # via django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in (line 5), edx-auth-backends
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
 stevedore==1.32.0         # via edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.8           # via requests
-zipp==1.2.0               # via -r requirements/base.in (line 26)
+zipp==1.2.0               # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,121 +4,127 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/quality.txt (line 7), -r requirements/test.txt (line 7), kombu
-anyjson==0.3.3            # via -r requirements/quality.txt (line 8), -r requirements/test.txt (line 8), kombu
-argparse==1.4.0           # via -r requirements/quality.txt (line 9), caniusepython3
-astroid==2.3.3            # via -r requirements/quality.txt (line 10), -r requirements/test.txt (line 9), pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt (line 10), pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt (line 11), caniusepython3
-billiard==3.3.0.23        # via -r requirements/quality.txt (line 12), -r requirements/test.txt (line 11), celery
-caniusepython3==7.2.0     # via -r requirements/quality.txt (line 13)
-celery==3.1.26.post2      # via -r requirements/quality.txt (line 14), -r requirements/test.txt (line 12)
-certifi==2019.11.28       # via -r requirements/quality.txt (line 15), -r requirements/test.txt (line 13), requests
-chardet==3.0.4            # via -r requirements/quality.txt (line 16), -r requirements/test.txt (line 14), requests
-click-log==0.3.2          # via -r requirements/quality.txt (line 17), -r requirements/test.txt (line 15), edx-lint
-click==7.0                # via -r requirements/pip-tools.txt (line 7), -r requirements/quality.txt (line 18), -r requirements/test.txt (line 16), click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.3.3   # via -r requirements/test.txt (line 17)
-coreapi==2.3.3            # via -r requirements/quality.txt (line 19), -r requirements/test.txt (line 18), django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/quality.txt (line 20), -r requirements/test.txt (line 19), coreapi
-coverage==5.0.3           # via -r requirements/test.txt (line 20), pytest-cov
-ddt==1.2.2                # via -r requirements/dev.in (line 13), -r requirements/test.txt (line 21)
-defusedxml==0.6.0         # via -r requirements/quality.txt (line 21), -r requirements/test.txt (line 22), djangorestframework-xml, python3-openid, social-auth-core
-diff-cover==2.6.0         # via -r requirements/dev.in (line 8)
-distlib==0.3.0            # via -r requirements/quality.txt (line 22), caniusepython3
-django-cors-headers==3.2.1  # via -r requirements/quality.txt (line 23), -r requirements/test.txt (line 23)
-django-crum==0.7.5        # via -r requirements/quality.txt (line 24), -r requirements/test.txt (line 24), edx-rbac
-django-debug-toolbar==2.2  # via -r requirements/dev.in (line 10)
-django-dynamic-fixture==3.0.3  # via -r requirements/test.txt (line 25)
-django-extensions==2.2.8  # via -r requirements/quality.txt (line 25), -r requirements/test.txt (line 26)
-django-model-utils==3.2.0  # via -r requirements/quality.txt (line 26), -r requirements/test.txt (line 27), edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/quality.txt (line 27), -r requirements/test.txt (line 28)
-django-simple-history==2.8.0  # via -r requirements/quality.txt (line 28), -r requirements/test.txt (line 29)
-django-waffle==0.20.0     # via -r requirements/quality.txt (line 29), -r requirements/test.txt (line 30), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/quality.txt (line 30), -r requirements/test.txt (line 31), code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
-djangorestframework-jwt==1.11.0  # via -r requirements/quality.txt (line 31), -r requirements/test.txt (line 32), edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/quality.txt (line 32), -r requirements/test.txt (line 33)
-djangorestframework==3.11.0  # via -r requirements/quality.txt (line 33), -r requirements/test.txt (line 34), django-rest-swagger, edx-drf-extensions, rest-condition
-edx-auth-backends==3.0.2  # via -r requirements/quality.txt (line 34), -r requirements/test.txt (line 35)
-edx-django-release-util==0.3.6  # via -r requirements/quality.txt (line 35), -r requirements/test.txt (line 36)
-edx-django-utils==3.0     # via -r requirements/quality.txt (line 36), -r requirements/test.txt (line 37), edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/quality.txt (line 37), -r requirements/test.txt (line 38), edx-rbac
-edx-i18n-tools==0.5.0     # via -r requirements/dev.in (line 9)
-edx-lint==1.4.1           # via -r requirements/quality.txt (line 38), -r requirements/test.txt (line 39)
-edx-opaque-keys==2.0.1    # via -r requirements/quality.txt (line 39), -r requirements/test.txt (line 40), edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/quality.txt (line 40), -r requirements/test.txt (line 41)
-edx-rest-api-client==1.9.2  # via -r requirements/quality.txt (line 41), -r requirements/test.txt (line 42)
-factory-boy==2.12.0       # via -r requirements/test.txt (line 43)
-faker==4.0.1              # via -r requirements/test.txt (line 44), factory-boy
-future==0.18.2            # via -r requirements/quality.txt (line 42), -r requirements/test.txt (line 45), pyjwkest
-idna==2.9                 # via -r requirements/quality.txt (line 43), -r requirements/test.txt (line 46), requests
-importlib-metadata==1.5.0  # via -r requirements/test.txt (line 47), inflect, path, pluggy, pytest
-inflect==3.0.2            # via -r requirements/dev.in (line 12), jinja2-pluralize
-isort==4.3.21             # via -r requirements/quality.txt (line 44), -r requirements/test.txt (line 48), pylint
-itypes==1.1.0             # via -r requirements/quality.txt (line 45), -r requirements/test.txt (line 49), coreapi
+amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
+anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
+appdirs==1.4.3            # via -r requirements/test.txt, virtualenv
+argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
+astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/test.txt, pytest
+backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, caniusepython3
+billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
+caniusepython3==7.2.0     # via -r requirements/quality.txt
+celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt
+certifi==2019.11.28       # via -r requirements/quality.txt, -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
+click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
+click==7.0                # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
+code-annotations==0.3.3   # via -r requirements/test.txt
+coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
+coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
+coverage==5.0.3           # via -r requirements/test.txt, pytest-cov
+ddt==1.2.2                # via -r requirements/dev.in, -r requirements/test.txt
+defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
+diff-cover==2.6.0         # via -r requirements/dev.in
+distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, virtualenv
+django-cors-headers==3.2.1  # via -r requirements/quality.txt, -r requirements/test.txt
+django-crum==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-debug-toolbar==2.2  # via -r requirements/dev.in
+django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
+django-extensions==2.2.8  # via -r requirements/quality.txt, -r requirements/test.txt
+django-model-utils==3.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-simple-history==2.8.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+djangorestframework-jwt==1.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+djangorestframework-xml==1.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
+djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, edx-drf-extensions, rest-condition
+edx-auth-backends==3.0.2  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-django-release-util==0.3.6  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-django-utils==3.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==3.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+edx-i18n-tools==0.5.0     # via -r requirements/dev.in
+edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-opaque-keys==2.0.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.1.1           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
+factory-boy==2.12.0       # via -r requirements/test.txt
+faker==4.0.1              # via -r requirements/test.txt, factory-boy
+filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
+future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
+idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
+importlib-metadata==1.5.0  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==1.2.0  # via -r requirements/test.txt, virtualenv
+inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
+isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
+itypes==1.1.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1            # via -r requirements/quality.txt (line 46), -r requirements/test.txt (line 50), code-annotations, coreschema, diff-cover, jinja2-pluralize
-jsonfield2==3.0.3         # via -r requirements/quality.txt (line 47), -r requirements/test.txt (line 51)
-kombu==3.0.37             # via -r requirements/quality.txt (line 48), -r requirements/test.txt (line 52), celery
-lazy-object-proxy==1.4.3  # via -r requirements/quality.txt (line 49), -r requirements/test.txt (line 53), astroid
-markupsafe==1.1.1         # via -r requirements/quality.txt (line 50), -r requirements/test.txt (line 54), jinja2
-mccabe==0.6.1             # via -r requirements/quality.txt (line 51), -r requirements/test.txt (line 55), pylint
-mock==3.0.5               # via -r requirements/test.txt (line 56)
-more-itertools==8.2.0     # via -r requirements/test.txt (line 57), pytest
-mysqlclient==1.4.6        # via -r requirements/quality.txt (line 52), -r requirements/test.txt (line 58)
-newrelic==5.8.0.136       # via -r requirements/quality.txt (line 53), -r requirements/test.txt (line 59), edx-django-utils
-oauthlib==3.1.0           # via -r requirements/quality.txt (line 54), -r requirements/test.txt (line 60), requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/quality.txt (line 55), -r requirements/test.txt (line 61), django-rest-swagger
-packaging==20.1           # via -r requirements/quality.txt (line 56), -r requirements/test.txt (line 62), caniusepython3, pytest
+jinja2==2.11.1            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
+jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
+kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
+lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
+markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
+mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
+mock==3.0.5               # via -r requirements/test.txt
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
+mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
+newrelic==5.8.0.136       # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
+openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
+packaging==20.1           # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
-pathlib2==2.3.5           # via -r requirements/test.txt (line 63), pytest
-pbr==5.4.4                # via -r requirements/quality.txt (line 57), -r requirements/test.txt (line 64), stevedore
-pip-tools==4.5.1          # via -r requirements/pip-tools.txt (line 8)
-pluggy==0.13.1            # via -r requirements/test.txt (line 65), diff-cover, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pbr==5.4.4                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
+pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1             # via -r requirements/quality.txt (line 58), -r requirements/test.txt (line 66), edx-django-utils, edx-drf-extensions
-py==1.8.1                 # via -r requirements/test.txt (line 67), pytest
-pycodestyle==2.5.0        # via -r requirements/quality.txt (line 59)
-pycryptodomex==3.9.7      # via -r requirements/quality.txt (line 60), -r requirements/test.txt (line 68), pyjwkest
-pydocstyle==5.0.2         # via -r requirements/quality.txt (line 61)
+psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+pycodestyle==2.5.0        # via -r requirements/quality.txt
+pycryptodomex==3.9.7      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
+pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.5.2           # via diff-cover
-pyjwkest==1.3.2           # via -r requirements/quality.txt (line 62), -r requirements/test.txt (line 69), edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/quality.txt (line 63), -r requirements/test.txt (line 70), djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via -r requirements/quality.txt (line 64), -r requirements/test.txt (line 71), edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt (line 65), -r requirements/test.txt (line 72), edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/quality.txt (line 66), -r requirements/test.txt (line 73), pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/quality.txt (line 67), -r requirements/test.txt (line 74), edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/quality.txt (line 68), -r requirements/test.txt (line 75), edx-opaque-keys
-pyparsing==2.4.6          # via -r requirements/quality.txt (line 69), -r requirements/test.txt (line 76), packaging
-pytest-cov==2.8.1         # via -r requirements/test.txt (line 77)
-pytest-django==3.8.0      # via -r requirements/test.txt (line 78)
-pytest==5.3.5             # via -r requirements/test.txt (line 79), pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt (line 70), -r requirements/test.txt (line 80), edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/test.txt (line 81), code-annotations
-python3-openid==3.1.0     # via -r requirements/quality.txt (line 71), -r requirements/test.txt (line 82), social-auth-core
-pytz==2019.3              # via -r requirements/quality.txt (line 72), -r requirements/test.txt (line 83), celery, django
-pyyaml==5.3               # via -r requirements/quality.txt (line 73), -r requirements/test.txt (line 84), code-annotations, edx-django-release-util, edx-i18n-tools
-redis==2.8                # via -r requirements/quality.txt (line 74), -r requirements/test.txt (line 85)
-requests-oauthlib==1.3.0  # via -r requirements/quality.txt (line 75), -r requirements/test.txt (line 86), social-auth-core
-requests==2.23.0          # via -r requirements/quality.txt (line 76), -r requirements/test.txt (line 87), caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/quality.txt (line 77), -r requirements/test.txt (line 88), edx-drf-extensions
-rules==2.2                # via -r requirements/quality.txt (line 78), -r requirements/test.txt (line 89)
-semantic-version==2.8.4   # via -r requirements/quality.txt (line 79), -r requirements/test.txt (line 90), edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/quality.txt (line 80), -r requirements/test.txt (line 91), django-rest-swagger
-six==1.14.0               # via -r requirements/pip-tools.txt (line 9), -r requirements/quality.txt (line 81), -r requirements/test.txt (line 92), astroid, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
-slumber==0.7.1            # via -r requirements/quality.txt (line 82), -r requirements/test.txt (line 93), edx-rest-api-client
-snowballstemmer==2.0.0    # via -r requirements/quality.txt (line 83), pydocstyle
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in (line 5), -r requirements/quality.txt (line 84), -r requirements/test.txt (line 94), edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/quality.txt (line 85), -r requirements/test.txt (line 95), edx-auth-backends, social-auth-app-django
+pyjwkest==1.3.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+pyjwt==1.7.1              # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
+pylint==2.4.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.6          # via -r requirements/quality.txt, -r requirements/test.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.8.0      # via -r requirements/test.txt
+pytest==5.3.5             # via -r requirements/test.txt, pytest-cov, pytest-django
+python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
+python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
+pytz==2019.3              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
+pyyaml==5.3               # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
+redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
+requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
+semantic-version==2.8.4   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+simplejson==3.17.0        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
+snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via django-debug-toolbar
-stevedore==1.32.0         # via -r requirements/quality.txt (line 86), -r requirements/test.txt (line 96), code-annotations, edx-opaque-keys
-text-unidecode==1.3       # via -r requirements/test.txt (line 97), faker, python-slugify
-typed-ast==1.4.1          # via -r requirements/quality.txt (line 87), -r requirements/test.txt (line 98), astroid
-uritemplate==3.0.1        # via -r requirements/quality.txt (line 88), -r requirements/test.txt (line 99), coreapi
-urllib3==1.25.8           # via -r requirements/quality.txt (line 89), -r requirements/test.txt (line 100), requests
-wcwidth==0.1.8            # via -r requirements/test.txt (line 101), pytest
-wrapt==1.11.2             # via -r requirements/quality.txt (line 90), -r requirements/test.txt (line 102), astroid
-zipp==1.2.0               # via -r requirements/quality.txt (line 91), -r requirements/test.txt (line 103), importlib-metadata
+stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
+text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
+toml==0.10.0              # via -r requirements/test.txt, tox
+tox==3.14.5               # via -r requirements/test.txt
+typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
+uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
+urllib3==1.25.8           # via -r requirements/quality.txt, -r requirements/test.txt, requests
+virtualenv==20.0.7        # via -r requirements/test.txt, tox
+wcwidth==0.1.8            # via -r requirements/test.txt, pytest
+wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
+zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.28           # via -r requirements/base.in (line 5), django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==1.11.28           # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,121 +5,128 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9               # via -r requirements/test.txt (line 7), kombu
-anyjson==0.3.3            # via -r requirements/test.txt (line 8), kombu
-astroid==2.3.3            # via -r requirements/test.txt (line 9), pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt (line 10), pytest
+amqp==1.4.9               # via -r requirements/test.txt, kombu
+anyjson==0.3.3            # via -r requirements/test.txt, kombu
+appdirs==1.4.3            # via -r requirements/test.txt, virtualenv
+astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-billiard==3.3.0.23        # via -r requirements/test.txt (line 11), celery
+billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.1             # via readme-renderer
-celery==3.1.26.post2      # via -r requirements/test.txt (line 12)
-certifi==2019.11.28       # via -r requirements/test.txt (line 13), requests
-chardet==3.0.4            # via -r requirements/test.txt (line 14), doc8, requests
-click-log==0.3.2          # via -r requirements/test.txt (line 15), edx-lint
-click==7.0                # via -r requirements/test.txt (line 16), click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.txt (line 17)
-coreapi==2.3.3            # via -r requirements/test.txt (line 18), django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/test.txt (line 19), coreapi
-coverage==5.0.3           # via -r requirements/test.txt (line 20), pytest-cov
-ddt==1.2.2                # via -r requirements/test.txt (line 21)
-defusedxml==0.6.0         # via -r requirements/test.txt (line 22), djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.2.1  # via -r requirements/test.txt (line 23)
-django-crum==0.7.5        # via -r requirements/test.txt (line 24), edx-rbac
-django-dynamic-fixture==3.0.3  # via -r requirements/test.txt (line 25)
-django-extensions==2.2.8  # via -r requirements/test.txt (line 26)
-django-model-utils==3.2.0  # via -r requirements/test.txt (line 27), edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/test.txt (line 28)
-django-simple-history==2.8.0  # via -r requirements/test.txt (line 29)
-django-waffle==0.20.0     # via -r requirements/test.txt (line 30), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/test.txt (line 31), code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-jwt==1.11.0  # via -r requirements/test.txt (line 32), edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/test.txt (line 33)
-djangorestframework==3.11.0  # via -r requirements/test.txt (line 34), django-rest-swagger, edx-drf-extensions, rest-condition
-doc8==0.8.0               # via -r requirements/doc.in (line 5)
+celery==3.1.26.post2      # via -r requirements/test.txt
+certifi==2019.11.28       # via -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
+click-log==0.3.2          # via -r requirements/test.txt, edx-lint
+click==7.0                # via -r requirements/test.txt, click-log, code-annotations, edx-lint
+code-annotations==0.3.3   # via -r requirements/test.txt
+coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
+coreschema==0.0.4         # via -r requirements/test.txt, coreapi
+coverage==5.0.3           # via -r requirements/test.txt, pytest-cov
+ddt==1.2.2                # via -r requirements/test.txt
+defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
+distlib==0.3.0            # via -r requirements/test.txt, virtualenv
+django-cors-headers==3.2.1  # via -r requirements/test.txt
+django-crum==0.7.5        # via -r requirements/test.txt, edx-rbac
+django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
+django-extensions==2.2.8  # via -r requirements/test.txt
+django-model-utils==3.2.0  # via -r requirements/test.txt, edx-rbac
+django-rest-swagger==2.2.0  # via -r requirements/test.txt
+django-simple-history==2.8.0  # via -r requirements/test.txt
+django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework-jwt==1.11.0  # via -r requirements/test.txt, edx-drf-extensions
+djangorestframework-xml==1.4.0  # via -r requirements/test.txt
+djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, edx-drf-extensions, rest-condition
+doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-auth-backends==3.0.2  # via -r requirements/test.txt (line 35)
-edx-django-release-util==0.3.6  # via -r requirements/test.txt (line 36)
-edx-django-utils==3.0     # via -r requirements/test.txt (line 37), edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/test.txt (line 38), edx-rbac
-edx-lint==1.4.1           # via -r requirements/test.txt (line 39)
-edx-opaque-keys==2.0.1    # via -r requirements/test.txt (line 40), edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/test.txt (line 41)
-edx-rest-api-client==1.9.2  # via -r requirements/test.txt (line 42)
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in (line 6)
-factory-boy==2.12.0       # via -r requirements/test.txt (line 43)
-faker==4.0.1              # via -r requirements/test.txt (line 44), factory-boy
-future==0.18.2            # via -r requirements/test.txt (line 45), pyjwkest
-idna==2.9                 # via -r requirements/test.txt (line 46), requests
+edx-auth-backends==3.0.2  # via -r requirements/test.txt
+edx-django-release-util==0.3.6  # via -r requirements/test.txt
+edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==3.0.0  # via -r requirements/test.txt, edx-rbac
+edx-lint==1.4.1           # via -r requirements/test.txt
+edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.1.1           # via -r requirements/test.txt
+edx-rest-api-client==1.9.2  # via -r requirements/test.txt
+edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+factory-boy==2.12.0       # via -r requirements/test.txt
+faker==4.0.1              # via -r requirements/test.txt, factory-boy
+filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
+future==0.18.2            # via -r requirements/test.txt, pyjwkest
+idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via -r requirements/test.txt (line 47), pluggy, pytest
-isort==4.3.21             # via -r requirements/test.txt (line 48), pylint
-itypes==1.1.0             # via -r requirements/test.txt (line 49), coreapi
-jinja2==2.11.1            # via -r requirements/test.txt (line 50), code-annotations, coreschema, sphinx
-jsonfield2==3.0.3         # via -r requirements/test.txt (line 51)
-kombu==3.0.37             # via -r requirements/test.txt (line 52), celery
-lazy-object-proxy==1.4.3  # via -r requirements/test.txt (line 53), astroid
-markupsafe==1.1.1         # via -r requirements/test.txt (line 54), jinja2
-mccabe==0.6.1             # via -r requirements/test.txt (line 55), pylint
-mock==3.0.5               # via -r requirements/test.txt (line 56)
-more-itertools==8.2.0     # via -r requirements/test.txt (line 57), pytest
-mysqlclient==1.4.6        # via -r requirements/test.txt (line 58)
-newrelic==5.8.0.136       # via -r requirements/test.txt (line 59), edx-django-utils
-oauthlib==3.1.0           # via -r requirements/test.txt (line 60), requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/test.txt (line 61), django-rest-swagger
-packaging==20.1           # via -r requirements/test.txt (line 62), pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/test.txt (line 63), pytest
-pbr==5.4.4                # via -r requirements/test.txt (line 64), stevedore
-pluggy==0.13.1            # via -r requirements/test.txt (line 65), pytest
-psutil==1.2.1             # via -r requirements/test.txt (line 66), edx-django-utils, edx-drf-extensions
-py==1.8.1                 # via -r requirements/test.txt (line 67), pytest
-pycryptodomex==3.9.7      # via -r requirements/test.txt (line 68), pyjwkest
+importlib-metadata==1.5.0  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.2.0  # via -r requirements/test.txt, virtualenv
+isort==4.3.21             # via -r requirements/test.txt, pylint
+itypes==1.1.0             # via -r requirements/test.txt, coreapi
+jinja2==2.11.1            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
+jsonfield2==3.0.3         # via -r requirements/test.txt
+kombu==3.0.37             # via -r requirements/test.txt, celery
+lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
+markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
+mccabe==0.6.1             # via -r requirements/test.txt, pylint
+mock==3.0.5               # via -r requirements/test.txt
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
+mysqlclient==1.4.6        # via -r requirements/test.txt
+newrelic==5.8.0.136       # via -r requirements/test.txt, edx-django-utils
+oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
+openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
+packaging==20.1           # via -r requirements/test.txt, pytest, sphinx, tox
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pbr==5.4.4                # via -r requirements/test.txt, stevedore
+pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
+psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
 pygments==2.5.2           # via readme-renderer, sphinx
-pyjwkest==1.3.2           # via -r requirements/test.txt (line 69), edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/test.txt (line 70), djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via -r requirements/test.txt (line 71), edx-lint
-pylint-django==2.0.11     # via -r requirements/test.txt (line 72), edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/test.txt (line 73), pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/test.txt (line 74), edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/test.txt (line 75), edx-opaque-keys
-pyparsing==2.4.6          # via -r requirements/test.txt (line 76), packaging
-pytest-cov==2.8.1         # via -r requirements/test.txt (line 77)
-pytest-django==3.8.0      # via -r requirements/test.txt (line 78)
-pytest==5.3.5             # via -r requirements/test.txt (line 79), pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt (line 80), edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/test.txt (line 81), code-annotations
-python3-openid==3.1.0     # via -r requirements/test.txt (line 82), social-auth-core
-pytz==2019.3              # via -r requirements/test.txt (line 83), babel, celery, django
-pyyaml==5.3               # via -r requirements/test.txt (line 84), code-annotations, edx-django-release-util
-readme-renderer==24.0     # via -r requirements/doc.in (line 7)
-redis==2.8                # via -r requirements/test.txt (line 85)
-requests-oauthlib==1.3.0  # via -r requirements/test.txt (line 86), social-auth-core
-requests==2.23.0          # via -r requirements/test.txt (line 87), coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
-rest-condition==1.0.3     # via -r requirements/test.txt (line 88), edx-drf-extensions
+pyjwkest==1.3.2           # via -r requirements/test.txt, edx-drf-extensions
+pyjwt==1.7.1              # via -r requirements/test.txt, djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
+pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.8.0      # via -r requirements/test.txt
+pytest==5.3.5             # via -r requirements/test.txt, pytest-cov, pytest-django
+python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
+python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
+pytz==2019.3              # via -r requirements/test.txt, babel, celery, django
+pyyaml==5.3               # via -r requirements/test.txt, code-annotations, edx-django-release-util
+readme-renderer==24.0     # via -r requirements/doc.in
+redis==2.8                # via -r requirements/test.txt
+requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
+requests==2.23.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
+rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via doc8
-rules==2.2                # via -r requirements/test.txt (line 89)
-semantic-version==2.8.4   # via -r requirements/test.txt (line 90), edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/test.txt (line 91), django-rest-swagger
-six==1.14.0               # via -r requirements/test.txt (line 92), astroid, bleach, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
-slumber==0.7.1            # via -r requirements/test.txt (line 93), edx-rest-api-client
+rules==2.2                # via -r requirements/test.txt
+semantic-version==2.8.4   # via -r requirements/test.txt, edx-drf-extensions
+simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
+six==1.14.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt (line 94), edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/test.txt (line 95), edx-auth-backends, social-auth-app-django
-sphinx==2.4.3             # via -r requirements/doc.in (line 8), edx-sphinx-theme
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sphinx==2.4.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-stevedore==1.32.0         # via -r requirements/test.txt (line 96), code-annotations, doc8, edx-opaque-keys
-text-unidecode==1.3       # via -r requirements/test.txt (line 97), faker, python-slugify
-typed-ast==1.4.1          # via -r requirements/test.txt (line 98), astroid
-uritemplate==3.0.1        # via -r requirements/test.txt (line 99), coreapi
-urllib3==1.25.8           # via -r requirements/test.txt (line 100), requests
-wcwidth==0.1.8            # via -r requirements/test.txt (line 101), pytest
+stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
+text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
+toml==0.10.0              # via -r requirements/test.txt, tox
+tox==3.14.5               # via -r requirements/test.txt
+typed-ast==1.4.1          # via -r requirements/test.txt, astroid
+uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
+urllib3==1.25.8           # via -r requirements/test.txt, requests
+virtualenv==20.0.7        # via -r requirements/test.txt, tox
+wcwidth==0.1.8            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.11.2             # via -r requirements/test.txt (line 102), astroid
-zipp==1.2.0               # via -r requirements/test.txt (line 103), importlib-metadata
+wrapt==1.11.2             # via -r requirements/test.txt, astroid
+zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip-tools.in (line 3)
+pip-tools==4.5.1          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,73 +4,73 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt (line 7), kombu
-anyjson==0.3.3            # via -r requirements/base.txt (line 8), kombu
-billiard==3.3.0.23        # via -r requirements/base.txt (line 9), celery
-celery==3.1.26.post2      # via -r requirements/base.txt (line 10)
-certifi==2019.11.28       # via -r requirements/base.txt (line 11), requests
-chardet==3.0.4            # via -r requirements/base.txt (line 12), requests
-coreapi==2.3.3            # via -r requirements/base.txt (line 13), django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt (line 14), coreapi
-defusedxml==0.6.0         # via -r requirements/base.txt (line 15), djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.2.1  # via -r requirements/base.txt (line 16)
-django-crum==0.7.5        # via -r requirements/base.txt (line 17), edx-rbac
-django-extensions==2.2.8  # via -r requirements/base.txt (line 18)
-django-model-utils==3.2.0  # via -r requirements/base.txt (line 19), edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.txt (line 20)
-django-simple-history==2.8.0  # via -r requirements/base.txt (line 21)
-django-waffle==0.20.0     # via -r requirements/base.txt (line 22), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/base.txt (line 23), django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-jwt==1.11.0  # via -r requirements/base.txt (line 24), edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/base.txt (line 25)
-djangorestframework==3.11.0  # via -r requirements/base.txt (line 26), django-rest-swagger, edx-drf-extensions, rest-condition
-edx-auth-backends==3.0.2  # via -r requirements/base.txt (line 27)
-edx-django-release-util==0.3.6  # via -r requirements/base.txt (line 28)
-edx-django-utils==3.0     # via -r requirements/base.txt (line 29), edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.txt (line 30), edx-rbac
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt (line 31), edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt (line 32)
-edx-rest-api-client==1.9.2  # via -r requirements/base.txt (line 33)
-future==0.18.2            # via -r requirements/base.txt (line 34), pyjwkest
-gevent==1.4.0             # via -r requirements/production.in (line 4)
+amqp==1.4.9               # via -r requirements/base.txt, kombu
+anyjson==0.3.3            # via -r requirements/base.txt, kombu
+billiard==3.3.0.23        # via -r requirements/base.txt, celery
+celery==3.1.26.post2      # via -r requirements/base.txt
+certifi==2019.11.28       # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
+coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
+django-cors-headers==3.2.1  # via -r requirements/base.txt
+django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
+django-extensions==2.2.8  # via -r requirements/base.txt
+django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
+django-rest-swagger==2.2.0  # via -r requirements/base.txt
+django-simple-history==2.8.0  # via -r requirements/base.txt
+django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework-jwt==1.11.0  # via -r requirements/base.txt, edx-drf-extensions
+djangorestframework-xml==1.4.0  # via -r requirements/base.txt
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, edx-drf-extensions, rest-condition
+edx-auth-backends==3.0.2  # via -r requirements/base.txt
+edx-django-release-util==0.3.6  # via -r requirements/base.txt
+edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==3.0.0  # via -r requirements/base.txt, edx-rbac
+edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-rest-api-client==1.9.2  # via -r requirements/base.txt
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
+gevent==1.4.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
-gunicorn==20.0.4          # via -r requirements/production.in (line 5)
-idna==2.9                 # via -r requirements/base.txt (line 35), requests
-itypes==1.1.0             # via -r requirements/base.txt (line 36), coreapi
-jinja2==2.11.1            # via -r requirements/base.txt (line 37), coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt (line 38)
-kombu==3.0.37             # via -r requirements/base.txt (line 39), celery
-markupsafe==1.1.1         # via -r requirements/base.txt (line 40), jinja2
-mysqlclient==1.4.6        # via -r requirements/base.txt (line 41)
-newrelic==5.8.0.136       # via -r requirements/base.txt (line 42), edx-django-utils
-oauthlib==3.1.0           # via -r requirements/base.txt (line 43), requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt (line 44), django-rest-swagger
-pbr==5.4.4                # via -r requirements/base.txt (line 45), stevedore
-psutil==1.2.1             # via -r requirements/base.txt (line 46), edx-django-utils, edx-drf-extensions
-pycryptodomex==3.9.7      # via -r requirements/base.txt (line 47), pyjwkest
-pyjwkest==1.3.2           # via -r requirements/base.txt (line 48), edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt (line 49), djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.10.1           # via -r requirements/base.txt (line 50), edx-opaque-keys
-python-dateutil==2.8.1    # via -r requirements/base.txt (line 51), edx-drf-extensions
-python-memcached==1.59    # via -r requirements/production.in (line 7)
-python3-openid==3.1.0     # via -r requirements/base.txt (line 52), social-auth-core
-pytz==2019.3              # via -r requirements/base.txt (line 53), celery, django
-pyyaml==5.3               # via -r requirements/base.txt (line 54), -r requirements/production.in (line 8), edx-django-release-util
-redis==2.8                # via -r requirements/base.txt (line 55)
-requests-oauthlib==1.3.0  # via -r requirements/base.txt (line 56), social-auth-core
-requests==2.23.0          # via -r requirements/base.txt (line 57), coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/base.txt (line 58), edx-drf-extensions
-rules==2.2                # via -r requirements/base.txt (line 59)
-semantic-version==2.8.4   # via -r requirements/base.txt (line 60), edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/base.txt (line 61), django-rest-swagger
-six==1.14.0               # via -r requirements/base.txt (line 62), django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
-slumber==0.7.1            # via -r requirements/base.txt (line 63), edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt (line 64), edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt (line 65), edx-auth-backends, social-auth-app-django
-stevedore==1.32.0         # via -r requirements/base.txt (line 66), edx-opaque-keys
-uritemplate==3.0.1        # via -r requirements/base.txt (line 67), coreapi
-urllib3==1.25.8           # via -r requirements/base.txt (line 68), requests
-zipp==1.2.0               # via -r requirements/base.txt (line 69)
+gunicorn==20.0.4          # via -r requirements/production.in
+idna==2.9                 # via -r requirements/base.txt, requests
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jinja2==2.11.1            # via -r requirements/base.txt, coreschema
+jsonfield2==3.0.3         # via -r requirements/base.txt
+kombu==3.0.37             # via -r requirements/base.txt, celery
+markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
+mysqlclient==1.4.6        # via -r requirements/base.txt
+newrelic==5.8.0.136       # via -r requirements/base.txt, edx-django-utils
+oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
+openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
+pbr==5.4.4                # via -r requirements/base.txt, stevedore
+psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
+pyjwkest==1.3.2           # via -r requirements/base.txt, edx-drf-extensions
+pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
+python-memcached==1.59    # via -r requirements/production.in
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+pytz==2019.3              # via -r requirements/base.txt, celery, django
+pyyaml==5.3               # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
+redis==2.8                # via -r requirements/base.txt
+requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
+requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
+rules==2.2                # via -r requirements/base.txt
+semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
+simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
+six==1.14.0               # via -r requirements/base.txt, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
+uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
+urllib3==1.25.8           # via -r requirements/base.txt, requests
+zipp==1.2.0               # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,91 +4,91 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt (line 7), kombu
-anyjson==0.3.3            # via -r requirements/base.txt (line 8), kombu
+amqp==1.4.9               # via -r requirements/base.txt, kombu
+anyjson==0.3.3            # via -r requirements/base.txt, kombu
 argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
 backports.functools-lru-cache==1.6.1  # via caniusepython3
-billiard==3.3.0.23        # via -r requirements/base.txt (line 9), celery
-caniusepython3==7.2.0     # via -r requirements/quality.in (line 5)
-celery==3.1.26.post2      # via -r requirements/base.txt (line 10)
-certifi==2019.11.28       # via -r requirements/base.txt (line 11), requests
-chardet==3.0.4            # via -r requirements/base.txt (line 12), requests
+billiard==3.3.0.23        # via -r requirements/base.txt, celery
+caniusepython3==7.2.0     # via -r requirements/quality.in
+celery==3.1.26.post2      # via -r requirements/base.txt
+certifi==2019.11.28       # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-coreapi==2.3.3            # via -r requirements/base.txt (line 13), django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt (line 14), coreapi
-defusedxml==0.6.0         # via -r requirements/base.txt (line 15), djangorestframework-xml, python3-openid, social-auth-core
+coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via caniusepython3
-django-cors-headers==3.2.1  # via -r requirements/base.txt (line 16)
-django-crum==0.7.5        # via -r requirements/base.txt (line 17), edx-rbac
-django-extensions==2.2.8  # via -r requirements/base.txt (line 18)
-django-model-utils==3.2.0  # via -r requirements/base.txt (line 19), edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.txt (line 20)
-django-simple-history==2.8.0  # via -r requirements/base.txt (line 21)
-django-waffle==0.20.0     # via -r requirements/base.txt (line 22), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/base.txt (line 23), django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-jwt==1.11.0  # via -r requirements/base.txt (line 24), edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/base.txt (line 25)
-djangorestframework==3.11.0  # via -r requirements/base.txt (line 26), django-rest-swagger, edx-drf-extensions, rest-condition
-edx-auth-backends==3.0.2  # via -r requirements/base.txt (line 27)
-edx-django-release-util==0.3.6  # via -r requirements/base.txt (line 28)
-edx-django-utils==3.0     # via -r requirements/base.txt (line 29), edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.txt (line 30), edx-rbac
-edx-lint==1.4.1           # via -r requirements/quality.in (line 6)
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt (line 31), edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt (line 32)
-edx-rest-api-client==1.9.2  # via -r requirements/base.txt (line 33)
-future==0.18.2            # via -r requirements/base.txt (line 34), pyjwkest
-idna==2.9                 # via -r requirements/base.txt (line 35), requests
-isort==4.3.21             # via -r requirements/quality.in (line 7), pylint
-itypes==1.1.0             # via -r requirements/base.txt (line 36), coreapi
-jinja2==2.11.1            # via -r requirements/base.txt (line 37), coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt (line 38)
-kombu==3.0.37             # via -r requirements/base.txt (line 39), celery
+django-cors-headers==3.2.1  # via -r requirements/base.txt
+django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
+django-extensions==2.2.8  # via -r requirements/base.txt
+django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
+django-rest-swagger==2.2.0  # via -r requirements/base.txt
+django-simple-history==2.8.0  # via -r requirements/base.txt
+django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework-jwt==1.11.0  # via -r requirements/base.txt, edx-drf-extensions
+djangorestframework-xml==1.4.0  # via -r requirements/base.txt
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, edx-drf-extensions, rest-condition
+edx-auth-backends==3.0.2  # via -r requirements/base.txt
+edx-django-release-util==0.3.6  # via -r requirements/base.txt
+edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==3.0.0  # via -r requirements/base.txt, edx-rbac
+edx-lint==1.4.1           # via -r requirements/quality.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-rest-api-client==1.9.2  # via -r requirements/base.txt
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
+idna==2.9                 # via -r requirements/base.txt, requests
+isort==4.3.21             # via -r requirements/quality.in, pylint
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jinja2==2.11.1            # via -r requirements/base.txt, coreschema
+jsonfield2==3.0.3         # via -r requirements/base.txt
+kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via -r requirements/base.txt (line 40), jinja2
+markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==1.4.6        # via -r requirements/base.txt (line 41)
-newrelic==5.8.0.136       # via -r requirements/base.txt (line 42), edx-django-utils
-oauthlib==3.1.0           # via -r requirements/base.txt (line 43), requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt (line 44), django-rest-swagger
+mysqlclient==1.4.6        # via -r requirements/base.txt
+newrelic==5.8.0.136       # via -r requirements/base.txt, edx-django-utils
+oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
+openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.1           # via caniusepython3
-pbr==5.4.4                # via -r requirements/base.txt (line 45), stevedore
-psutil==1.2.1             # via -r requirements/base.txt (line 46), edx-django-utils, edx-drf-extensions
-pycodestyle==2.5.0        # via -r requirements/quality.in (line 8)
-pycryptodomex==3.9.7      # via -r requirements/base.txt (line 47), pyjwkest
-pydocstyle==5.0.2         # via -r requirements/quality.in (line 9)
-pyjwkest==1.3.2           # via -r requirements/base.txt (line 48), edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt (line 49), djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pbr==5.4.4                # via -r requirements/base.txt, stevedore
+psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+pycodestyle==2.5.0        # via -r requirements/quality.in
+pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
+pydocstyle==5.0.2         # via -r requirements/quality.in
+pyjwkest==1.3.2           # via -r requirements/base.txt, edx-drf-extensions
+pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/base.txt (line 50), edx-opaque-keys
+pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.6          # via packaging
-python-dateutil==2.8.1    # via -r requirements/base.txt (line 51), edx-drf-extensions
-python3-openid==3.1.0     # via -r requirements/base.txt (line 52), social-auth-core
-pytz==2019.3              # via -r requirements/base.txt (line 53), celery, django
-pyyaml==5.3               # via -r requirements/base.txt (line 54), edx-django-release-util
-redis==2.8                # via -r requirements/base.txt (line 55)
-requests-oauthlib==1.3.0  # via -r requirements/base.txt (line 56), social-auth-core
-requests==2.23.0          # via -r requirements/base.txt (line 57), caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/base.txt (line 58), edx-drf-extensions
-rules==2.2                # via -r requirements/base.txt (line 59)
-semantic-version==2.8.4   # via -r requirements/base.txt (line 60), edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/base.txt (line 61), django-rest-swagger
-six==1.14.0               # via -r requirements/base.txt (line 62), astroid, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
-slumber==0.7.1            # via -r requirements/base.txt (line 63), edx-rest-api-client
+python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+pytz==2019.3              # via -r requirements/base.txt, celery, django
+pyyaml==5.3               # via -r requirements/base.txt, edx-django-release-util
+redis==2.8                # via -r requirements/base.txt
+requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
+requests==2.23.0          # via -r requirements/base.txt, caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
+rules==2.2                # via -r requirements/base.txt
+semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
+simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
+six==1.14.0               # via -r requirements/base.txt, astroid, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt (line 64), edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt (line 65), edx-auth-backends, social-auth-app-django
-stevedore==1.32.0         # via -r requirements/base.txt (line 66), edx-opaque-keys
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 typed-ast==1.4.1          # via astroid
-uritemplate==3.0.1        # via -r requirements/base.txt (line 67), coreapi
-urllib3==1.25.8           # via -r requirements/base.txt (line 68), requests
+uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
+urllib3==1.25.8           # via -r requirements/base.txt, requests
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt (line 69)
+zipp==1.2.0               # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,3 +11,4 @@ factory-boy
 mock<4
 pytest-cov
 pytest-django
+tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,99 +4,106 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt (line 7), kombu
-anyjson==0.3.3            # via -r requirements/base.txt (line 8), kombu
+amqp==1.4.9               # via -r requirements/base.txt, kombu
+anyjson==0.3.3            # via -r requirements/base.txt, kombu
+appdirs==1.4.3            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
-billiard==3.3.0.23        # via -r requirements/base.txt (line 9), celery
-celery==3.1.26.post2      # via -r requirements/base.txt (line 10)
-certifi==2019.11.28       # via -r requirements/base.txt (line 11), requests
-chardet==3.0.4            # via -r requirements/base.txt (line 12), requests
+billiard==3.3.0.23        # via -r requirements/base.txt, celery
+celery==3.1.26.post2      # via -r requirements/base.txt
+certifi==2019.11.28       # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.in (line 5)
-coreapi==2.3.3            # via -r requirements/base.txt (line 13), django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt (line 14), coreapi
-coverage==5.0.3           # via -r requirements/test.in (line 6), pytest-cov
-ddt==1.2.2                # via -r requirements/test.in (line 7)
-defusedxml==0.6.0         # via -r requirements/base.txt (line 15), djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.2.1  # via -r requirements/base.txt (line 16)
-django-crum==0.7.5        # via -r requirements/base.txt (line 17), edx-rbac
-django-dynamic-fixture==3.0.3  # via -r requirements/test.in (line 8)
-django-extensions==2.2.8  # via -r requirements/base.txt (line 18)
-django-model-utils==3.2.0  # via -r requirements/base.txt (line 19), edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.txt (line 20)
-django-simple-history==2.8.0  # via -r requirements/base.txt (line 21)
-django-waffle==0.20.0     # via -r requirements/base.txt (line 22), edx-django-utils, edx-drf-extensions
-djangorestframework-jwt==1.11.0  # via -r requirements/base.txt (line 24), edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/base.txt (line 25)
-djangorestframework==3.11.0  # via -r requirements/base.txt (line 26), django-rest-swagger, edx-drf-extensions, rest-condition
-edx-auth-backends==3.0.2  # via -r requirements/base.txt (line 27)
-edx-django-release-util==0.3.6  # via -r requirements/base.txt (line 28)
-edx-django-utils==3.0     # via -r requirements/base.txt (line 29), edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.txt (line 30), edx-rbac
-edx-lint==1.4.1           # via -r requirements/test.in (line 9)
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt (line 31), edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt (line 32)
-edx-rest-api-client==1.9.2  # via -r requirements/base.txt (line 33)
-factory-boy==2.12.0       # via -r requirements/test.in (line 10)
+code-annotations==0.3.3   # via -r requirements/test.in
+coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+coverage==5.0.3           # via -r requirements/test.in, pytest-cov
+ddt==1.2.2                # via -r requirements/test.in
+defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
+distlib==0.3.0            # via virtualenv
+django-cors-headers==3.2.1  # via -r requirements/base.txt
+django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
+django-dynamic-fixture==3.0.3  # via -r requirements/test.in
+django-extensions==2.2.8  # via -r requirements/base.txt
+django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
+django-rest-swagger==2.2.0  # via -r requirements/base.txt
+django-simple-history==2.8.0  # via -r requirements/base.txt
+django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+djangorestframework-jwt==1.11.0  # via -r requirements/base.txt, edx-drf-extensions
+djangorestframework-xml==1.4.0  # via -r requirements/base.txt
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, edx-drf-extensions, rest-condition
+edx-auth-backends==3.0.2  # via -r requirements/base.txt
+edx-django-release-util==0.3.6  # via -r requirements/base.txt
+edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==3.0.0  # via -r requirements/base.txt, edx-rbac
+edx-lint==1.4.1           # via -r requirements/test.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-rest-api-client==1.9.2  # via -r requirements/base.txt
+factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.1              # via factory-boy
-future==0.18.2            # via -r requirements/base.txt (line 34), pyjwkest
-idna==2.9                 # via -r requirements/base.txt (line 35), requests
-importlib-metadata==1.5.0  # via pluggy, pytest
+filelock==3.0.12          # via tox, virtualenv
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
+idna==2.9                 # via -r requirements/base.txt, requests
+importlib-metadata==1.5.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.2.0  # via virtualenv
 isort==4.3.21             # via pylint
-itypes==1.1.0             # via -r requirements/base.txt (line 36), coreapi
-jinja2==2.11.1            # via -r requirements/base.txt (line 37), code-annotations, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt (line 38)
-kombu==3.0.37             # via -r requirements/base.txt (line 39), celery
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jinja2==2.11.1            # via -r requirements/base.txt, code-annotations, coreschema
+jsonfield2==3.0.3         # via -r requirements/base.txt
+kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via -r requirements/base.txt (line 40), jinja2
+markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/test.in (line 11)
+mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.2.0     # via pytest
-mysqlclient==1.4.6        # via -r requirements/base.txt (line 41)
-newrelic==5.8.0.136       # via -r requirements/base.txt (line 42), edx-django-utils
-oauthlib==3.1.0           # via -r requirements/base.txt (line 43), requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt (line 44), django-rest-swagger
-packaging==20.1           # via pytest
+mysqlclient==1.4.6        # via -r requirements/base.txt
+newrelic==5.8.0.136       # via -r requirements/base.txt, edx-django-utils
+oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
+openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
+packaging==20.1           # via pytest, tox
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via -r requirements/base.txt (line 45), stevedore
-pluggy==0.13.1            # via pytest
-psutil==1.2.1             # via -r requirements/base.txt (line 46), edx-django-utils, edx-drf-extensions
-py==1.8.1                 # via pytest
-pycryptodomex==3.9.7      # via -r requirements/base.txt (line 47), pyjwkest
-pyjwkest==1.3.2           # via -r requirements/base.txt (line 48), edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt (line 49), djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pbr==5.4.4                # via -r requirements/base.txt, stevedore
+pluggy==0.13.1            # via pytest, tox
+psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+py==1.8.1                 # via pytest, tox
+pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
+pyjwkest==1.3.2           # via -r requirements/base.txt, edx-drf-extensions
+pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/base.txt (line 50), edx-opaque-keys
+pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1         # via -r requirements/test.in (line 12)
-pytest-django==3.8.0      # via -r requirements/test.in (line 13)
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.8.0      # via -r requirements/test.in
 pytest==5.3.5             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/base.txt (line 51), edx-drf-extensions, faker
+python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
-python3-openid==3.1.0     # via -r requirements/base.txt (line 52), social-auth-core
-pytz==2019.3              # via -r requirements/base.txt (line 53), celery, django
-pyyaml==5.3               # via -r requirements/base.txt (line 54), code-annotations, edx-django-release-util
-redis==2.8                # via -r requirements/base.txt (line 55)
-requests-oauthlib==1.3.0  # via -r requirements/base.txt (line 56), social-auth-core
-requests==2.23.0          # via -r requirements/base.txt (line 57), coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/base.txt (line 58), edx-drf-extensions
-rules==2.2                # via -r requirements/base.txt (line 59)
-semantic-version==2.8.4   # via -r requirements/base.txt (line 60), edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/base.txt (line 61), django-rest-swagger
-six==1.14.0               # via -r requirements/base.txt (line 62), astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
-slumber==0.7.1            # via -r requirements/base.txt (line 63), edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt (line 64), edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt (line 65), edx-auth-backends, social-auth-app-django
-stevedore==1.32.0         # via -r requirements/base.txt (line 66), code-annotations, edx-opaque-keys
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+pytz==2019.3              # via -r requirements/base.txt, celery, django
+pyyaml==5.3               # via -r requirements/base.txt, code-annotations, edx-django-release-util
+redis==2.8                # via -r requirements/base.txt
+requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
+requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
+rules==2.2                # via -r requirements/base.txt
+semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
+simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
+six==1.14.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
+toml==0.10.0              # via tox
+tox==3.14.5               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
-uritemplate==3.0.1        # via -r requirements/base.txt (line 67), coreapi
-urllib3==1.25.8           # via -r requirements/base.txt (line 68), requests
+uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
+urllib3==1.25.8           # via -r requirements/base.txt, requests
+virtualenv==20.0.7        # via tox
 wcwidth==0.1.8            # via pytest
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt (line 69), importlib-metadata
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,15 +7,15 @@
 appdirs==1.4.3            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.5.0  # via pluggy, tox, virtualenv
-importlib-resources==1.1.0  # via virtualenv
+importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.2.0  # via virtualenv
 packaging==20.1           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.2        # via -r requirements/tox.in (line 4)
-tox==3.14.5               # via -r requirements/tox.in (line 3), tox-battery
+tox-battery==0.5.2        # via -r requirements/tox.in
+tox==3.14.5               # via -r requirements/tox.in, tox-battery
 virtualenv==20.0.7        # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,5 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     -r{toxinidir}/requirements/test.txt
-whitelist_externals =
-    make
 commands =
-    make test
+    {posargs:pytest}


### PR DESCRIPTION
## Description

- Added django20,21,22 workers to travis
- Removed `SessionAuthenticationMiddleware` to fix djnago 2.x error failures

## Ticket Link

Link to the associated ticket
[BOM-1347](https://openedx.atlassian.net/browse/BOM-1347)

## Post-review

Squash commits into discrete sets of changes
