### PR TITLE
refactor contains_content_keys to handle when content key exists in a course's course_runs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,24 +28,23 @@ To use ``django-silk`` during local development to profile requests and database
 #. Make any request (e.g., http://localhost:18160/api/v1/enterprise-catalogs/) and check back on the Silk UI.
 #. The request you made should appear in the Django Silk UI. From here, click on the request to view its details.
 
-``django-silk`` can also be used to profile specific code blocks within a function/method through the `silk_profile` decorator and/or context manager:
+``django-silk`` can also be used to profile specific code blocks within a function/method through the `silk_profile` decorator and/or context manager. Example:
 
-.. code-block::
-    :linenos:
+.. code-block:: python
 
     from silk.profiling.profiler import silk_profile
 
     class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
-      @silk_profile(name='get_enterprise_catalog')
-      def get_enterprise_catalog(self):
-          uuid = self.kwargs.get('uuid')
-          return get_object_or_404(EnterpriseCatalog, uuid=uuid)
-
-    class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
-      def get_enterprise_catalog(self):
-        with silk_profile(name='get_enterprise_catalog'):
+        @silk_profile(name='get_enterprise_catalog')
+        def get_enterprise_catalog(self):
             uuid = self.kwargs.get('uuid')
             return get_object_or_404(EnterpriseCatalog, uuid=uuid)
+
+    class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
+        def get_enterprise_catalog(self):
+            with silk_profile(name='get_enterprise_catalog'):
+                uuid = self.kwargs.get('uuid')
+                return get_object_or_404(EnterpriseCatalog, uuid=uuid)
 
 See https://github.com/jazzband/django-silk for more advanced usage.
 

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,45 @@ Enterprise catalog service  |Travis|_ |Codecov|_
 A Django-based microservice for handling Enterprise catalogs, associating enterprise customers with curated courses from the full course catalog.
 
 Getting Started
--------
+---------------
+
 Check out the `initial steps <docs/getting_started.rst>`_ for getting started with the Enterprise catalog service.
+
+Using ``django-silk`` for database/performance profiling
+--------------------------------------------------------
+
+``django-silk`` provides middleware to intercept/store HTTP requests and database queries for the purpose of profiling and inspection. For example,
+you may want to examine the response times, number of database queries made, and the raw SQL the Django ORM creates to make database queries.
+
+To use ``django-silk`` during local development to profile requests and database queries:
+
+#. ``make dev.up.build`` (this will install ``django-silk`` if it hasn't already been installed)
+#. ``make app-shell``
+#. ``./manage.py migrate silk`` to run ``django-silk``'s migrations.
+#. Navigate to http://localhost:18160/silk/ for the Django Silk UI.
+#. Make any request (e.g., http://localhost:18160/api/v1/enterprise-catalogs/) and check back on the Silk UI.
+#. The request you made should appear in the Django Silk UI. From here, click on the request to view its details.
+
+``django-silk`` can also be used to profile specific code blocks within a function/method through the `silk_profile` decorator and/or context manager:
+
+.. code-block::
+    :linenos:
+
+    from silk.profiling.profiler import silk_profile
+
+    class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
+      @silk_profile(name='get_enterprise_catalog')
+      def get_enterprise_catalog(self):
+          uuid = self.kwargs.get('uuid')
+          return get_object_or_404(EnterpriseCatalog, uuid=uuid)
+
+    class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
+      def get_enterprise_catalog(self):
+        with silk_profile(name='get_enterprise_catalog'):
+            uuid = self.kwargs.get('uuid')
+            return get_object_or_404(EnterpriseCatalog, uuid=uuid)
+
+See https://github.com/jazzband/django-silk for more advanced usage.
 
 License
 -------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       CELERY_BROKER_PASSWORD: password
       DJANGO_SETTINGS_MODULE: enterprise_catalog.settings.devstack
       ENABLE_DJANGO_TOOLBAR: 1
