### PR TITLE
run task only for queries used by at least one catalog

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -3,7 +3,10 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
-from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
+from enterprise_catalog.apps.catalog.tests.factories import (
+    CatalogQueryFactory,
+    EnterpriseCatalogFactory,
+)
 
 
 class UpdateContentMetadataCommandTests(TestCase):
@@ -12,13 +15,40 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task.delay'
     )
-    def test_update_content_metadata(self, mock_task):
+    def test_update_content_metadata_for_all_queries(self, mock_task):
         """
-        Verify that the job creates an update task for every enterprise catalog
+        Verify that the job creates an update task for every catalog query
         """
         [catalog_query_a, catalog_query_b, catalog_query_c] = CatalogQueryFactory.create_batch(3)
+
+        enterprise_catalog_a = EnterpriseCatalogFactory(catalog_query=catalog_query_a)
+        enterprise_catalog_b = EnterpriseCatalogFactory(catalog_query=catalog_query_b)
+        enterprise_catalog_c = EnterpriseCatalogFactory(catalog_query=catalog_query_c)
+
         call_command(self.command_name)
+
+        assert mock_task.call_count == 3
 
         mock_task.assert_any_call(catalog_query_id=catalog_query_a.id)
         mock_task.assert_any_call(catalog_query_id=catalog_query_b.id)
         mock_task.assert_any_call(catalog_query_id=catalog_query_c.id)
+
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task.delay'
+    )
+    def test_update_content_metadata_for_filtered_queries(self, mock_task):
+        """
+        Verify that the job creates an update task for every catalog query that is used by
+        at least one enterprise catalog.
+        """
+        [catalog_query_a, catalog_query_b, catalog_query_c] = CatalogQueryFactory.create_batch(3)
+
+        enterprise_catalog_a = EnterpriseCatalogFactory(catalog_query=catalog_query_a)
+        enterprise_catalog_b = EnterpriseCatalogFactory(catalog_query=catalog_query_b)
+
+        call_command(self.command_name)
+
+        assert mock_task.call_count == 2
+
+        mock_task.assert_any_call(catalog_query_id=catalog_query_a.id)
+        mock_task.assert_any_call(catalog_query_id=catalog_query_b.id)

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -3,7 +3,10 @@ import logging
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
-from enterprise_catalog.apps.catalog.models import CatalogQuery, EnterpriseCatalog
+from enterprise_catalog.apps.catalog.models import (
+    CatalogQuery,
+    EnterpriseCatalog,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
-from enterprise_catalog.apps.catalog.models import CatalogQuery
+from enterprise_catalog.apps.catalog.models import CatalogQuery, EnterpriseCatalog
 
 
 logger = logging.getLogger(__name__)
@@ -11,12 +11,13 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = (
-        'Update Content Metadata, along with the associations of Catalog Queries and Content Metadata, for all'
-        ' Enterprise Catalogs'
+        'Update Content Metadata, along with the associations of Catalog Queries and Content Metadata',
     )
 
     def handle(self, *args, **options):
-        for catalog_query in CatalogQuery.objects.all():
+        # Iterate through all CatalogQuery records used by at least one EnterpriseCatalog to avoid
+        # calling /search/all/ for a CatalogQuery that is not currently used by any catalogs.
+        for catalog_query in CatalogQuery.objects.filter(enterprise_catalogs__isnull=False).distinct():
             update_catalog_metadata_task.delay(catalog_query_id=catalog_query.id)
             message = (
                 'Spinning off update_catalog_metadata_task from update_content_metadata command'


### PR DESCRIPTION
## Description

Right now, we have 118 unused `CatalogQuery` records in our DB (i.e., no associated `EnterpriseCatalog` records). Despite this, we still try to update those `CatalogQuery` records even though no catalog will be using those results.

To further reduce the number of requests/load to the `/search/all/` endpoint during the `update_content_metadata` job that runs daily, we can iterate through just the `CatalogQuery` records that are used by at least 1 `EnterpriseCatalog`.

Using today's numbers, we will reduce the number of tasks generated and requests to the `/search/all/` endpoint from 820 to 702. This will speed up the `update_content_metadata` job further and reduce load for course-discovery.

## Post-review

Squash commits into discrete sets of changes
