### PR TITLE
Add mgmt command to update all catalog metadata

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -1,0 +1,26 @@
+import mock
+from django.core.management import call_command
+from django.test import TestCase
+
+from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
+from enterprise_catalog.apps.catalog.tests.factories import (
+    EnterpriseCatalogFactory,
+)
+
+
+class UpdateContentMetadataCommandTests(TestCase):
+    command_name = 'update_content_metadata'
+
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task.delay'
+    )
+    def test_update_content_metadata(self, mock_task):
+        """
+        Verify that the job creates an update task for every enterprise catalog
+        """
+        [catalog_a, catalog_b, catalog_c] = EnterpriseCatalogFactory.create_batch(3)
+        call_command(self.command_name)
+
+        mock_task.assert_any_call(catalog_uuid=str(catalog_a.uuid))
+        mock_task.assert_any_call(catalog_uuid=str(catalog_b.uuid))
+        mock_task.assert_any_call(catalog_uuid=str(catalog_c.uuid))

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -20,6 +20,6 @@ class Command(BaseCommand):
             update_catalog_metadata_task.delay(catalog_uuid=str(catalog.uuid))
             message = (
                 'Spinning off update_catalog_metadata_task from update_content_metadata command'
-                'to update content_metadata for catalog %s'
+                ' to update content_metadata for catalog %s'
             )
             logger.info(message, catalog)

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -1,0 +1,25 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
+from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        'Update Content Metadata, along with the associations of Catalog Queries and Content Metadata, for all'
+        ' Enterprise Catalogs'
+    )
+
+    def handle(self, *args, **options):
+        for catalog in EnterpriseCatalog.objects.all():
+            update_catalog_metadata_task.delay(catalog_uuid=str(catalog.uuid))
+            message = (
+                'Spinning off update_catalog_metadata_task from update_content_metadata command'
+                'to update content_metadata for catalog %s'
+            )
+            logger.info(message, catalog)


### PR DESCRIPTION
This command is to be used as part of a jenkins job. The job is meant
to be run daily in order to keep all of the content metadata associated
with all catalogs up to date, and to update the associations between
catalog queries and content metadata.

[ENT-2610](https://openedx.atlassian.net/browse/ENT-2610)