### PR TITLE
use correct content_key for course runs

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -161,7 +161,7 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
                 for course_run in course_runs:
                     course_run['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
                         content_resource='course',
-                        content_key=content_key,
+                        content_key=course_run.get('key'),
                     )
         elif content_type == PROGRAM:
             json_metadata['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -312,7 +312,6 @@ def associate_content_metadata_with_query(metadata, catalog_query):
                 metadata_list.append(existing_metadata)
                 continue
 
-        if existing_metadata:
             for key, value in defaults.items():
                 setattr(existing_metadata, key, value)
             existing_metadata.save()


### PR DESCRIPTION
## Description

The enrollment_url for course_runs that are part of a course is currently using the content_key of the course instead of the content_key for each of the course_runs.

## Post-review

Squash commits into discrete sets of changes
