### PR TITLE
improve error handling and add logging around requests to /search/all/

### DIFF
--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -4,6 +4,7 @@ import mock
 from django.test import TestCase
 
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
+from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
 
 
 class TestDiscoveryApiClient(TestCase):
@@ -19,10 +20,10 @@ class TestDiscoveryApiClient(TestCase):
             'results': [{'key': 'fakeX'}],
         }
 
-        content_filter = {'*': '*'}
+        catalog_query = CatalogQueryFactory()
         query_params = {'exclude_expired_course_run': True}
         client = DiscoveryApiClient()
-        actual_response = client.get_metadata_by_query(content_filter, query_params)
+        actual_response = client.get_metadata_by_query(catalog_query, query_params)
 
         mock_oauth_client.return_value.post.assert_called_once()
 

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -415,7 +415,7 @@ def update_contentmetadata_from_discovery(catalog_query_id):
             # Ensure paginated results are consistently ordered by `aggregation_key` and `start`
             'ordering': 'aggregation_key,start',
         }
-        metadata = client.get_metadata_by_query(catalog_query.content_filter, query_params=query_params)
+        metadata = client.get_metadata_by_query(catalog_query, query_params=query_params)
         metadata_content_keys = [get_content_key(entry) for entry in metadata]
 
         LOGGER.info(


### PR DESCRIPTION
## Description

Adding a try/catch block around requests to discovery to catch when it throws a `JsonDecodeError`, when the /search/all/ requests returns nothing (i.e., fails):

https://rpm.newrelic.com/accounts/88178/applications/512093214/filterable_errors#/table?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart&filters=%5B%7B%22key%22%3A%22error.class%22%2C%22value%22%3A%22simplejson.errors%3AJSONDecodeError%22%2C%22like%22%3Afalse%7D%5D

Also, logs the error including the `CatalogQuery` to be able to figure out which catalog queries the issue is affecting for debugging purposes.

## Post-review

Squash commits into discrete sets of changes
