### PR TITLE
increase page_size query parameter on /search/all request

### DIFF
--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -179,13 +179,14 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         enterprise_catalog = self.get_enterprise_catalog()
         return str(enterprise_catalog.enterprise_uuid)
 
-    def get_queryset(self):
+    def get_queryset(self, enterprise_catalog=None):
         """
         Returns all of the json of content metadata associated with the catalog.
 
         Note that the metadata is ordered by content key.
         """
-        enterprise_catalog = self.get_enterprise_catalog()
+        if not enterprise_catalog:
+            enterprise_catalog = self.get_enterprise_catalog()
         ordered_metadata = enterprise_catalog.content_metadata.order_by('content_key')
         return ordered_metadata
 
@@ -213,8 +214,8 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
 
         Adding the query parameter `traverse_pagination` will collect the results onto a single page.
         """
-        queryset = self.filter_queryset(self.get_queryset())
         enterprise_catalog = self.get_enterprise_catalog()
+        queryset = self.filter_queryset(self.get_queryset(enterprise_catalog=enterprise_catalog))
         context = self.get_serializer_context()
         context['enterprise_catalog'] = enterprise_catalog
         # Traverse pagination query parameter signals that we should collect the results onto a single page

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -179,14 +179,13 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         enterprise_catalog = self.get_enterprise_catalog()
         return str(enterprise_catalog.enterprise_uuid)
 
-    def get_queryset(self, enterprise_catalog=None):
+    def get_queryset(self):
         """
         Returns all of the json of content metadata associated with the catalog.
 
         Note that the metadata is ordered by content key.
         """
-        if not enterprise_catalog:
-            enterprise_catalog = self.get_enterprise_catalog()
+        enterprise_catalog = self.get_enterprise_catalog()
         ordered_metadata = enterprise_catalog.content_metadata.order_by('content_key')
         return ordered_metadata
 
@@ -214,8 +213,8 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
 
         Adding the query parameter `traverse_pagination` will collect the results onto a single page.
         """
+        queryset = self.filter_queryset(self.get_queryset())
         enterprise_catalog = self.get_enterprise_catalog()
-        queryset = self.filter_queryset(self.get_queryset(enterprise_catalog=enterprise_catalog))
         context = self.get_serializer_context()
         context['enterprise_catalog'] = enterprise_catalog
         # Traverse pagination query parameter signals that we should collect the results onto a single page

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -403,9 +403,15 @@ def update_contentmetadata_from_discovery(catalog_uuid):
 
     catalog = EnterpriseCatalog.objects.get(uuid=catalog_uuid)
     catalog_query = catalog.catalog_query
-    query_params = {}
-    # Omit non-active course runs from the course-discovery results
-    query_params['exclude_expired_course_run'] = True
+    query_params = {
+        # Omit non-active course runs from the course-discovery results
+        'exclude_expired_course_run': True,
+        # Increasing page_size will help alleviate the non-deterministic behavior
+        # of the /search/all/ endpoint where a content items may appear on multiple
+        # pages (e.g., a course is included on both pages 1 and 2). This issue with the
+        # /search/all/ endpoint is likely the reason we get duplicate results.
+        'page_size': 200,
+    }
     metadata = client.get_metadata_by_query(catalog_query.content_filter, query_params=query_params)
     metadata_content_keys = [get_content_key(entry) for entry in metadata]
 

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -407,7 +407,7 @@ def update_contentmetadata_from_discovery(catalog_uuid):
         # Omit non-active course runs from the course-discovery results
         'exclude_expired_course_run': True,
         # Increasing page_size will help alleviate the non-deterministic behavior
-        # of the /search/all/ endpoint where a content items may appear on multiple
+        # of the /search/all/ endpoint where a content item may appear on multiple
         # pages (e.g., a course is included on both pages 1 and 2). This issue with the
         # /search/all/ endpoint is likely the reason we get duplicate results.
         'page_size': 200,


### PR DESCRIPTION
## Description

Increases the `page_size` query parameter to 200 (from the default 20) due to non-deterministic pagination behavior within the /search/all endpoint, and likely the reason why we're seeing duplicate results from discovery.

## Ticket Link

N/A

## Post-review

Squash commits into discrete sets of changes
