### PR TITLE
Implement pagination on get_content_metadata

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -92,3 +92,28 @@ class EnterpriseCatalogCreateSerializer(EnterpriseCatalogSerializer):
     UUID is writable to allow importing existing Enterprise Catalogs and keeping the same UUID
     """
     uuid = serializers.UUIDField(read_only=False, required=False)
+
+
+class ImmutableStateSerializer(serializers.Serializer):
+    """
+    Base serializer for any serializer that inhibits state changing requests.
+    """
+
+    def create(self, validated_data):
+        """
+        Do not perform any operations for state changing requests.
+        """
+
+    def update(self, instance, validated_data):
+        """
+        Do not perform any operations for state changing requests.
+        """
+
+
+class ContentMetadataSerializer(ImmutableStateSerializer):
+    """
+    Serializer for rendering Content Metadata objects
+    """
+
+    def to_representation(self, instance):
+        return instance.json_metadata

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -471,18 +471,19 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
         url = self._get_content_metadata_url(self.enterprise_catalog)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual((response.json()['count']), api_settings.PAGE_SIZE + 1)
-        self.assertEqual(uuid.UUID(response.json()['uuid']), self.enterprise_catalog.uuid)
-        self.assertEqual(response.json()['title'], self.enterprise_catalog.title)
-        self.assertEqual(uuid.UUID(response.json()['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
+        response_data = response.json()
+        self.assertEqual((response_data['count']), api_settings.PAGE_SIZE + 1)
+        self.assertEqual(uuid.UUID(response_data['uuid']), self.enterprise_catalog.uuid)
+        self.assertEqual(response_data['title'], self.enterprise_catalog.title)
+        self.assertEqual(uuid.UUID(response_data['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
 
         # Check that the first page contains all but the last metadata
         sorted_metadata = sorted(metadata, key=lambda metadata: metadata.content_key)
         json_metadata = [metadata.json_metadata for metadata in sorted_metadata]
-        self.assertEqual(response.json()['results'], json_metadata[:-1])
+        self.assertEqual(response_data['results'], json_metadata[:-1])
 
         # Check that the second page contains the last metadata
-        second_page_response = self.client.get(response.json()['next'])
+        second_page_response = self.client.get(response_data['next'])
         self.assertEqual(second_page_response.status_code, status.HTTP_200_OK)
         self.assertEqual(second_page_response.json()['results'], [json_metadata[-1]])
 
@@ -497,15 +498,16 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
         url = self._get_content_metadata_url(self.enterprise_catalog) + '?traverse_pagination=1'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual((response.json()['count']), api_settings.PAGE_SIZE + 1)
-        self.assertEqual(uuid.UUID(response.json()['uuid']), self.enterprise_catalog.uuid)
-        self.assertEqual(response.json()['title'], self.enterprise_catalog.title)
-        self.assertEqual(uuid.UUID(response.json()['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
+        response_data = response.json()
+        self.assertEqual((response_data['count']), api_settings.PAGE_SIZE + 1)
+        self.assertEqual(uuid.UUID(response_data['uuid']), self.enterprise_catalog.uuid)
+        self.assertEqual(response_data['title'], self.enterprise_catalog.title)
+        self.assertEqual(uuid.UUID(response_data['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
 
         # Check that the page contains all the metadata
         sorted_metadata = sorted(metadata, key=lambda metadata: metadata.content_key)
         json_metadata = [metadata.json_metadata for metadata in sorted_metadata]
-        self.assertEqual(response.json()['results'], json_metadata)
+        self.assertEqual(response_data['results'], json_metadata)
 
 
 class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -6,6 +6,7 @@ import mock
 from django.db import IntegrityError
 from rest_framework import status
 from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
 
 from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
 from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
@@ -312,13 +313,13 @@ class EnterpriseCatalogCRUDViewSetTests(APITestMixin):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
-class EnterpriseCatalogActionViewSetTests(APITestMixin):
+class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
     """
