### PR TITLE
Aed/catalog list authz

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -27,6 +27,8 @@ SYSTEM_ENTERPRISE_LEARNER_ROLE = 'enterprise_learner'
 SYSTEM_ENTERPRISE_ADMIN_ROLE = 'enterprise_admin'
 SYSTEM_ENTERPRISE_OPERATOR_ROLE = 'enterprise_openedx_operator'
 
+ACCESS_TO_ALL_ENTERPRISES_TOKEN = '*'
+
 
 def json_serialized_course_modes():
     """

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -17,6 +17,7 @@ from enterprise_catalog.apps.api.v1.utils import (
 )
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.constants import (
+    ACCESS_TO_ALL_ENTERPRISES_TOKEN,
     CONTENT_TYPE_CHOICES,
     json_serialized_course_modes,
 )
@@ -360,11 +361,17 @@ class EnterpriseCatalogRoleAssignment(UserRoleAssignment):
         """
         Return the enterprise customer id or `*` if the user has access to all resources.
         """
-        enterprise_id = '*'
         if self.enterprise_id:
             # converting the UUID('ee5e6b3a-069a-4947-bb8d-d2dbc323396c') to 'ee5e6b3a-069a-4947-bb8d-d2dbc323396c'
-            enterprise_id = str(self.enterprise_id)
-        return enterprise_id
+            return str(self.enterprise_id)
+        return ACCESS_TO_ALL_ENTERPRISES_TOKEN
+
+    @classmethod
+    def user_assignments_for_role_name(cls, user, role_name):
+        """
+        Returns assignments for a given user and role name.
+        """
+        return cls.objects.filter(user__id=user.id, role__name=role_name)
 
     def __str__(self):
         """

--- a/enterprise_catalog/apps/catalog/rules.py
+++ b/enterprise_catalog/apps/catalog/rules.py
@@ -13,12 +13,14 @@ from edx_rest_framework_extensions.auth.jwt.authentication import (
 from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from enterprise_catalog.apps.catalog.constants import (
+    ACCESS_TO_ALL_ENTERPRISES_TOKEN,
     ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_CATALOG_LEARNER_ROLE,
 )
 from enterprise_catalog.apps.catalog.models import (
     EnterpriseCatalogRoleAssignment,
 )
+from enterprise_catalog.apps.catalog.utils import get_jwt_roles
 
 
 @rules.predicate
@@ -96,3 +98,44 @@ rules.add_perm(
     (has_implicit_access_to_catalog_learner | has_explicit_access_to_catalog_learner
      | has_implicit_access_to_catalog_admin | has_explicit_access_to_catalog_admin)
 )
+
+
+def has_access_to_all_enterprises(enterprise_ids):
+    """
+    Returns true if the given set of enterprise customer ids contains the "wildcard" access identifier.
+    """
+    return ACCESS_TO_ALL_ENTERPRISES_TOKEN in enterprise_ids
+
+
+def enterprises_with_admin_access(user):
+    """
+    Returns a set of enterprise ids to which a user has been granted admin access.
+
+    Note that this may include the "*" wildcard identifier, which means that the user
+    is allowed access to all enterprises.
+    """
+    if user.is_superuser:
+        return {ACCESS_TO_ALL_ENTERPRISES_TOKEN}
+    return set(_enterprises_with_jwt_admin_access() + _enterprises_with_database_admin_access(user))
+
+
+def _enterprises_with_database_admin_access(user):
+    """
+    Returns a list of enterprise ids to which a user has been granted admin access via database assignment.
+    """
+    return [
+        assignment.get_context() for assignment in
+        EnterpriseCatalogRoleAssignment.user_assignments_for_role_name(
+            user,
+            ENTERPRISE_CATALOG_ADMIN_ROLE
+        )
+    ]
+
+
+def _enterprises_with_jwt_admin_access():
+    """
+    Returns a list of enterprise ids to which a user has been granted admin access via JWT roles.
+    """
+    request = crum.get_current_request()
+    roles_from_jwt = get_jwt_roles(request)
+    return roles_from_jwt.get(ENTERPRISE_CATALOG_ADMIN_ROLE, [])

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -54,13 +54,16 @@ class ContentMetadataFactory(factory.DjangoModelFactory):
     class Meta:
         model = ContentMetadata
 
-    content_key = factory.Faker('word')
+    content_key = factory.Sequence(lambda n: 'metadata_item_{}'.format(n))  # pylint: disable=unnecessary-lambda
     content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM])
     parent_content_key = None   # Default to None
