### PR TITLE
Don't associate metadata when discovery call(s) fails during `update_content_metadata` job

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -45,7 +45,8 @@ class DiscoveryApiClient:
         query_params (dict): additional query params for the rest api endpoint
              we're hitting. e.g. - {'page': 3}
 
-        Returns a list of the results.
+        Returns a list of the results, or `None` if there was an error calling the
+        discovery service.
         """
         if query_params is None:
             query_params = {}
@@ -70,11 +71,15 @@ class DiscoveryApiClient:
                     params=query_params
                 ).json()
                 results += response.get('results', [])
-        except JSONDecodeError:
+        except JSONDecodeError as exc:
             LOGGER.error(
-                'Could not retrieve content items from course-discovery (page %s) for catalog query %s',
+                'Could not retrieve content items from course-discovery (page %s) for catalog query %s: %s',
                 page,
                 catalog_query,
+                exc,
             )
+            # if a request to discovery fails, return `None` so that callers of this
+            # method are aware we weren't able to get all metadata for the given query
+            return None
 
         return results

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -2,6 +2,7 @@
 
 import mock
 from django.test import TestCase
+from simplejson import JSONDecodeError
 
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
@@ -11,7 +12,7 @@ class TestDiscoveryApiClient(TestCase):
     """ DiscoveryApiClient tests. """
 
     @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
-    def test_get_metadata_by_query(self, mock_oauth_client):
+    def test_get_metadata_by_query_with_results(self, mock_oauth_client):
         """
         get_metadata_by_query should call discovery endpoint, but not call
         traverse_pagination if traverse_pagination is false.
@@ -28,4 +29,21 @@ class TestDiscoveryApiClient(TestCase):
         mock_oauth_client.return_value.post.assert_called_once()
 
         expected_response = [{'key': 'fakeX'}]
+        self.assertEqual(actual_response, expected_response)
+
+    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
+    def test_get_metadata_by_query_with_error(self, mock_oauth_client):
+        """
+        get_metadata_by_query should return None when a call(s) to discovery endpoint fail.
+        """
+        mock_oauth_client.return_value.post.side_effect = JSONDecodeError('error', '{}', 0)
+
+        catalog_query = CatalogQueryFactory()
+        query_params = {'exclude_expired_course_run': True}
+        client = DiscoveryApiClient()
+        actual_response = client.get_metadata_by_query(catalog_query, query_params)
+
+        mock_oauth_client.return_value.post.assert_called_once()
+
+        expected_response = None
         self.assertEqual(actual_response, expected_response)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -431,24 +431,28 @@ def update_contentmetadata_from_discovery(catalog_query_id):
             'ordering': 'aggregation_key,start',
         }
         metadata = client.get_metadata_by_query(catalog_query, query_params=query_params)
-        metadata_content_keys = [get_content_key(entry) for entry in metadata]
 
-        LOGGER.info(
-            'Retrieved %d content items (%d unique) from course-discovery for catalog query %s: %s',
-            len(metadata_content_keys),
-            len(set(metadata_content_keys)),
-            catalog_query,
-            metadata_content_keys
-        )
+        # associate content metadata with a catalog query only when we get valid results
+        # back from the discovery service. if metadata is `None`, an error occurred while
+        # calling discovery and we should not proceed with the below association logic.
+        if metadata is not None:
+            metadata_content_keys = [get_content_key(entry) for entry in metadata]
+            LOGGER.info(
+                'Retrieved %d content items (%d unique) from course-discovery for catalog query %s: %s',
+                len(metadata_content_keys),
+                len(set(metadata_content_keys)),
+                catalog_query,
+                metadata_content_keys
+            )
 
-        associated_content_keys = associate_content_metadata_with_query(metadata, catalog_query)
-        LOGGER.info(
-            'Associated %d content items (%d unique) with catalog query %s: %s',
-            len(associated_content_keys),
-            len(set(associated_content_keys)),
-            catalog_query,
-            associated_content_keys,
-        )
+            associated_content_keys = associate_content_metadata_with_query(metadata, catalog_query)
+            LOGGER.info(
+                'Associated %d content items (%d unique) with catalog query %s: %s',
+                len(associated_content_keys),
+                len(set(associated_content_keys)),
+                catalog_query,
+                associated_content_keys,
+            )
     else:
         LOGGER.warning(
             'Could not find a CatalogQuery with id %s',


### PR DESCRIPTION
## Description

Several Enterprise catalogs had 0 results on the `get_content_metadata` response but edx-enterprise was returning 31 results. I re-synced one of these catalogs and the update worked; `get_content_metadata` for that catalog now returns the expected 31 results.

Digging into splunk, this was caused when calls to Discovery fails during the `update_content_metadata` job, we were returning 0 results and continuing to associate 0 metadata results with the catalog query, overwriting what was already in there.

This PR proposes a solution to only associate content metadata when we get all results for a catalog query. When a call(s) to discovery fails for a catalog, it would need to be re-synced or wait until the next run of the the `update_content_metadata` job.

## Post-review

Squash commits into discrete sets of changes