-    Tests on the EnterpriseCatalogActionViewSet
+    Tests on the contains_content_items on enterprise catalogs endpoint
     """
 
     def setUp(self):
-        super(EnterpriseCatalogActionViewSetTests, self).setUp()
+        super(EnterpriseCatalogContainsContentItemsTests, self).setUp()
         # Set up catalog.has_learner_access permissions
         self.set_up_catalog_learner()
         self.enterprise_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
@@ -328,12 +329,6 @@ class EnterpriseCatalogActionViewSetTests(APITestMixin):
         Helper to construct the base url for the contains_content_items endpoint
         """
         return reverse('api:v1:enterprise-catalog-contains-content-items', kwargs={'uuid': enterprise_catalog.uuid})
-
-    def _get_content_metadata_url(self, enterprise_catalog):
-        """
-        Helper to get the get_content_metadata endpoint url for a given catalog
-        """
-        return reverse('api:v1:enterprise-catalog-get-content-metadata', kwargs={'uuid': enterprise_catalog.uuid})
 
     def test_contains_content_items_no_params(self):
         """
@@ -404,6 +399,24 @@ class EnterpriseCatalogActionViewSetTests(APITestMixin):
         url = self._get_contains_content_base_url(self.enterprise_catalog) + '?course_run_ids=' + 'test-key'
         self.assert_correct_contains_response(url, False)
 
+
+class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
+    """
+    Tests on the get_content_metadata endpoint
+    """
+
+    def setUp(self):
+        super(EnterpriseCatalogGetContentMetadataTests, self).setUp()
+        # Set up catalog.has_learner_access permissions
+        self.set_up_catalog_learner()
+        self.enterprise_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+
+    def _get_content_metadata_url(self, enterprise_catalog):
+        """
+        Helper to get the get_content_metadata endpoint url for a given catalog
+        """
+        return reverse('api:v1:enterprise-catalog-get-content-metadata', kwargs={'uuid': enterprise_catalog.uuid})
+
     def test_get_content_metadata_unauthorized_invalid_permissions(self):
         """
         Verify the get_content_metadata endpoint rejects users with invalid permissions
@@ -452,21 +465,47 @@ class EnterpriseCatalogActionViewSetTests(APITestMixin):
         """
         Verify the get_content_metadata endpoint returns all the metadata associated with a particular catalog
         """
-        # Associate two pieces of metadata with the catalog, making sure the content keys are ordered for testing
-        json_metadata_1 = {'content': 'fake'}
-        metadata_1 = ContentMetadataFactory(json_metadata=json_metadata_1, content_key='first')
-        json_metadata_2 = {'content': 'fake2'}
-        metadata_2 = ContentMetadataFactory(json_metadata=json_metadata_2, content_key='second')
-        self.add_metadata_to_catalog(self.enterprise_catalog, [metadata_1, metadata_2])
-
+        # Create enough metadata to force pagination
+        metadata = ContentMetadataFactory.create_batch(api_settings.PAGE_SIZE + 1)
+        self.add_metadata_to_catalog(self.enterprise_catalog, metadata)
         url = self._get_content_metadata_url(self.enterprise_catalog)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual((response.json()['count']), api_settings.PAGE_SIZE + 1)
         self.assertEqual(uuid.UUID(response.json()['uuid']), self.enterprise_catalog.uuid)
