### PR TITLE
Restart containers as the last step of the provision script.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -11,7 +11,7 @@ Initialize and Provision
 ------------------------
     1. Start and provision the edX `devstack <https://github.com/edx/devstack>`_, as enterprise-catalog currently relies on devstack
     2. Verify that your virtual environment is active before proceeding
-    3. Clone the enterprise-catalog repo and cd into that directory
+    3. Clone the enterprise-catalog repo and **cd into that directory**
     4. Run *make dev.provision* to provision a new enterprise catalog environment
     5. Run *make dev.init* to start the enterprise catalog app and run migrations
 
@@ -19,7 +19,7 @@ Viewing Enterprise Catalog
 ------------------------
 Once the server is up and running you can view the enterprise catalog at http://localhost:18160/admin.
 
-You can login with the username *edx@example.com* and password *edx*.
+You can login with the username *edx* and password *edx*.
 
 Makefile Commands
 --------------------

--- a/provision-catalog.sh
+++ b/provision-catalog.sh
@@ -31,5 +31,5 @@ docker exec -t edx.devstack.lms  bash -c "source /edx/app/edxapp/edxapp_env && p
 docker exec -t edx.devstack.lms  bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type authorization-code --skip-authorization --redirect-uris 'http://localhost:${port}/complete/edx-oauth2/' --client-id '${name}-sso-key' --client-secret '${name}-sso-secret' --scopes 'user_id' ${name}-sso ${name}_worker"
 docker exec -t edx.devstack.lms bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type client-credentials --client-id '${name}-backend-service-key' --client-secret '${name}-backend-service-secret' ${name}-backend-service ${name}_worker"
 
-# Restart enterprise.catalog app
-docker-compose stop enterprise_catalog
+# Restart enterprise.catalog app and worker containers
+docker-compose restart app worker


### PR DESCRIPTION
## Description

The provision script tries to restart the catalog app docker container by name, but docker-compose really wants the "service" name defined in the `docker-compose.yml` file for doing operations.  Hence, `docker-compose restart app`.  Also restarts the worker container, to make sure it's "in-sync" with the app container.

## Post-review

Squash commits into discrete sets of changes
