### PR TITLE
an attempt to get consistent paginated results from search/all

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -415,6 +415,11 @@ def update_contentmetadata_from_discovery(catalog_query_id):
             # pages (e.g., a course is included on both pages 1 and 2). This issue with the
             # /search/all/ endpoint is likely the reason we get duplicate results.
             'page_size': 200,
+            # Another attempt to address the non-deterministic pagination behavior of the
+            # /search/all endpoint. The endpoint enables ordering for the `start` field,
+            # but doesn't seem to apply that ordering by default. This query param may help
+            # to get consistent results when traversing pagination.
+            'ordering': 'start',
         }
         metadata = client.get_metadata_by_query(catalog_query.content_filter, query_params=query_params)
         metadata_content_keys = [get_content_key(entry) for entry in metadata]


### PR DESCRIPTION
## Description

Another attempt to address the non-deterministic pagination behavior of the /search/all endpoint. The endpoint enables ordering for the `start` field, but doesn't seem to apply that ordering by default. This query param may help to get consistent results when traversing pagination.

## Post-review

Squash commits into discrete sets of changes