-        self.assertEqual((response.json()['count']), 2)
         self.assertEqual(response.json()['title'], self.enterprise_catalog.title)
         self.assertEqual(uuid.UUID(response.json()['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
-        self.assertEqual(response.json()['results'], [json_metadata_1, json_metadata_2])
+
+        # Check that the first page contains all but the last metadata
+        sorted_metadata = sorted(metadata, key=lambda metadata: metadata.content_key)
+        json_metadata = [metadata.json_metadata for metadata in sorted_metadata]
+        self.assertEqual(response.json()['results'], json_metadata[:-1])
+
+        # Check that the second page contains the last metadata
+        second_page_response = self.client.get(response.json()['next'])
+        self.assertEqual(second_page_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(second_page_response.json()['results'], [json_metadata[-1]])
+
+    def test_get_content_metadata_traverse_pagination(self):
+        """
+        Verify the get_content_metadata endpoint returns all metadata on one page if the traverse pagination query
+        parameter is added.
+        """
+        # Create enough metadata to force pagination (if the query parameter wasn't sent)
+        metadata = ContentMetadataFactory.create_batch(api_settings.PAGE_SIZE + 1)
+        self.add_metadata_to_catalog(self.enterprise_catalog, metadata)
+        url = self._get_content_metadata_url(self.enterprise_catalog) + '?traverse_pagination=1'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual((response.json()['count']), api_settings.PAGE_SIZE + 1)
+        self.assertEqual(uuid.UUID(response.json()['uuid']), self.enterprise_catalog.uuid)
+        self.assertEqual(response.json()['title'], self.enterprise_catalog.title)
+        self.assertEqual(uuid.UUID(response.json()['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
+
+        # Check that the page contains all the metadata
+        sorted_metadata = sorted(metadata, key=lambda metadata: metadata.content_key)
+        json_metadata = [metadata.json_metadata for metadata in sorted_metadata]
+        self.assertEqual(response.json()['results'], json_metadata)
 
 
 class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -12,7 +12,8 @@ app_name = 'v1'
 
 router = DefaultRouter()  # pylint: disable=invalid-name
 router.register(r'enterprise-catalogs', views.EnterpriseCatalogCRUDViewSet, basename='enterprise-catalog')
-router.register(r'enterprise-catalogs', views.EnterpriseCatalogActionViewSet, basename='enterprise-catalog')
+router.register(r'enterprise-catalogs', views.EnterpriseCatalogContainsContentItems, basename='enterprise-catalog')
+router.register(r'enterprise-catalogs', views.EnterpriseCatalogGetContentMetadata, basename='enterprise-catalog')
 router.register(r'enterprise-customer', views.EnterpriseCustomerViewSet, basename='enterprise-customer')
 
 urlpatterns = [

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -31,19 +31,29 @@ class DiscoveryApiClient:
     def oauth2_client_secret(self):
         return settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET
 
-    def traverse_pagination(self, response, content_filter_query, query_params):
+    def get_metadata_by_query(self, content_filter_query, query_params=None):
         """
-        Traverse a paginated API response and extracts and concatenates "results"
-        returned by API.
+        Return results from the discovery service's search/all endpoint.
 
-        response (dict): API response object.
-        content_filter_query (dict): query parameters used to filter catalog results.
-        query_params (dict): query parameters used to paginate results.
+        content_filter_query (dict): some elasticsearch filter
+            e.g. - {'aggregation_key': 'course-v1:some+key+here'}
+        query_params (dict): additional query params for the rest api endpoint
+             we're hitting. e.g. - {'page': 3}
+        traverse_pagination (bool): determine if we should iterate over all
+            pages of results for given query
 
-        Return a list (all the results returned by the API).
+        Returns a list of the results.
         """
+        if query_params is None:
+            query_params = {}
+
+        response = self.client.post(
+            self.SEARCH_ALL_ENDPOINT,
+            data=content_filter_query,
+            params=query_params
+        ).json()
+
         results = response.get('results', [])
-
         page = 1
         while response.get('next'):
             page += 1
@@ -56,36 +66,3 @@ class DiscoveryApiClient:
             results += response.get('results', [])
 
         return results
-
-    def get_metadata_by_query(self, content_filter_query, query_params=None, traverse_pagination=False):
-        """
-        Return results from the discovery service's search/all endpoint.
-
-        content_filter_query (dict): some elasticsearch filter
-            e.g. - {'aggregation_key': 'course-v1:some+key+here'}
-        query_params (dict): additional query params for the rest api endpoint
-             we're hitting. e.g. - {'page': 3}
-        traverse_pagination (bool): determine if we should iterate over all
-            pages of results for given query
-
-        Returns a dictionary.
-        """
-        if query_params is None:
-            query_params = {}
-
-        response = self.client.post(
-            self.SEARCH_ALL_ENDPOINT,
-            data=content_filter_query,
-            params=query_params
-        ).json()
-
-        if traverse_pagination:
-            response['results'] = self.traverse_pagination(
-                response,
-                content_filter_query,
-                query_params
-            )
-
-            response['next'] = response['previous'] = None
-
-        return response

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -9,99 +9,22 @@ from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 class TestDiscoveryApiClient(TestCase):
     """ DiscoveryApiClient tests. """
 
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.DiscoveryApiClient.traverse_pagination')
     @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
-    def test_get_metadata_by_query_with_traverse(self, mock_oauth_client, mock_traverse):
-        """
-        get_metadata_by_query should call discovery endpoint, and then call
-        traverse_pagination if traverse_pagination is true.
-        """
-        mock_oauth_client.return_value.post.return_value.json.return_value = {
-            'this is': 'just a test'
-        }
-        mock_traverse.return_value = [{'Title': 'My Title', 'Etc': 'More stuff'}]
-
-        content_filter = {'*': '*'}
-        traverse_pagination = True
-        query_params = None
-
-        client = DiscoveryApiClient()
-        actual_response = client.get_metadata_by_query(
-            content_filter,
-            query_params,
-            traverse_pagination
-        )
-
-        mock_oauth_client.return_value.post.assert_called_once()
-        mock_traverse.assert_called_once()
-
-        expected_response = {
-            'this is': 'just a test',
-            'results': [{'Title': 'My Title', 'Etc': 'More stuff'}],
-            'next': None,
-            'previous': None,
-        }
-        self.assertDictEqual(actual_response, expected_response)
-
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.DiscoveryApiClient.traverse_pagination')
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
-    def test_get_metadata_by_query_without_traverse(self, mock_oauth_client, mock_traverse):
+    def test_get_metadata_by_query(self, mock_oauth_client):
         """
         get_metadata_by_query should call discovery endpoint, but not call
         traverse_pagination if traverse_pagination is false.
         """
         mock_oauth_client.return_value.post.return_value.json.return_value = {
-            'this is': 'just a test'
+            'results': [{'key': 'fakeX'}],
         }
 
         content_filter = {'*': '*'}
-        traverse_pagination = False
         query_params = {'exclude_expired_course_run': True}
-
         client = DiscoveryApiClient()
-        actual_response = client.get_metadata_by_query(
-            content_filter,
-            query_params,
-            traverse_pagination
-        )
+        actual_response = client.get_metadata_by_query(content_filter, query_params)
 
         mock_oauth_client.return_value.post.assert_called_once()
-        mock_traverse.assert_not_called()
 
-        expected_response = {
-            'this is': 'just a test',
-        }
-        self.assertDictEqual(actual_response, expected_response)
-
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
-    def test_traverse_pagination(self, mock_oauth_client):
-        """
-        traverse_pagination should call discovery service and add its results
-        to current response dict.
-        """
-        mock_oauth_client.return_value.post.return_value.json.return_value = {
-            'results': [{'item2': 'is from the second page'}],
-        }
-
-        current_response_dict = {
-            'page': 1,
-            'count': '2',
-            'previous': None,
-            'next': 'url/to/next/page',
-            'results': [{'item1': 'is from the first page'}],
-        }
-        content_filter = {'*': '*'}
-        query_params = {}
-
-        client = DiscoveryApiClient()
-        actual_results = client.traverse_pagination(
-            current_response_dict,
-            content_filter,
-            query_params
-        )
-        expected_results = [
-            {'item1': 'is from the first page'},
-            {'item2': 'is from the second page'},
-        ]
-
-        self.assertEqual(actual_results, expected_results)
+        expected_response = [{'key': 'fakeX'}]
+        self.assertEqual(actual_response, expected_response)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -132,6 +132,18 @@ class EnterpriseCatalog(TimeStampedModel):
             )
         )
 
+    @property
+    def content_metadata(self):
+        """
+        Helper to retrieve the content metadata associated with the catalog.
+
+        Returns:
+            Queryset: The queryset of associated content metadata
+        """
+        if not self.catalog_query:
+            return ContentMetadata.objects.none()
+        return self.catalog_query.contentmetadata_set.all()
+
     def contains_content_keys(self, content_keys):
         """
         Return True if catalog contains the courses/course runs/programs specified by the given content keys, else False
@@ -143,8 +155,7 @@ class EnterpriseCatalog(TimeStampedModel):
             return False
 
         content_keys = set(content_keys)
-        associated_metadata_content_keys = {metadata_chunk.content_key for metadata_chunk
-                                            in self.catalog_query.contentmetadata_set.all()}
+        associated_metadata_content_keys = {metadata_chunk.content_key for metadata_chunk in self.content_metadata}
         contained_in_catalog = True
         for content_key in content_keys:
             try:
@@ -239,7 +250,7 @@ def associate_content_metadata_with_query(metadata, catalog_query):
     Returns set of content_keys
     """
     content_keys = set()
-    for entry in metadata.get('results', []):
+    for entry in metadata:
         content_key = get_content_key(entry)
         defaults = {
             'content_key': content_key,

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -41,19 +41,10 @@ class TestModels(TestCase):
             ('title', 'test program'),
             ('uuid', 'fake-uuid'),
         ])
-        mock_client.return_value.get_metadata_by_query.side_effect = [
-            {
-                'count': 3,
-                'previous': None,
-                'next': None,
-                'results': [course_metadata, course_run_metadata, program_metadata],
-            },
-            {
-                'count': 1,
-                'previous': None,
-                'next': None,
-                'results': [program_metadata],
-            }
+        mock_client.return_value.get_metadata_by_query.return_value = [
+            course_metadata,
+            course_run_metadata,
+            program_metadata,
         ]
         catalog = factories.EnterpriseCatalogFactory()
 
@@ -62,7 +53,7 @@ class TestModels(TestCase):
         mock_client.assert_called_once()
         self.assertEqual(ContentMetadata.objects.count(), 3)
 
-        associated_metadata = catalog.catalog_query.contentmetadata_set.all()
+        associated_metadata = catalog.content_metadata
 
         # Assert stored content metadata is correct for each type
         course_cm = ContentMetadata.objects.get(content_key=course_metadata['key'])
@@ -86,10 +77,11 @@ class TestModels(TestCase):
         # Run again and expect that we will unassociate some content metadata
         # from catalog query while perserving the content metadata objects
         # themselves.
+        mock_client.return_value.get_metadata_by_query.return_value = [program_metadata]
         update_contentmetadata_from_discovery(catalog.uuid)
         self.assertEqual(ContentMetadata.objects.count(), 3)
 
-        associated_metadata = catalog.catalog_query.contentmetadata_set.all()
+        associated_metadata = catalog.content_metadata
         assert course_cm not in associated_metadata
         assert course_run_cm not in associated_metadata
         assert program_cm in associated_metadata

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -14,8 +14,8 @@ SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
 )
 
 # OAuth2 variables specific to backend service API calls.
-BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise_catalog-key')
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise_catalog-secret')
+BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise-catalog-backend-service-key')
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise-catalog-backend-service-secret')
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',


### PR DESCRIPTION
Update the get_content_metadata endpoint on enterprise catalogs to
paginate the results (as opposed to just returning them all on one
page).
Consumers also have the option to get all of the metadata on a single
page by adding the `?traverse_pagination` query parameter
* Update devstack client id & secret
* Add utility to get the content metadata associated with a catalog
* Small naming,test fixes

ENT-2802



**Testing Instructions**
* Hit `api/v1/{catalog_uuid}/refresh_metadata` to associate content metadata with some catalog
* Change your local setting for `REST_FRAMEWORK.PAGE_SIZE` to `1` or something low enough to force pagination
* Hit `api/v1/{catalog_uuid}/get_content_metadata.json` and see the results paginated
* Hit `api/v1/{catalog_uuid}/get_content_metadata.json/?traverse_pagination=1` and see the results all placed onto one page