### PR TITLE
Fix query parameters in discovery client

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -51,7 +51,7 @@ class DiscoveryApiClient:
             response = self.client.post(
                 self.SEARCH_ALL_ENDPOINT,
                 data=content_filter_query,
-                **query_params
+                params=query_params
             ).json()
             results += response.get('results', [])
 
@@ -76,7 +76,7 @@ class DiscoveryApiClient:
         response = self.client.post(
             self.SEARCH_ALL_ENDPOINT,
             data=content_filter_query,
-            **query_params
+            params=query_params
         ).json()
 
         if traverse_pagination:


### PR DESCRIPTION
We're currently not seeing any query parameters showing up in splunk
for calls to the discovery api, which we aim to fix.
Based off of:
https://requests.readthedocs.io/en/master/user/quickstart/#passing-parameters-in-urls
we should be passing query parameters as a dictionary under the keyword
arg `params`.
