### PR TITLE
Switch to GET request for `/search/all/` instead of POST

### DIFF
--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -20,11 +20,10 @@ class TestDiscoveryApiClient(TestCase):
         }
 
         content_filter = {'*': '*'}
-        query_params = {'exclude_expired_course_run': True}
         client = DiscoveryApiClient()
-        actual_response = client.get_metadata_by_query(content_filter, query_params)
+        actual_response = client.get_metadata_by_query(content_filter)
 
-        mock_oauth_client.return_value.post.assert_called_once()
+        mock_oauth_client.return_value.get.assert_called_once()
 
         expected_response = [{'key': 'fakeX'}]
         self.assertEqual(actual_response, expected_response)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -396,10 +396,7 @@ def update_contentmetadata_from_discovery(catalog_uuid):
 
     catalog = EnterpriseCatalog.objects.get(uuid=catalog_uuid)
     catalog_query = catalog.catalog_query
-    query_params = {}
-    # Omit non-active course runs from the course-discovery results
-    query_params['exclude_expired_course_run'] = True
-    metadata = client.get_metadata_by_query(catalog_query.content_filter, query_params=query_params)
+    metadata = client.get_metadata_by_query(catalog_query.content_filter)
 
     content_keys = associate_content_metadata_with_query(metadata, catalog_query)
 


### PR DESCRIPTION
## Description

When fetching the metadata from discovery service, we are currently using a POST request and passing the `content_filter_query` as the data for the request.

Replicating the POST request in Postman using the parameters from an [existing `content_filter_query`](https://enterprise-catalog.edx.org/admin/catalog/catalogquery/20/change/), I get back 5 results. All 5 of these `ContentMetadata` objects are properly linked to the `CatalogQuery` object in question. This corresponds with the same 5 content items that get associated with the `CatalogQuery` when triggering an update to the same catalog in the LMS django admin, as seen by Splunk logs.

However, using a GET request in Postman with the same parameters from the `content_filter_query` as query parameters, I get back 103 results which matches the results given by the "Preview" link from the corresponding catalog in the LMS. However, all 103 results (minus the 5 mentioned above) **are not** associated with the `CatalogQuery` object in question.

Given this, I am hypothesizing that we should not be using a `POST` request to fetch the content metadata from discovery. Rather, I believe it should be a `GET` request. Conceptually, I'm not sure why this was initially a POST given that we're retrieving data, not creating new data.

This PR swaps over the POST request to a GET request.

**Testing Plan**

To test if this change makes a difference, I plan to trigger the `post_save` method on a catalog within the LMS django admin to update the corresponding catalog in the enterprise-catalog service. I will then monitor Splunk logs to determine which `ContentMetadata` items were associated with the `CatalogQuery`.

## Ticket Link

TBD

## Post-review

Squash commits into discrete sets of changes