+      ENABLE_DJANGO_SILK: 1
 
   worker:
     build:

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -506,10 +506,6 @@ class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
         """
         content_key = 'course-content-key'
         course_run_content_key = 'course-run-content-key'
-        associated_course_run_metadata = ContentMetadataFactory(
-            content_key=course_run_content_key,
-            parent_content_key=content_key,
-        )
         associated_course_metadata = ContentMetadataFactory(
             content_key=content_key,
             json_metadata={
@@ -517,6 +513,8 @@ class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
                 'course_runs': [{'key': course_run_content_key}],
             }
         )
+        # create content metadata for course run associated with above course
+        ContentMetadataFactory(content_key=course_run_content_key, parent_content_key=content_key)
         self.add_metadata_to_catalog(self.enterprise_catalog, [associated_course_metadata])
 
         url = self._get_contains_content_base_url(self.enterprise_catalog) + '?course_run_ids=' + course_run_content_key

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -489,12 +489,34 @@ class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
         """
         Verify the contains_content_items endpoint returns True if the parent's key is in the catalog
         """
-        child_key = 'child-key+101x'
         parent_metadata = ContentMetadataFactory(content_key='parent-key')
-        ContentMetadataFactory(content_key=child_key, parent_content_key=parent_metadata.content_key)
-        self.add_metadata_to_catalog(self.enterprise_catalog, [parent_metadata])
+        associated_metadata = ContentMetadataFactory(
+            content_key='child-key+101x',
+            parent_content_key=parent_metadata.content_key
+        )
+        self.add_metadata_to_catalog(self.enterprise_catalog, [associated_metadata])
 
-        url = self._get_contains_content_base_url(self.enterprise_catalog) + '?course_run_ids=' + child_key
+        query_string = '?course_run_ids=' + parent_metadata.content_key
+        url = self._get_contains_content_base_url(self.enterprise_catalog) + query_string
+        self.assert_correct_contains_response(url, True)
+
+    def test_contains_content_items_course_run_keys_in_catalog(self):
+        """
+        Verify the contains_content_items endpoint returns True if a course run's key is in the catalog
+        """
+        content_key = 'course-content-key'
+        course_run_content_key = 'course-run-content-key'
+        associated_metadata = ContentMetadataFactory(
+            content_key=content_key,
+            json_metadata={
+                'key': content_key,
+                'marketing_url': 'http://marketing.url/{}'.format(content_key),
+                'course_runs': [{'key': course_run_content_key}],
+            }
+        )
+        self.add_metadata_to_catalog(self.enterprise_catalog, [associated_metadata])
+
+        url = self._get_contains_content_base_url(self.enterprise_catalog) + '?course_run_ids=' + course_run_content_key
         self.assert_correct_contains_response(url, True)
 
     def test_contains_content_items_keys_not_in_catalog(self):

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -506,15 +506,18 @@ class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
         """
         content_key = 'course-content-key'
         course_run_content_key = 'course-run-content-key'
-        associated_metadata = ContentMetadataFactory(
+        associated_course_run_metadata = ContentMetadataFactory(
+            content_key=course_run_content_key,
+            parent_content_key=content_key,
+        )
+        associated_course_metadata = ContentMetadataFactory(
             content_key=content_key,
             json_metadata={
                 'key': content_key,
-                'marketing_url': 'http://marketing.url/{}'.format(content_key),
                 'course_runs': [{'key': course_run_content_key}],
             }
         )
-        self.add_metadata_to_catalog(self.enterprise_catalog, [associated_metadata])
+        self.add_metadata_to_catalog(self.enterprise_catalog, [associated_course_metadata])
 
         url = self._get_contains_content_base_url(self.enterprise_catalog) + '?course_run_ids=' + course_run_content_key
         self.assert_correct_contains_response(url, True)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -197,10 +197,8 @@ class EnterpriseCatalog(TimeStampedModel):
         }
         query |= Q(content_key__in=parent_content_keys)
 
