### PR TITLE
Upgrade edx-rbac for Django 2.2 support

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ coreschema==0.0.4         # via coreapi
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.2.1  # via -r requirements/base.in
 django-crum==0.7.5        # via -r requirements/base.in, edx-rbac
-django-extensions==2.2.8  # via -r requirements/base.in
+django-extensions==2.2.9  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -r requirements/base.in, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.8.0  # via -r requirements/base.in
@@ -25,11 +25,11 @@ djangorestframework-xml==1.4.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
-edx-django-release-util==0.3.6  # via -r requirements/base.in
-edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==4.0.2  # via -r requirements/base.in, edx-rbac
-edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.in
+edx-django-release-util==0.4.1  # via -r requirements/base.in
+edx-django-utils==3.1     # via edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
+edx-opaque-keys==2.0.2    # via edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
@@ -51,7 +51,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3              # via -r requirements/base.in, celery, django
-pyyaml==5.3               # via edx-django-release-util
+pyyaml==5.3.1             # via edx-django-release-util
 redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
@@ -62,7 +62,7 @@ simplejson==3.17.0        # via django-rest-swagger
 six==1.14.0               # via django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 stevedore==1.32.0         # via edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.8           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@ drf-jwt==1.14.0
 
 # jsonfield2 > 3.0.3 dropped support for python 3.5
 jsonfield2==3.0.3
+
+# 3.3.0 updates models with data from get_user_details(), which overrides is_superuser
+social-auth-core<3.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,4 +15,5 @@ drf-jwt==1.14.0
 jsonfield2==3.0.3
 
 # 3.3.0 updates models with data from get_user_details(), which overrides is_superuser
+# https://openedx.atlassian.net/browse/ARCHBOM-1078
 social-auth-core<3.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,8 +21,8 @@ click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/q
 code-annotations==0.3.3   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.0.3           # via -r requirements/test.txt, pytest-cov
-ddt==1.3.0                # via -r requirements/dev.in, -r requirements/test.txt
+coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+ddt==1.3.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 diff-cover==2.6.0         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, virtualenv
@@ -30,7 +30,7 @@ django-cors-headers==3.2.1  # via -r requirements/quality.txt, -r requirements/t
 django-crum==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
-django-extensions==2.2.8  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==3.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.8.0  # via -r requirements/quality.txt, -r requirements/test.txt
@@ -40,21 +40,21 @@ djangorestframework-xml==1.4.0  # via -r requirements/quality.txt, -r requiremen
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-release-util==0.3.6  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==4.0.2  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+edx-django-release-util==0.4.1  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-django-utils==3.1     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
-edx-opaque-keys==2.0.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-opaque-keys==2.0.2    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.1              # via -r requirements/test.txt, factory-boy
+faker==4.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==1.5.0  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==1.4.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.1.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
@@ -95,12 +95,12 @@ pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/tes
 pyparsing==2.4.6          # via -r requirements/quality.txt, -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==5.4.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 pytz==2019.3              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
-pyyaml==5.3               # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
@@ -117,12 +117,12 @@ sqlparse==0.3.1           # via django-debug-toolbar
 stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.5               # via -r requirements/test.txt
+tox==3.14.6               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-virtualenv==20.0.10       # via -r requirements/test.txt, tox
-wcwidth==0.1.8            # via -r requirements/test.txt, pytest
+virtualenv==20.0.15       # via -r requirements/test.txt, tox
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
-bleach==3.1.1             # via readme-renderer
+bleach==3.1.4             # via readme-renderer
 celery==3.1.26.post2      # via -r requirements/test.txt
 certifi==2019.11.28       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
@@ -21,14 +21,14 @@ click==7.1.1              # via -r requirements/test.txt, click-log, code-annota
 code-annotations==0.3.3   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.0.3           # via -r requirements/test.txt, pytest-cov
-ddt==1.3.0                # via -r requirements/test.txt
+coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+ddt==1.3.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.2.1  # via -r requirements/test.txt
 django-crum==0.7.5        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
-django-extensions==2.2.8  # via -r requirements/test.txt
+django-extensions==2.2.9  # via -r requirements/test.txt
 django-model-utils==3.2.0  # via -r requirements/test.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.8.0  # via -r requirements/test.txt
@@ -40,22 +40,22 @@ doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
-edx-django-release-util==0.3.6  # via -r requirements/test.txt
-edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==4.0.2  # via -r requirements/test.txt, edx-rbac
+edx-django-release-util==0.4.1  # via -r requirements/test.txt
+edx-django-utils==3.1     # via -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.txt
-edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/test.txt
+edx-opaque-keys==2.0.2    # via -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.1              # via -r requirements/test.txt, factory-boy
+faker==4.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.4.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.1.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.1            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
@@ -88,13 +88,13 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==5.4.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
 pytz==2019.3              # via -r requirements/test.txt, babel, celery, django