-    json_metadata = factory.Dict({
-        'key': factory.Faker('word'),
-        'marketing_url': factory.Faker('word'),
-    })
+
+    @factory.lazy_attribute
+    def json_metadata(self):
+        return {
+            'key': self.content_key,
+            'marketing_url': 'http://marketing.yay/{}'.format(self.content_key),
+        }
 
 
 class UserFactory(factory.DjangoModelFactory):

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -5,6 +5,13 @@ Utility functions for catalog app.
 import hashlib
 import json
 
+from edx_rbac.utils import feature_roles_from_jwt
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    get_decoded_jwt_from_auth,
+)
+from edx_rest_framework_extensions.auth.jwt.cookies import \
+    get_decoded_jwt as get_decoded_jwt_from_cookie
+
 from enterprise_catalog.apps.catalog.constants import COURSE_RUN
 
 
@@ -56,3 +63,13 @@ def get_content_type(metadata):
     aggregation_key = metadata.get('aggregation_key', '')
     content_type, _ = _partition_aggregation_key(aggregation_key)
     return content_type
+
+
+def get_jwt_roles(request):
+    """
+    Decodes the request's JWT from either cookies or auth payload and returns mapping of features roles from it.
+    """
+    decoded_jwt = get_decoded_jwt_from_cookie(request) or get_decoded_jwt_from_auth(request)
+    if not decoded_jwt:
+        return {}
+    return feature_roles_from_jwt(decoded_jwt)

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -65,6 +65,7 @@ MIDDLEWARE = (
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtRedirectToLoginIfUnauthenticatedMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,32 +14,32 @@ coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.2.1  # via -r requirements/base.in
-django-crum==0.7.5        # via -r requirements/base.in, edx-rbac
+django-crum==0.7.6        # via -r requirements/base.in, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.in
-django-model-utils==3.2.0  # via -r requirements/base.in, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.in, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
-django-simple-history==2.8.0  # via -r requirements/base.in
+django-simple-history==2.10.0  # via -r requirements/base.in
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
-edx-auth-backends==3.0.2  # via -r requirements/base.in
-edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.2.0   # via edx-drf-extensions
-edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
-edx-opaque-keys==2.0.2    # via edx-drf-extensions
-edx-rbac==1.1.3           # via -r requirements/base.in
+edx-auth-backends==3.1.0  # via -r requirements/base.in
+edx-django-release-util==0.4.4  # via -r requirements/base.in
+edx-django-utils==3.2.2   # via edx-drf-extensions
+edx-drf-extensions==6.0.0  # via -r requirements/base.in, edx-rbac
+edx-opaque-keys==2.1.0    # via edx-drf-extensions
+edx-rbac==1.2.1           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
-itypes==1.1.0             # via coreapi
+itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
-newrelic==5.12.0.140      # via edx-django-utils
+newrelic==5.12.1.141      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
@@ -50,14 +50,14 @@ pyjwt==1.7.1              # via drf-jwt, edx-auth-backends, edx-rest-api-client,
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/base.in, celery, django
+pytz==2020.1              # via -r requirements/base.in, celery, django
 pyyaml==5.3.1             # via edx-django-release-util
 redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
-semantic-version==2.8.4   # via edx-drf-extensions
+semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
 six==1.14.0               # via django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
@@ -66,5 +66,5 @@ social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backen
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests
 zipp==1.2.0               # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,3 +17,6 @@ jsonfield2==3.0.3
 # 3.3.0 updates models with data from get_user_details(), which overrides is_superuser
 # https://openedx.atlassian.net/browse/ARCHBOM-1078
 social-auth-core<3.3.0
+
+# pinned until https://github.com/datadriventests/ddt/issues/83 is resolved
+ddt<1.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
-appdirs==1.4.3            # via -r requirements/test.txt, virtualenv
+appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
@@ -17,8 +17,8 @@ celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/tes
 certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.3.3   # via -r requirements/test.txt
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
+code-annotations==0.3.4   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
@@ -27,37 +27,37 @@ defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/tes
 diff-cover==2.6.1         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, virtualenv
 django-cors-headers==3.2.1  # via -r requirements/quality.txt, -r requirements/test.txt
-django-crum==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
-django-model-utils==3.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-simple-history==2.8.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-simple-history==2.10.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.0.2  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-release-util==0.4.2  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==5.0.2  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
-edx-i18n-tools==0.5.0     # via -r requirements/dev.in
+edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-django-utils==3.2.2   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==6.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
-edx-opaque-keys==2.0.2    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.3           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-opaque-keys==2.1.0    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.2.1           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.3              # via -r requirements/test.txt, factory-boy
+faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via -r requirements/test.txt, virtualenv
+importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
-itypes==1.1.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
+itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
@@ -68,7 +68,7 @@ mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/tes
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.12.0.140      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.12.1.141      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, pytest, tox
@@ -76,12 +76,12 @@ path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
-pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pip-tools==5.1.2          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
-pycodestyle==2.5.0        # via -r requirements/quality.txt
+pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycryptodomex==3.9.7      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
@@ -95,18 +95,18 @@ pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/tes
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-pytz==2019.3              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
+pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
-semantic-version==2.8.4   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
@@ -117,14 +117,15 @@ sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/tes
 stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.6               # via -r requirements/test.txt
+tox==3.15.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-urllib3==1.25.8           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-virtualenv==20.0.17       # via -r requirements/test.txt, tox
+urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
+virtualenv==20.0.20       # via -r requirements/test.txt, tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,18 +7,18 @@
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/test.txt, kombu
-appdirs==1.4.3            # via -r requirements/test.txt, virtualenv
+appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
-bleach==3.1.4             # via readme-renderer
+bleach==3.1.5             # via readme-renderer
 celery==3.1.26.post2      # via -r requirements/test.txt
 certifi==2020.4.5.1       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.txt
+click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
+code-annotations==0.3.4   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
@@ -26,12 +26,12 @@ ddt==1.3.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.2.1  # via -r requirements/test.txt
-django-crum==0.7.5        # via -r requirements/test.txt, edx-rbac
+django-crum==0.7.6        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/test.txt
-django-model-utils==3.2.0  # via -r requirements/test.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-simple-history==2.8.0  # via -r requirements/test.txt
+django-simple-history==2.10.0  # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/test.txt
@@ -39,25 +39,25 @@ djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.0.2  # via -r requirements/test.txt
-edx-django-release-util==0.4.2  # via -r requirements/test.txt
-edx-django-utils==3.2.0   # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==5.0.2  # via -r requirements/test.txt, edx-rbac
+edx-auth-backends==3.1.0  # via -r requirements/test.txt
+edx-django-release-util==0.4.4  # via -r requirements/test.txt
+edx-django-utils==3.2.2   # via -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==6.0.0  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.txt
-edx-opaque-keys==2.0.2    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.3           # via -r requirements/test.txt
+edx-opaque-keys==2.1.0    # via -r requirements/test.txt, edx-drf-extensions
+edx-rbac==1.2.1           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.3              # via -r requirements/test.txt, factory-boy
+faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via -r requirements/test.txt, virtualenv
+importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
-itypes==1.1.0             # via -r requirements/test.txt, coreapi
+itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jsonfield2==3.0.3         # via -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/test.txt, celery
@@ -67,10 +67,10 @@ mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
-newrelic==5.12.0.140      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.12.1.141      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
-packaging==20.3           # via -r requirements/test.txt, pytest, sphinx, tox
+packaging==20.3           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
@@ -88,27 +88,27 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
-pytz==2019.3              # via -r requirements/test.txt, babel, celery, django
+pytz==2020.1              # via -r requirements/test.txt, babel, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
-readme-renderer==25.0     # via -r requirements/doc.in
+readme-renderer==26.0     # via -r requirements/doc.in
 redis==2.8                # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via doc8
 rules==2.2                # via -r requirements/test.txt
-semantic-version==2.8.4   # via -r requirements/test.txt, edx-drf-extensions
+semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
 six==1.14.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.0.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -119,11 +119,11 @@ sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.6               # via -r requirements/test.txt
+tox==3.15.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.8           # via -r requirements/test.txt, requests
-virtualenv==20.0.17       # via -r requirements/test.txt, tox
+urllib3==1.25.9           # via -r requirements/test.txt, requests
+virtualenv==20.0.20       # via -r requirements/test.txt, tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip-tools.in
+click==7.1.2              # via pip-tools
+pip-tools==5.1.2          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,35 +14,35 @@ coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, o
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.2.1  # via -r requirements/base.txt
-django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
+django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
-django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.8.0  # via -r requirements/base.txt
+django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-django-release-util==0.4.2  # via -r requirements/base.txt
-edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
-edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.3           # via -r requirements/base.txt
+edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-django-release-util==0.4.4  # via -r requirements/base.txt
+edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
+edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-gevent==1.5.0             # via -r requirements/production.in
+gevent==20.5.0            # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests
-itypes==1.1.0             # via -r requirements/base.txt, coreapi
+itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
@@ -54,14 +54,14 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
-pytz==2019.3              # via -r requirements/base.txt, celery, django
+pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
-semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
+semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
 six==1.14.0               # via -r requirements/base.txt, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
@@ -70,7 +70,7 @@ social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, soc
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.8           # via -r requirements/base.txt, requests
+urllib3==1.25.9           # via -r requirements/base.txt, requests
 zipp==1.2.0               # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,34 +15,34 @@ celery==3.1.26.post2      # via -r requirements/base.txt
 certifi==2020.4.5.1       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, edx-lint
+click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via caniusepython3
 django-cors-headers==3.2.1  # via -r requirements/base.txt
-django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
+django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
-django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.8.0  # via -r requirements/base.txt
+django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-django-release-util==0.4.2  # via -r requirements/base.txt
-edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
+edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-django-release-util==0.4.4  # via -r requirements/base.txt
+edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/quality.in
-edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.3           # via -r requirements/base.txt
+edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
 isort==4.3.21             # via -r requirements/quality.in, pylint
-itypes==1.1.0             # via -r requirements/base.txt, coreapi
+itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
@@ -50,13 +50,13 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via caniusepython3
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
-pycodestyle==2.5.0        # via -r requirements/quality.in
+pycodestyle==2.6.0        # via -r requirements/quality.in
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
@@ -69,14 +69,14 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
-pytz==2019.3              # via -r requirements/base.txt, celery, django
+pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, caniusepython3, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
-semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
+semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
 six==1.14.0               # via -r requirements/base.txt, astroid, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
@@ -87,7 +87,7 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.8           # via -r requirements/base.txt, requests
+urllib3==1.25.9           # via -r requirements/base.txt, requests
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,6 @@
 # Requirements for test runs.
 
+-c constraints.txt
 -r base.txt               # Core dependencies for this package
 
 code-annotations

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
@@ -14,44 +14,44 @@ celery==3.1.26.post2      # via -r requirements/base.txt
 certifi==2020.4.5.1       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.in
+click==7.1.2              # via click-log, code-annotations, edx-lint
+code-annotations==0.3.4   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.1             # via -r requirements/test.in, pytest-cov
-ddt==1.3.1                # via -r requirements/test.in
+ddt==1.3.1                # via -c requirements/constraints.txt, -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
 django-cors-headers==3.2.1  # via -r requirements/base.txt
-django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
+django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
 django-extensions==2.2.9  # via -r requirements/base.txt
-django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.8.0  # via -r requirements/base.txt
+django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-django-release-util==0.4.2  # via -r requirements/base.txt
-edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
+edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-django-release-util==0.4.4  # via -r requirements/base.txt
+edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.in
-edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.3           # via -r requirements/base.txt
+edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
+edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.3              # via factory-boy
+faker==4.1.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 isort==4.3.21             # via pylint
-itypes==1.1.0             # via -r requirements/base.txt, coreapi
+itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
@@ -59,7 +59,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.2.0     # via pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via pytest, tox
@@ -79,32 +79,32 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.1             # via pytest-cov, pytest-django
+pytest==5.4.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
-pytz==2019.3              # via -r requirements/base.txt, celery, django
+pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
-semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
+semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
 six==1.14.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.0              # via tox
-tox==3.14.6               # via -r requirements/test.in
+tox==3.15.0               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.8           # via -r requirements/base.txt, requests
-virtualenv==20.0.17       # via tox
+urllib3==1.25.9           # via -r requirements/base.txt, requests
+virtualenv==20.0.20       # via tox
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
@@ -16,6 +16,6 @@ pyparsing==2.4.7          # via packaging
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/tox.in
-tox==3.14.6               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.17       # via tox
+tox==3.15.0               # via -r requirements/tox.in, tox-battery
+virtualenv==20.0.20       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description

* Implement authorization checks on the `/api/v1/enterprise-catalogs/` (list) endpoint that allow folks other that superusers to access data.
* Update edx-rbac to 1.2.1
* Updated the docs with testing instructions under the `Permissions` section here: https://github.com/edx/enterprise-catalog/blob/279878024586540bf2837c705be899c21c0c8290/docs/getting_started.rst

## Ticket Link

https://openedx.atlassian.net/browse/ENT-2809

## Testing notes

For authorization via JWT roles to work, a request must send the `use_jwt_cookie: true` header.  You can do this with cURL, Postman, or in a browser using an extension like ModHeader.

For authorization via database role assignment records, just create the appropriate assignments via Django Admin.

## Post-review

Squash commits into discrete sets of changes
