### PR TITLE
prevent future errors

### DIFF
--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -65,6 +65,6 @@ def is_any_course_run_enrollable(course_runs):
         bool: True if enrollable course run is found, else False
     """
     for course_run in course_runs:
-        if course_run['is_enrollable']:
+        if course_run.get('is_enrollable'):
             return True
     return False


### PR DESCRIPTION
## Description

Changing `course_run['is_enrollable']` to `course_run.get('is_enrollable')` to be more error-proof and avoid an `AttributeError` if the "is_enrollable" attribute doesn't exist on a course run.

This was inspired by running the `update_content_metadata` command locally on an outdated version of discovery before the `is_enrollable` attribute was introduced on the /search/all/ endpoint.

I don't imagine we will should run into an `AttributeError` on production as is but just in case? 💭 

## Post-review

Squash commits into discrete sets of changes
