### PR TITLE
simplify ContentMetadata to CatalogQuery association logic

### DIFF
--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -77,3 +77,16 @@ def get_jwt_roles(request):
     if not decoded_jwt:
         return {}
     return feature_roles_from_jwt(decoded_jwt)
+
+
+def get_sorted_string_from_json(json_metadata):
+    """
+    Get the string representing a json piece of metadata in alphabetical order for comparisons.
+
+    Arguments:
+        json_metadata (json): The json metadata of a particular piece of content metadata.
+
+    Returns:
+        string: The json metadata as a sorted string
+    """
+    return sorted(json.dumps(json_metadata))


### PR DESCRIPTION
## Description

This PR simplifies the association/dissociation logic into a single function to avoid needing to pass content_keys around between 2 functions when they were separate. It makes use of `.set(clear=True)` to remove all CatalogQuery -> ContentMetadata associations before adding the updated list.

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