-pyyaml==5.3               # via -r requirements/test.txt, code-annotations, edx-django-release-util
-readme-renderer==24.0     # via -r requirements/doc.in
+pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
+readme-renderer==25.0     # via -r requirements/doc.in
 redis==2.8                # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
@@ -118,12 +118,12 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.5               # via -r requirements/test.txt
+tox==3.14.6               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/test.txt, requests
-virtualenv==20.0.10       # via -r requirements/test.txt, tox
-wcwidth==0.1.8            # via -r requirements/test.txt, pytest
+virtualenv==20.0.15       # via -r requirements/test.txt, tox
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,7 +15,7 @@ coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.2.1  # via -r requirements/base.txt
 django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
-django-extensions==2.2.8  # via -r requirements/base.txt
+django-extensions==2.2.9  # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.8.0  # via -r requirements/base.txt
@@ -25,11 +25,11 @@ djangorestframework-xml==1.4.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-django-release-util==0.3.6  # via -r requirements/base.txt
-edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==4.0.2  # via -r requirements/base.txt, edx-rbac
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-django-release-util==0.4.1  # via -r requirements/base.txt
+edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 gevent==1.4.0             # via -r requirements/production.in
@@ -55,7 +55,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, celery, django
-pyyaml==5.3               # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,7 +22,7 @@ defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xm
 distlib==0.3.0            # via caniusepython3
 django-cors-headers==3.2.1  # via -r requirements/base.txt
 django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
-django-extensions==2.2.8  # via -r requirements/base.txt
+django-extensions==2.2.9  # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.8.0  # via -r requirements/base.txt
@@ -32,12 +32,12 @@ djangorestframework-xml==1.4.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-django-release-util==0.3.6  # via -r requirements/base.txt
-edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==4.0.2  # via -r requirements/base.txt, edx-rbac
+edx-django-release-util==0.4.1  # via -r requirements/base.txt
+edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/quality.in
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
@@ -70,7 +70,7 @@ pyparsing==2.4.6          # via packaging
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, celery, django
-pyyaml==5.3               # via -r requirements/base.txt, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,14 +18,14 @@ click==7.1.1              # via click-log, code-annotations, edx-lint
 code-annotations==0.3.3   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.0.3           # via -r requirements/test.in, pytest-cov
-ddt==1.3.0                # via -r requirements/test.in
+coverage==5.0.4           # via -r requirements/test.in, pytest-cov
+ddt==1.3.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
 django-cors-headers==3.2.1  # via -r requirements/base.txt
 django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.0.3  # via -r requirements/test.in
-django-extensions==2.2.8  # via -r requirements/base.txt
+django-extensions==2.2.9  # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.8.0  # via -r requirements/base.txt
@@ -34,20 +34,20 @@ djangorestframework-xml==1.4.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-django-release-util==0.3.6  # via -r requirements/base.txt
-edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==4.0.2  # via -r requirements/base.txt, edx-rbac
+edx-django-release-util==0.4.1  # via -r requirements/base.txt
+edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.in
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.1.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.1              # via factory-boy
+faker==4.0.2              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
 isort==4.3.21             # via pylint
 itypes==1.1.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.1            # via -r requirements/base.txt, code-annotations, coreschema
@@ -79,12 +79,12 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
-pytest==5.4.0             # via pytest-cov, pytest-django
+pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, celery, django
-pyyaml==5.3               # via -r requirements/base.txt, code-annotations, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
@@ -99,11 +99,11 @@ social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, soc
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/test.in
+tox==3.14.6               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.8           # via -r requirements/base.txt, requests
-virtualenv==20.0.10       # via tox
-wcwidth==0.1.8            # via pytest
+virtualenv==20.0.15       # via tox
+wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,8 +7,8 @@
 appdirs==1.4.3            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
@@ -16,6 +16,6 @@ pyparsing==2.4.6          # via packaging
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/tox.in
-tox==3.14.5               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.10       # via tox
+tox==3.14.6               # via -r requirements/tox.in, tox-battery
+virtualenv==20.0.15       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description

Upgraded edx-rbac to a version that properly checks for Django 2.2 support.  Also pulled in assorted other dependency updates from the past 2 weeks.

## Ticket Link

[Support Django 2.2 in edx-rbac](https://openedx.atlassian.net/browse/BOM-1042)

## Post-review

Squash commits into discrete sets of changes
