### PR TITLE
ENT-2761 | Correct JWT_ISSUERS for devstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,9 @@ dev.migrate: # Migrates databases. Application and DB server must be up for this
 	docker exec -it enterprise.catalog.app bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && make migrate'
 
 dev.up: # Starts all containers
+	docker-compose up -d
+
+dev.up.build:
 	docker-compose up -d --build
 
 dev.down: # Kills containers and all of their data that isn't in volumes
@@ -161,8 +164,8 @@ dev.destroy: dev.down #Kills containers and destroys volumes. If you get an erro
 dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
 
-%-shell: ## Run a shell on the specified service container
-	docker exec -it enterprise.catalog.$* bash
+%-shell: ## Run a shell, as root, on the specified service container
+	docker exec -u 0 -it enterprise.catalog.$* env TERM=$(TERM) bash
 
 %-logs: ## View the logs of the specified service container
 	docker-compose logs -f --tail=500 $*

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -28,6 +28,11 @@ JWT_AUTH.update({
         '4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzG'
         'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
     ),
+    'JWT_ISSUERS': [{
+        'AUDIENCE': 'lms-key',
+        'ISSUER': 'http://localhost:18000/oauth2',
+        'SECRET_KEY': 'lms-secret',
+    }],
 })
 
 DATABASES = {


### PR DESCRIPTION
## Description

Before this change, we were trying to match on the default (and useless) 'SET-ME-PLEASE' key from JWT_ISSUERS during the JWT Auth flow.  This change updates the `devstack` settings to include a JWT_ISSUER that matches the issuer specified in the LMS devstack settings.

This commit also makes a slight `Makefile` change for developer convenience.

## Ticket Link

Link to the associated ticket
[Broken Devstack JWT Auth](https://openedx.atlassian.net/browse/ENT-2761)

## Post-review

Squash commits into discrete sets of changes
