### PR TITLE
Pin pip to a version that works with pip-tools==4.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ branches:
   - master
 cache: pip
 install:
-- pip install -U pip wheel codecov
+- pip install -U pip==20.0.2 wheel codecov
 - make requirements
 after_success:
 - codecov


### PR DESCRIPTION
## Description

When running `make requirements` with `pip==20.1`, we get `AttributeError: 'ParsedRequirement' object has no attribute 'req'`.  This is a quick fix to pin pip (in travis) to a version known to work with the pip-tools library.


## Post-review

Squash commits into discrete sets of changes
