### PR TITLE
ENT-2728: ran make upgrade to version bump edx-rbac

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,25 +21,25 @@ django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.8.0  # via -r requirements/base.in
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/base.in
+djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.1     # via edx-drf-extensions
+edx-django-utils==3.2.0   # via edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.0.2    # via edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.in
+edx-rbac==1.1.3           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 itypes==1.1.0             # via coreapi
-jinja2==2.11.1            # via coreschema
+jinja2==2.11.2            # via coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,10 +21,10 @@ click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/q
 code-annotations==0.3.3   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
-diff-cover==2.6.0         # via -r requirements/dev.in
+diff-cover==2.6.1         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, virtualenv
 django-cors-headers==3.2.1  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
@@ -36,20 +36,20 @@ django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/t
 django-simple-history==2.8.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
+djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.2  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.1     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.0.2    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-rbac==1.1.3           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.2              # via -r requirements/test.txt, factory-boy
+faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
@@ -59,7 +59,7 @@ inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.1.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
@@ -68,7 +68,7 @@ mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/tes
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.10.0.138      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, pytest, tox
@@ -121,7 +121,7 @@ tox==3.14.6               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-virtualenv==20.0.16       # via -r requirements/test.txt, tox
+virtualenv==20.0.17       # via -r requirements/test.txt, tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -21,7 +21,7 @@ click==7.1.1              # via -r requirements/test.txt, click-log, code-annota
 code-annotations==0.3.3   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
@@ -34,22 +34,22 @@ django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.8.0  # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/test.txt
+djangorestframework-xml==2.0.0  # via -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.4.2  # via -r requirements/test.txt
-edx-django-utils==3.1     # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.2.0   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.txt
 edx-opaque-keys==2.0.2    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/test.txt
+edx-rbac==1.1.3           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.2              # via -r requirements/test.txt, factory-boy
+faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/test.txt, requests
@@ -58,7 +58,7 @@ importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, 
 importlib-resources==1.4.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.1.0             # via -r requirements/test.txt, coreapi
-jinja2==2.11.1            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
+jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jsonfield2==3.0.3         # via -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
@@ -67,7 +67,7 @@ mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
-newrelic==5.10.0.138      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, pytest, sphinx, tox
@@ -108,7 +108,7 @@ slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.0.0             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.0.1             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -123,7 +123,7 @@ tox==3.14.6               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/test.txt, requests
-virtualenv==20.0.16       # via -r requirements/test.txt, tox
+virtualenv==20.0.17       # via -r requirements/test.txt, tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -21,28 +21,28 @@ django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.8.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/base.txt
+djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.4.2  # via -r requirements/base.txt
-edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.txt
+edx-rbac==1.1.3           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-gevent==1.4.0             # via -r requirements/production.in
+gevent==1.5.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests
 itypes==1.1.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.1            # via -r requirements/base.txt, coreschema
+jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,29 +28,29 @@ django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.8.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==1.4.0  # via -r requirements/base.txt
+djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.4.2  # via -r requirements/base.txt
-edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.txt
+edx-rbac==1.1.3           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.1.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.1            # via -r requirements/base.txt, coreschema
+jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via caniusepython3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ click==7.1.1              # via click-log, code-annotations, edx-lint
 code-annotations==0.3.3   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.0.4           # via -r requirements/test.in, pytest-cov
+coverage==5.1             # via -r requirements/test.in, pytest-cov
 ddt==1.3.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
@@ -30,19 +30,19 @@ django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.8.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-djangorestframework-xml==1.4.0  # via -r requirements/base.txt
+djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.4.2  # via -r requirements/base.txt
-edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.2           # via -r requirements/base.txt
+edx-rbac==1.1.3           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.2              # via factory-boy
+faker==4.0.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
@@ -50,7 +50,7 @@ importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, tox, virtu
 importlib-resources==1.4.0  # via virtualenv
 isort==4.3.21             # via pylint
 itypes==1.1.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.1            # via -r requirements/base.txt, code-annotations, coreschema
+jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
@@ -59,7 +59,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.2.0     # via pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via pytest, tox
@@ -104,7 +104,7 @@ tox==3.14.6               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.8           # via -r requirements/base.txt, requests
-virtualenv==20.0.16       # via tox
+virtualenv==20.0.17       # via tox
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -17,5 +17,5 @@ six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/tox.in
 tox==3.14.6               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.16       # via tox
+virtualenv==20.0.17       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description

Ran make upgrade to version bump edx-rbac. This will prevent 500 errors from being thrown when the catalog endpoints are hit by an anonymous user. 

## Ticket Link

[Link to the associated ticket](https://openedx.atlassian.net/browse/ENT-2728)

## Post-review

Squash commits into discrete sets of changes
