### PR TITLE
reduce number of catalog query updates during update_content_metadata command

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -7,5 +7,5 @@ from enterprise_catalog.apps.catalog.models import (
 
 @shared_task(bind=True)
 # pylint: disable=unused-argument
-def update_catalog_metadata_task(self, catalog_uuid):
-    update_contentmetadata_from_discovery(catalog_uuid)
+def update_catalog_metadata_task(self, catalog_query_id):
+    update_contentmetadata_from_discovery(catalog_query_id)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -6,9 +6,7 @@ from unittest import mock
 from django.test import TestCase
 
 from enterprise_catalog.apps.api import tasks
-from enterprise_catalog.apps.catalog.tests.factories import (
-    CatalogQueryFactory,
-)
+from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
 
 
 class EnterpriseCatalogCeleryTaskTests(TestCase):

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -7,16 +7,16 @@ from django.test import TestCase
 
 from enterprise_catalog.apps.api import tasks
 from enterprise_catalog.apps.catalog.tests.factories import (
-    EnterpriseCatalogFactory,
+    CatalogQueryFactory,
 )
 
 
 class EnterpriseCatalogCeleryTaskTests(TestCase):
     def setUp(self):
         super(EnterpriseCatalogCeleryTaskTests, self).setUp()
-        self.enterprise_catalog = EnterpriseCatalogFactory()
+        self.catalog_query = CatalogQueryFactory()
 
     @mock.patch('enterprise_catalog.apps.api.tasks.update_contentmetadata_from_discovery')
     def test_refresh_metadata(self, update_contentmetadata_from_discovery_mock):
-        tasks.update_catalog_metadata_task(self.enterprise_catalog.uuid)  # pylint: disable=no-value-for-parameter
-        update_contentmetadata_from_discovery_mock.assert_called_with(self.enterprise_catalog.uuid)
+        tasks.update_catalog_metadata_task(self.catalog_query.id)  # pylint: disable=no-value-for-parameter
+        update_contentmetadata_from_discovery_mock.assert_called_with(self.catalog_query.id)

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -72,7 +72,7 @@ class EnterpriseCatalogSerializer(serializers.ModelSerializer):
             'to update content_metadata for catalog %s'
         )
         logger.info(message, catalog)
-        update_catalog_metadata_task.delay(catalog_uuid=str(catalog.uuid))
+        update_catalog_metadata_task.delay(catalog_query_id=catalog.catalog_query.id)
 
         return catalog
 
@@ -92,7 +92,7 @@ class EnterpriseCatalogSerializer(serializers.ModelSerializer):
             'to update content_metadata for catalog %s'
         )
         logger.info(message, instance)
-        update_catalog_metadata_task.delay(catalog_uuid=str(instance.uuid))
+        update_catalog_metadata_task.delay(catalog_query_id=instance.catalog_query.id)
 
         return super().update(instance, validated_data)
 

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -253,7 +253,9 @@ class EnterpriseCatalogRefreshDataFromDiscovery(BaseViewSet, APIView):
         return str(enterprise_catalog.enterprise_uuid)
 
     def post(self, request, uuid):
-        async_task = update_catalog_metadata_task.delay(catalog_uuid=uuid)
+        enterprise_catalog = get_object_or_404(EnterpriseCatalog, uuid=uuid)
+        catalog_query_id = enterprise_catalog.catalog_query.id
+        async_task = update_catalog_metadata_task.delay(catalog_query_id=catalog_query_id)
         return Response({'async_task_id': async_task.task_id}, status=HTTP_200_OK)
 
 

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
 from enterprise_catalog.apps.catalog.tests.factories import (
-    EnterpriseCatalogFactory,
+    CatalogQueryFactory,
 )
 
 
@@ -18,9 +18,9 @@ class UpdateContentMetadataCommandTests(TestCase):
         """
         Verify that the job creates an update task for every enterprise catalog
         """
-        [catalog_a, catalog_b, catalog_c] = EnterpriseCatalogFactory.create_batch(3)
+        [catalog_query_a, catalog_query_b, catalog_query_c] = CatalogQueryFactory.create_batch(3)
         call_command(self.command_name)
 
-        mock_task.assert_any_call(catalog_uuid=str(catalog_a.uuid))
-        mock_task.assert_any_call(catalog_uuid=str(catalog_b.uuid))
-        mock_task.assert_any_call(catalog_uuid=str(catalog_c.uuid))
+        mock_task.assert_any_call(catalog_query_id=catalog_query_a.id)
+        mock_task.assert_any_call(catalog_query_id=catalog_query_b.id)
+        mock_task.assert_any_call(catalog_query_id=catalog_query_c.id)

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -3,9 +3,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
-from enterprise_catalog.apps.catalog.tests.factories import (
-    CatalogQueryFactory,
-)
+from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
 
 
 class UpdateContentMetadataCommandTests(TestCase):

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
-from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
+from enterprise_catalog.apps.catalog.models import CatalogQuery
 
 
 logger = logging.getLogger(__name__)
@@ -16,10 +16,10 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        for catalog in EnterpriseCatalog.objects.all():
-            update_catalog_metadata_task.delay(catalog_uuid=str(catalog.uuid))
+        for catalog_query in CatalogQuery.objects.all():
+            update_catalog_metadata_task.delay(catalog_query_id=catalog_query.id)
             message = (
                 'Spinning off update_catalog_metadata_task from update_content_metadata command'
-                ' to update content_metadata for catalog %s'
+                ' to update content_metadata for catalog query %s'
             )
-            logger.info(message, catalog)
+            logger.info(message, catalog_query)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -436,7 +436,7 @@ def update_contentmetadata_from_discovery(catalog_query_id):
             associated_content_keys,
         )
     else:
-        # CatalogQuery with
         LOGGER.warning(
-            'Could not find a CatalogQuery with id %s'
+            'Could not find a CatalogQuery with id %s',
+            catalog_query_id,
         )

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -391,7 +391,7 @@ class EnterpriseCatalogRoleAssignment(UserRoleAssignment):
 
 def update_contentmetadata_from_discovery(catalog_query_id):
     """
-    catalog_query_id is a identifer for CatalogQuery objects (str)
+    catalog_query_id is a identifer for CatalogQuery objects (int)
 
     Takes a uuid, looks up catalogquery, uses discovery service client to
     grab fresh metadata, and then create/updates ContentMetadata objects.

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -49,7 +49,7 @@ class TestModels(TestCase):
         catalog = factories.EnterpriseCatalogFactory()
 
         self.assertEqual(ContentMetadata.objects.count(), 0)
-        update_contentmetadata_from_discovery(catalog.uuid)
+        update_contentmetadata_from_discovery(catalog.catalog_query.id)
         mock_client.assert_called_once()
         self.assertEqual(ContentMetadata.objects.count(), 3)
 
@@ -78,7 +78,7 @@ class TestModels(TestCase):
         # from catalog query while perserving the content metadata objects
         # themselves.
         mock_client.return_value.get_metadata_by_query.return_value = [program_metadata]
-        update_contentmetadata_from_discovery(catalog.uuid)
+        update_contentmetadata_from_discovery(catalog.catalog_query.id)
         self.assertEqual(ContentMetadata.objects.count(), 3)
 
         associated_metadata = catalog.content_metadata


### PR DESCRIPTION
## Description

The `update_content_metadata` command runs daily. In it, we iterate through all `EnterpriseCatalog` and update their associated content metadata.

To reduce the number of updates we're making, we can instead iterate through all the `CatalogQuery` objects instead.

## Post-review

Squash commits into discrete sets of changes
