### PR TITLE
change ordering query parameter on /search/all requests

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -416,10 +416,10 @@ def update_contentmetadata_from_discovery(catalog_query_id):
             # /search/all/ endpoint is likely the reason we get duplicate results.
             'page_size': 200,
             # Another attempt to address the non-deterministic pagination behavior of the
-            # /search/all endpoint. The endpoint enables ordering for the `start` field,
-            # but doesn't seem to apply that ordering by default. This query param may help
+            # /search/all endpoint. The endpoint now enables ordering for the `aggregation_key` 
+            # field, but doesn't apply that ordering by default. This query param may help
             # to get consistent results when traversing pagination.
-            'ordering': 'start',
+            'ordering': 'aggregation_key',
         }
         metadata = client.get_metadata_by_query(catalog_query.content_filter, query_params=query_params)
         metadata_content_keys = [get_content_key(entry) for entry in metadata]

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -410,15 +410,9 @@ def update_contentmetadata_from_discovery(catalog_query_id):
         query_params = {
             # Omit non-active course runs from the course-discovery results
             'exclude_expired_course_run': True,
-            # Increasing page_size will help alleviate the non-deterministic behavior
-            # of the /search/all/ endpoint where a content item may appear on multiple
-            # pages (e.g., a course is included on both pages 1 and 2). This issue with the
-            # /search/all/ endpoint is likely the reason we get duplicate results.
-            'page_size': 200,
-            # Another attempt to address the non-deterministic pagination behavior of the
-            # /search/all endpoint. The endpoint now enables ordering for the `aggregation_key`
-            # field, but doesn't apply that ordering by default. This query param may help
-            # to get consistent results when traversing pagination.
+            # Increase number of results per page for the course-discovery response
+            'page_size': 100,
+            # Ensure paginated results are consistently ordered by `aggregation_key`
             'ordering': 'aggregation_key',
         }
         metadata = client.get_metadata_by_query(catalog_query.content_filter, query_params=query_params)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -416,7 +416,7 @@ def update_contentmetadata_from_discovery(catalog_query_id):
             # /search/all/ endpoint is likely the reason we get duplicate results.
             'page_size': 200,
             # Another attempt to address the non-deterministic pagination behavior of the
-            # /search/all endpoint. The endpoint now enables ordering for the `aggregation_key` 
+            # /search/all endpoint. The endpoint now enables ordering for the `aggregation_key`
             # field, but doesn't apply that ordering by default. This query param may help
             # to get consistent results when traversing pagination.
             'ordering': 'aggregation_key',


### PR DESCRIPTION
## Description

The /search/all endpoint can now accept an `ordering=aggregation_key` query parameter in order to return sorted (and hopefully consistent 🤞) results through this PR: https://github.com/edx/course-discovery/pull/2624

Once that change deploys, we will want to update the `ordering` query parameter to "aggregation_key".

## Post-review

Squash commits into discrete sets of changes