-        content_metadata = self.content_metadata.filter(query)
-
-        # if content metadata was returned, the specified content_keys exist in the catalog
-        return bool(content_metadata)
+        # if the filtered content metadata exists, the specified content_keys exist in the catalog
+        return self.content_metadata.filter(query).exists()
 
     def get_content_enrollment_url(self, content_resource, content_key):
         """

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -177,9 +177,8 @@ class EnterpriseCatalog(TimeStampedModel):
         content_keys = set(content_keys)
 
         # retrieve content metadata objects for the specified content keys to get a set of
-        # parent content keys to use in the below query that returns all matching content
-        # metadata for the specified content keys. this handles the case for when a catalog
-        # contains only courses but course runs are specified in content_keys.
+        # parent content keys to use in the below query. this handles the case for when a
+        # catalog contains only courses but course run(s) are specified in content_keys.
         searched_metadata = ContentMetadata.objects.filter(content_key__in=content_keys)
         parent_content_keys = {
             metadata.parent_content_key
@@ -191,10 +190,11 @@ class EnterpriseCatalog(TimeStampedModel):
         query = Q(content_key__in=content_keys)
         query |= Q(parent_content_key__in=content_keys)
         query |= Q(content_key__in=parent_content_keys)
+
         content_metadata = self.catalog_query.contentmetadata_set.filter(query)
 
         # if content metadata was returned, the specified content keys exist in the catalog
-        return True if content_metadata else False
+        return bool(content_metadata)
 
     def get_content_enrollment_url(self, content_resource, content_key):
         """

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -159,8 +159,8 @@ class EnterpriseCatalog(TimeStampedModel):
         """
         Determines whether content_keys are part of the catalog.
 
-        Return True if catalog contains the {courses/course runs} and/or programs specified by the given
-        content key(s), else False.
+        Return True if catalog contains the courses, course runs, and/or programs specified by
+        the given content key(s), else False.
 
         A content key is considered contained within the catalog when:
           - associated metadata contains the specified content key.
@@ -184,7 +184,7 @@ class EnterpriseCatalog(TimeStampedModel):
         #   - contains course runs and the specified content_keys are course run ids
         #   - contains programs and the specified content_keys are program ids
         query = Q(content_key__in=content_keys) | Q(parent_content_key__in=content_keys)
-        
+
         # retrieve content metadata objects for the specified content keys to get a set of
         # parent content keys, i.e. course ids associated with the specified content_keys
         # (if any) to handle the following case:

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -60,10 +60,12 @@ class ContentMetadataFactory(factory.DjangoModelFactory):
 
     @factory.lazy_attribute
     def json_metadata(self):
-        return {
-            'key': self.content_key,
-            'marketing_url': 'http://marketing.yay/{}'.format(self.content_key),
-        }
+        json_metadata = {'key': self.content_key}
+        if self.content_key == COURSE:
+            json_metadata.update({
+                'marketing_url': 'http://marketing.url/{}'.format(self.content_key),
+            })
+        return json_metadata
 
 
 class UserFactory(factory.DjangoModelFactory):

--- a/enterprise_catalog/settings/local.py
+++ b/enterprise_catalog/settings/local.py
@@ -46,6 +46,18 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
 INTERNAL_IPS = ('127.0.0.1',)
 # END TOOLBAR CONFIGURATION
 
+# DJANGO-SILK CONFIGURATION
+# See: https://github.com/jazzband/django-silk
+if os.environ.get('ENABLE_DJANGO_SILK', False):
+    MIDDLEWARE += (
+        'silk.middleware.SilkyMiddleware',
+    )
+
+    INSTALLED_APPS += (
+        'silk',
+    )
+# END OF DJANGO-SILK CONFIGURATION
+
 # AUTHENTICATION
 # Use a non-SSL URL for authorization redirects
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False

--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -37,8 +37,12 @@ urlpatterns = [
     url(r'^health/$', core_views.health, name='health'),
 ]
 
-if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
-    # Disable pylint import error because we don't install django-debug-toolbar
-    # for CI build
-    import debug_toolbar
-    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+if settings.DEBUG:
+    if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
+        # Disable pylint import error because we don't install django-debug-toolbar
+        # for CI build
+        import debug_toolbar
+        urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+
+    if os.environ.get('ENABLE_DJANGO_SILK', False):  # pragma: no cover
+        urlpatterns.append(url(r'^silk/', include('silk.urls', namespace='silk')))

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,3 +11,4 @@ django-debug-toolbar      # For debugging Django
 #transifex-client         # For managing translations
 inflect<4.0.0             # Inflect 4.0.0 requires python>=3.6
 ddt
+django-silk                      # For SQL query and performance profiling

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,4 +11,4 @@ django-debug-toolbar      # For debugging Django
 #transifex-client         # For managing translations
 inflect<4.0.0             # Inflect 4.0.0 requires python>=3.6
 ddt
-django-silk                      # For SQL query and performance profiling
+django-silk               # For SQL query and performance profiling

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,7 @@ anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/tes
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
+autopep8==1.5.3           # via django-silk
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
 celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt
 certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/test.txt, requests
@@ -30,9 +31,10 @@ django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-silk==4.0.1        # via -r requirements/dev.in
 django-simple-history==2.10.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, django-silk, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -49,6 +51,7 @@ factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
+gprof2dot==2019.11.30     # via django-silk
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
@@ -56,7 +59,7 @@ inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, django-silk, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
@@ -78,10 +81,10 @@ pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, to
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
-pycodestyle==2.6.0        # via -r requirements/quality.txt
+pycodestyle==2.6.0        # via -r requirements/quality.txt, autopep8
 pycryptodomex==3.9.7      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.txt
-pygments==2.6.1           # via diff-cover
+pygments==2.6.1           # via diff-cover, django-silk
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
@@ -93,14 +96,14 @@ pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
+python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, django-silk, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
+pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-silk
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, django-silk, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -110,16 +113,16 @@ slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/tes
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar
+sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar, django-silk
 stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, tox
+toml==0.10.1              # via -r requirements/test.txt, autopep8, tox
 tox==3.15.1               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
 virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.1.9            # via -r requirements/test.txt, pytest
+wcwidth==0.2.2            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,7 +36,7 @@ django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-
 django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-doc8==0.8.0               # via -r requirements/doc.in
+doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
@@ -77,7 +77,7 @@ pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
-pygments==2.6.1           # via readme-renderer, sphinx
+pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
@@ -124,7 +124,7 @@ typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.1.9            # via -r requirements/test.txt, pytest
+wcwidth==0.2.2            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -32,7 +32,7 @@ edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-gevent==20.5.1            # via -r requirements/production.in
+gevent==20.5.2            # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -105,6 +105,6 @@ typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, requests
 virtualenv==20.0.21       # via tox
-wcwidth==0.1.9            # via pytest
+wcwidth==0.2.2            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description

> May 31 18:28:45 ip-10-2-12-181 [service_variant=lms][enterprise.api.v1.serializers][env:prod-edx-edxapp] ERROR [ip-10-2-12-181  31166] [user 32845815] [serializers.py:703] - [Enterprise API] The course run id is not in the catalog for the Enterprise Customer. EnterpriseCustomer: University of Iceland, CourseRun: course-v1:IMFx+MRCx+1T2020


The contains_content_items call for this course run returns `True` on edx-enterprise but enterprise-catalog returns `False`.

After investigating, this error is valid as the course run is technically part of the catalog (the course run with the specified content key comes back as part of the “course_runs” list for the associated course in the get_content_metadata response.

In the contains_content_keys method, we should also check to see if the specified content key matches the key of any course runs for a course.

### Django Silk

This PR also installs [django-silk](https://github.com/jazzband/django-silk) locally to capture requests for SQL query and performance optimization debugging.

#### Instructions

1. `make dev.up.build`
1. `make app-shell` and then `./manage.py migrate silk` to run django-silk's migrations.
1. Browse to http://localhost:18160/silk/ for the Django Silk UI.
1. Make any request (e.g., http://localhost:18160/api/v1/enterprise-catalogs/3a18971e-dede-41d3-a7da-6db2dba9c80e/get_content_metadata) and check back on the Silk UI. You should see your request appear. You can now click on it to see the details about SQL queries and performance.

Example:

![image](https://user-images.githubusercontent.com/2828721/83541257-6a794100-a4c7-11ea-955f-722c808f25ba.png)

![image](https://user-images.githubusercontent.com/2828721/83542376-ddcf8280-a4c8-11ea-9a57-adb8020038d4.png)

## Post-review

Squash commits into discrete sets of changes
