### PR TITLE
Fix paths for API gateway

### DIFF
--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -258,7 +258,7 @@ endpoints:
           responses: *responses
           x-amazon-apigateway-integration:
             <<: *apigateway_integration_enterprise_catalog_list
-            uri: "https://${stageVariables.enterprise_host}/api/v1/enterprise-catalogs/"
+            uri: "https://${stageVariables.enterprise_catalog_host}/api/v1/enterprise-catalogs/"
 
     # /v2/enterprise-catalogs/{uuid}/
     enterpriseCatalogByUuid:
@@ -275,4 +275,4 @@ endpoints:
             <<: *apigateway_integration_enterprise_catalog_detail
             # In the enterprise catalog service, the `get_content_metadata` endpoint contains the additional info that
             # the edx-enterprise endpoints used in their detail endpoints
-            uri: "https://${stageVariables.enterprise_host}/api/v1/enterprise-catalogs/{uuid}/get_content_metadata"
+            uri: "https://${stageVariables.enterprise_catalog_host}/api/v1/enterprise-catalogs/{uuid}/get_content_metadata"

--- a/api.yaml
+++ b/api.yaml
@@ -98,7 +98,7 @@ auth_header:
   required: true
   type: string
 endpoints: 
-  v1: 
+  v2:
     enterpriseCatalogByUuid: 
       get: 
         operationId: get_enterprise_catalog_by_uuid
@@ -174,7 +174,7 @@ endpoints:
             default: 
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/enterprise/api/v1/enterprise-catalogs/{uuid}/get_content_metadata"
+          uri: "https://${stageVariables.enterprise_catalog_host}/api/v1/enterprise-catalogs/{uuid}/get_content_metadata"
     enterpriseCatalogs: 
       get: 
         operationId: get_enterprise_catalogs
@@ -244,7 +244,7 @@ endpoints:
             default: 
               statusCode: "400"
           type: http
-          uri: "https://${stageVariables.enterprise_host}/api/v1/enterprise-catalogs/"
+          uri: "https://${stageVariables.enterprise_catalog_host}/api/v1/enterprise-catalogs/"
 id_parameter: 
   in: path
   name: id


### PR DESCRIPTION
Just fixing variables that were missed last time. The `v2` doesn't affect anything in gateway, but might as well have it v2 for consistency and less confusion on our end (since that's where it's hosted in gateway)