### PR TITLE
Index course data in enterprise_catalog Algolia index

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -1,8 +1,90 @@
+import logging
+
 from celery import shared_task
 
+from enterprise_catalog.apps.api.v1.utils import (
+    add_uuids_to_courses,
+    create_algolia_objects_from_courses,
+    initialize_algolia_index,
+)
+from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.models import (
+    get_related_enterprise_catalogs_for_content_keys,
     update_contentmetadata_from_discovery,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True)
+# pylint: disable=unused-argument
+def index_enterprise_catalog_courses_in_algolia(self, content_keys, index_name, app_id, api_key, algolia_fields):
+    """
+    Index a batch of course content into Algolia.
+
+    Arguments:
+        content_keys (list): a list of content_keys to index in Algolia
+        index_name (str): name of an Algolia index
+        app_id (str): an APPLICATION_ID for Algolia
+        api_key (str): an API_KEY for Algolia
+    """
+    algolia_index = initialize_algolia_index(index_name, app_id, api_key)
+    if not algolia_index:
+        # without an Algolia index, we can't really do much of anything so exit early
+        return
+
+    discovery_client = DiscoveryApiClient()
+    query_params = {
+        'keys': ','.join(content_keys),
+        'limit': 100,
+        'ordering': 'key',
+    }
+    courses = discovery_client.get_courses(query_params=query_params)
+    logger.info(
+        'Retrieved %d courses from course-discovery for %d content keys: %s',
+        len(courses),
+        len(content_keys),
+        content_keys,
+    )
+
+    if courses is not None:
+        # Get related enterprise_catalog_uuids and enterprise_customer_uuids for the provided content_keys
+        related_enterprise_catalogs = get_related_enterprise_catalogs_for_content_keys(content_keys)
+        for content_key, uuids in related_enterprise_catalogs.items():
+            # add those enterprise-specific uuids to the appropriate course object within the list of courses
+            courses = add_uuids_to_courses(content_key, uuids, courses)
+
+        # create objects to send to Algolia by extracting only the fields we care about
+        algolia_objects = create_algolia_objects_from_courses(courses, algolia_fields)
+
+        try:
+            # Add algolia_objects to the Algolia index
+            response = algolia_index.partial_update_objects(algolia_objects, {
+                'createIfNotExists': True,
+            })
+            object_ids = []
+            for response in response.raw_responses:
+                object_ids += response.get('objectIDs', [])
+            logger.info(
+                'Successfully indexed %d (%d unique) courses in Algolia\'s %s index: %s',
+                len(object_ids),
+                len(set(object_ids)),
+                index_name,
+                object_ids,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                'Could not index %d course(s) in Algolia\'s %s index: %s',
+                len(algolia_objects),
+                index_name,
+                exc,
+            )
+    else:
+        logger.error(
+            'No courses retrieved from course-discovery for content keys: %s',
+            content_keys,
+        )
 
 
 @shared_task(bind=True)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -2,6 +2,7 @@ import copy
 import logging
 
 from celery import shared_task
+from celery_utils.logged_task import LoggedTask
 
 from enterprise_catalog.apps.api.v1.utils import (
     create_algolia_objects_from_courses,
@@ -19,7 +20,7 @@ from enterprise_catalog.apps.catalog.models import (
 logger = logging.getLogger(__name__)
 
 
-@shared_task
+@shared_task(base=LoggedTask)
 def index_enterprise_catalog_courses_in_algolia(content_keys, algolia_fields):
     """
     Index a batch of course content into Algolia.
@@ -83,6 +84,6 @@ def index_enterprise_catalog_courses_in_algolia(content_keys, algolia_fields):
     algolia_client.partially_update_index(algolia_objects)
 
 
-@shared_task
+@shared_task(base=LoggedTask)
 def update_catalog_metadata_task(catalog_query_id):
     update_contentmetadata_from_discovery(catalog_query_id)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -1,12 +1,14 @@
+import copy
 import logging
 
 from celery import shared_task
 
 from enterprise_catalog.apps.api.v1.utils import (
-    add_uuids_to_courses,
     create_algolia_objects_from_courses,
-    initialize_algolia_index,
+    find_index_in_courses_for_content_key,
+    get_algolia_object_id,
 )
+from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.models import (
     get_related_enterprise_catalogs_for_content_keys,
@@ -17,30 +19,30 @@ from enterprise_catalog.apps.catalog.models import (
 logger = logging.getLogger(__name__)
 
 
-@shared_task(bind=True)
-# pylint: disable=unused-argument
-def index_enterprise_catalog_courses_in_algolia(self, content_keys, index_name, app_id, api_key, algolia_fields):
+@shared_task
+def index_enterprise_catalog_courses_in_algolia(content_keys, algolia_fields):
     """
     Index a batch of course content into Algolia.
 
     Arguments:
         content_keys (list): a list of content_keys to index in Algolia
-        index_name (str): name of an Algolia index
-        app_id (str): an APPLICATION_ID for Algolia
-        api_key (str): an API_KEY for Algolia
+        algolia_fields (list): list of course fields we want to index in Algolia
     """
-    algolia_index = initialize_algolia_index(index_name, app_id, api_key)
-    if not algolia_index:
-        # without an Algolia index, we can't really do much of anything so exit early
-        return
+    # initialize Algolia index
+    algolia_client = AlgoliaSearchClient()
+    algolia_client.init_index()
 
-    discovery_client = DiscoveryApiClient()
     query_params = {
         'keys': ','.join(content_keys),
         'limit': 100,
         'ordering': 'key',
     }
-    courses = discovery_client.get_courses(query_params=query_params)
+    try:
+        discovery_client = DiscoveryApiClient()
+        courses = discovery_client.get_courses(query_params=query_params)
+    except Exception:  # pylint: disable=broad-except
+        courses = None
+
     logger.info(
         'Retrieved %d courses from course-discovery for %d content keys: %s',
         len(courses),
@@ -48,46 +50,39 @@ def index_enterprise_catalog_courses_in_algolia(self, content_keys, index_name, 
         content_keys,
     )
 
-    if courses is not None:
-        # Get related enterprise_catalog_uuids and enterprise_customer_uuids for the provided content_keys
-        related_enterprise_catalogs = get_related_enterprise_catalogs_for_content_keys(content_keys)
-        for content_key, uuids in related_enterprise_catalogs.items():
-            # add those enterprise-specific uuids to the appropriate course object within the list of courses
-            courses = add_uuids_to_courses(content_key, uuids, courses)
-
-        # create objects to send to Algolia by extracting only the fields we care about
-        algolia_objects = create_algolia_objects_from_courses(courses, algolia_fields)
-
-        try:
-            # Add algolia_objects to the Algolia index
-            response = algolia_index.partial_update_objects(algolia_objects, {
-                'createIfNotExists': True,
-            })
-            object_ids = []
-            for response in response.raw_responses:
-                object_ids += response.get('objectIDs', [])
-            logger.info(
-                'Successfully indexed %d (%d unique) courses in Algolia\'s %s index: %s',
-                len(object_ids),
-                len(set(object_ids)),
-                index_name,
-                object_ids,
-            )
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.error(
-                'Could not index %d course(s) in Algolia\'s %s index: %s',
-                len(algolia_objects),
-                index_name,
-                exc,
-            )
-    else:
+    if not courses:
         logger.error(
             'No courses retrieved from course-discovery for content keys: %s',
             content_keys,
         )
+        return
+
+    # Get related enterprise_catalog_uuids and enterprise_customer_uuids for the provided content_keys
+    related_enterprise_catalogs = get_related_enterprise_catalogs_for_content_keys(content_keys)
+
+    for content_key, uuids in related_enterprise_catalogs.items():
+        # add those enterprise-specific uuids to the appropriate course object within the list of courses
+        course_index = find_index_in_courses_for_content_key(content_key, courses)
+        if course_index is not None:
+            course = copy.deepcopy(courses[course_index])
+            course.update({
+                'objectID': get_algolia_object_id(course['uuid']),
+                'enterprise_catalog_uuids': uuids.get('enterprise_catalog_uuids', []),
+                'enterprise_customer_uuids': uuids.get('enterprise_customer_uuids', []),
+            })
+            courses[course_index] = course
+        else:
+            logger.error(
+                'Could not find content_key "%s" in list of %d courses.',
+                content_key,
+                len(content_keys),
+            )
+
+    # extract out only the fields we care about and send to Algolia index
+    algolia_objects = create_algolia_objects_from_courses(courses, algolia_fields)
+    algolia_client.partial_update_algolia_index(algolia_objects)
 
 
-@shared_task(bind=True)
-# pylint: disable=unused-argument
-def update_catalog_metadata_task(self, catalog_query_id):
+@shared_task
+def update_catalog_metadata_task(catalog_query_id):
     update_contentmetadata_from_discovery(catalog_query_id)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -80,7 +80,7 @@ def index_enterprise_catalog_courses_in_algolia(content_keys, algolia_fields):
 
     # extract out only the fields we care about and send to Algolia index
     algolia_objects = create_algolia_objects_from_courses(courses, algolia_fields)
-    algolia_client.partial_update_algolia_index(algolia_objects)
+    algolia_client.partially_update_index(algolia_objects)
 
 
 @shared_task

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -16,5 +16,5 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
 
     @mock.patch('enterprise_catalog.apps.api.tasks.update_contentmetadata_from_discovery')
     def test_refresh_metadata(self, update_contentmetadata_from_discovery_mock):
-        tasks.update_catalog_metadata_task(self.catalog_query.id)  # pylint: disable=no-value-for-parameter
+        tasks.update_catalog_metadata_task(self.catalog_query.id)
         update_contentmetadata_from_discovery_mock.assert_called_with(self.catalog_query.id)

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -134,7 +134,7 @@ def get_course_language(course_runs):
 
 def get_course_availability(course_runs):
     """
-    Gets the availability for a course.
+    Gets the availability for a course. Used for adding the "Availability" facet for courses in Algolia.
 
     Arguments:
         course_runs (list): list of course runs for a course
@@ -170,18 +170,19 @@ def get_algolia_object_from_course(course, algolia_fields):
     Returns:
         dict: a dictionary containing only the fields noted in algolia_fields
     """
-    course = copy.deepcopy(course)
-    published_course_runs = list(
-        filter(lambda d: d['status'].lower() == 'published', course.get('course_runs', []))
-    )
-    course.update({
+    searchable_course = copy.deepcopy(course)
+    published_course_runs = [
+        course_run for course_run in searchable_course.get('course_runs', [])
+        if course_run['status'].lower() == 'published'
+    ]
+    searchable_course.update({
         'language': get_course_language(published_course_runs),
         'availability': get_course_availability(published_course_runs),
     })
 
     algolia_object = {}
     for field in algolia_fields:
-        algolia_object[field] = course.get(field)
+        algolia_object[field] = searchable_course.get(field)
 
     return algolia_object
 

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -1,4 +1,8 @@
+import logging
+
+from algoliasearch.search_client import SearchClient
 from django.utils.text import slugify
+from langcodes import Language
 from six.moves.urllib.parse import (
     parse_qs,
     quote_plus,
@@ -7,6 +11,9 @@ from six.moves.urllib.parse import (
     urlsplit,
     urlunsplit,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def unquote_course_keys(course_keys):
@@ -59,7 +66,7 @@ def is_any_course_run_enrollable(course_runs):
     Iterates over all course runs to check if there any course run that is available for enrollment.
 
     Arguments:
-            course_runs (list): list of course runs
+        course_runs (list): list of course runs
 
     Returns:
         bool: True if enrollable course run is found, else False
@@ -68,3 +75,178 @@ def is_any_course_run_enrollable(course_runs):
         if course_run.get('is_enrollable'):
             return True
     return False
+
+
+def initialize_algolia_index(index_name, app_id, api_key):
+    """
+    Creates an Algolia client and initializes an index with the given name.
+
+    Initializing an index will create it if it does not yet exist.
+
+    Arguments:
+        index_name (str): name of the Algolia index
+        app_id (str): APPLICATION_ID to connect to Algolia
+        api_key (str): API_KEY to connect to Algolia
+
+    Returns:
+        dict: an Algolia index or None if we cannot initialize an Algolia index
+    """
+    if not index_name:
+        logger.error('Could not initialize Algolia index due to missing index name.')
+        # can't do much without an index_name, so return None
+        return None
+
+    algolia_client = None
+    if app_id and api_key:
+        algolia_client = SearchClient.create(app_id, api_key)
+        if algolia_client:
+            return algolia_client.init_index(index_name)
+
+    logger.error(
+        'Could not initialize Algolia\'s %s index due to missing Algolia settings: %s',
+        index_name,
+        ['APPLICATION_ID', 'API_KEY'],
+    )
+    return None
+
+
+def get_algolia_object_id(uuid):
+    """
+    Given a uuid, returns an object_id to use for Algolia indexing.
+
+    Arguments:
+        uuid (str): a course uuid
+
+    Returns:
+        str: the generated Algolia object_id
+    """
+    object_id = 'course-{}'.format(uuid)
+    return object_id
+
+
+def add_uuids_to_courses(content_key, uuids, courses):
+    """
+    Adds associated enterprise_catalog_uuids and enterprise_customer_uuids to a course.
+
+    Arguments:
+        content_key (str): content_key of a course that we want to add uuids for
+        uuids (dict): a dictionary containing both enterprise_catalog_uuids and enterprise_customer_uuids
+        courses (list): a list of courses
+
+    Returns:
+        list: a list of courses with the uuids added on to the appropriate course
+    """
+    # find index in courses where course key matches content_key
+    course_index = next(
+        (index for (index, d) in enumerate(courses) if d['key'] == content_key),
+        None
+    )
+    if course_index is not None:
+        course = courses[course_index].copy()
+        course.update({
+            'objectID': get_algolia_object_id(course['uuid']),
+            'enterprise_catalog_uuids': uuids.get('enterprise_catalog_uuids', []),
+            'enterprise_customer_uuids': uuids.get('enterprise_customer_uuids', []),
+        })
+        courses[course_index] = course
+    else:
+        logger.error(
+            'Could not find course with content key %s from course-discovery discovery',
+            content_key,
+        )
+
+    return courses
+
+
+def get_course_language(course_runs):
+    """
+    Gets the languages associated with a course.
+
+    Arguments:
+        course_runs (list): list of course runs for a course
+
+    Returns:
+        list: a list of supported languages for those course runs
+    """
+    languages = set()
+
+    for course_run in course_runs:
+        content_language = course_run.get('content_language')
+        if not content_language:
+            continue
+        language_name = Language.make(language=content_language).language_name()
+        languages.add(language_name)
+
+    return list(languages)
+
+
+def get_course_availability(course_runs):
+    """
+    Gets the availability for a course.
+
+    Arguments:
+        course_runs (list): list of course runs for a course
+
+    Returns:
+        list: a list of availabilities for those course runs (e.g., "Upcoming")
+    """
+    availability = set()
+
+    for course_run in course_runs:
+        run_availability = course_run.get('availability', '').lower()
+        if run_availability == 'current':
+            availability.add('Available now')
+        elif run_availability == 'upcoming':
+            availability.add('Upcoming')
+        else:
+            availability.add('Archived')
+
+    return list(availability)
+
+
+def get_algolia_object_from_course(course, algolia_fields):
+    """
+    Transforms a course into an Algolia object.
+
+    Arguments:
+        course (dict): a course dict
+        algolia_fields (list): list of fields to extract from the course
+
+    Returns:
+        dict: a dictionary containing only the fields noted in algolia_fields
+    """
+    course = course.copy()
+    published_course_runs = list(
+        filter(lambda d: d['status'].lower() == 'published', course.get('course_runs', []))
+    )
+    course.update({
+        'language': get_course_language(published_course_runs),
+        'availability': get_course_availability(published_course_runs),
+    })
+
+    algolia_object = {}
+    for field in algolia_fields:
+        algolia_object[field] = course.get(field)
+
+    return algolia_object
+
+
+def create_algolia_objects_from_courses(courses, algolia_fields):
+    """
+    Transforms all courses into Algolia objects.
+
+    Arguments:
+        courses (list): list of courses
+        algolia_fields (list): list of fields to extract from courses
+
+    Returns:
+        list: a list of Algolia objects containing only the fields noted in algolia_fields
+    """
+    if not algolia_fields:
+        algolia_fields = []
+
+    algolia_objects = []
+    for course in courses:
+        algolia_objects.append(get_algolia_object_from_course(course, algolia_fields))
+
+    return algolia_objects

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -159,7 +159,7 @@ def get_course_availability(course_runs):
     return list(availability)
 
 
-def get_algolia_object_from_course(course, algolia_fields):
+def _algolia_object_from_course(course, algolia_fields):
     """
     Transforms a course into an Algolia object.
 
@@ -201,9 +201,9 @@ def create_algolia_objects_from_courses(courses, algolia_fields):
     if not algolia_fields:
         algolia_fields = []
 
-    algolia_objects = list()
-    for course in courses:
-        algolia_object = get_algolia_object_from_course(course, algolia_fields)
-        algolia_objects.append(algolia_object)
+    algolia_objects = [
+        _algolia_object_from_course(course, algolia_fields)
+        for course in courses
+    ]
 
     return algolia_objects

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -112,7 +112,7 @@ def find_index_in_courses_for_content_key(content_key, courses):
 
 def get_course_language(course_runs):
     """
-    Gets the languages associated with a course.
+    Gets the languages associated with a course. Used for the "Language" facet in Algolia.
 
     Arguments:
         course_runs (list): list of course runs for a course
@@ -134,7 +134,7 @@ def get_course_language(course_runs):
 
 def get_course_availability(course_runs):
     """
-    Gets the availability for a course. Used for adding the "Availability" facet for courses in Algolia.
+    Gets the availability for a course. Used for the "Availability" facet in Algolia.
 
     Arguments:
         course_runs (list): list of course runs for a course

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -22,7 +22,7 @@ class AlgoliaSearchClient:
     ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME')
 
     def __init__(self):
-        self.client = None
+        self._client = None
         self.algolia_index = None
 
     def init_index(self):
@@ -45,10 +45,10 @@ class AlgoliaSearchClient:
             )
             return
 
-        self.client = SearchClient.create(self.ALGOLIA_APPLICATION_ID, self.ALGOLIA_API_KEY)
+        self._client = SearchClient.create(self.ALGOLIA_APPLICATION_ID, self.ALGOLIA_API_KEY)
 
         try:
-            self.algolia_index = self.client.init_index(self.ALGOLIA_INDEX_NAME)
+            self.algolia_index = self._client.init_index(self.ALGOLIA_INDEX_NAME)
         except Exception as exc:  # pylint: disable=broad-except
             logger.error(
                 'Could not initialize %s index in Algolia: %s',
@@ -80,7 +80,7 @@ class AlgoliaSearchClient:
                 exc,
             )
 
-    def partial_update_algolia_index(self, algolia_objects):
+    def partially_update_index(self, algolia_objects):
         """
         Performs a partial update of the Algolia index with the specified data.
 

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""
+Algolia api client code.
+"""
+
+import logging
+
+from algoliasearch.search_client import SearchClient
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class AlgoliaSearchClient:
+    """
+    Object builds an API client to make calls to an Algolia index.
+    """
+
+    ALGOLIA_APPLICATION_ID = settings.ALGOLIA.get('APPLICATION_ID')
+    ALGOLIA_API_KEY = settings.ALGOLIA.get('API_KEY')
+    ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME')
+
+    def __init__(self):
+        self.client = None
+        self.algolia_index = None
+
+    def init_index(self):
+        """
+        Initializes an index within Algolia with the specified name. Initializing an
+        index will create it if it does not yet exist.
+
+        Returns:
+            dict: an Algolia index or None if we cannot initialize an Algolia index
+        """
+        if not self.ALGOLIA_INDEX_NAME:
+            logger.error('Could not initialize Algolia index due to missing index name.')
+            return
+
+        if not self.ALGOLIA_APPLICATION_ID or not self.ALGOLIA_API_KEY:
+            logger.error(
+                'Could not initialize Algolia\'s %s index due to missing Algolia settings: %s',
+                self.ALGOLIA_INDEX_NAME,
+                ['APPLICATION_ID', 'API_KEY'],
+            )
+            return
+
+        self.client = SearchClient.create(self.ALGOLIA_APPLICATION_ID, self.ALGOLIA_API_KEY)
+
+        try:
+            self.algolia_index = self.client.init_index(self.ALGOLIA_INDEX_NAME)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                'Could not initialize %s index in Algolia: %s',
+                self.ALGOLIA_INDEX_NAME,
+                exc,
+            )
+            self.algolia_index = None
+
+    def set_index_settings(self, index_settings):
+        """
+        Set default settings to use for the Algolia index.
+
+        Note: This will override manual updates to the index configuration on the
+        Algolia dashboard but ensures consistent settings (configuration as code).
+
+        Arguments:
+            settings (dict): A dictionary of Algolia settings.
+        """
+        if not self.algolia_index:
+            logger.error('Algolia index does not exist. Did you initialize it?')
+            return
+
+        try:
+            self.algolia_index.set_settings(index_settings)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                'Unable to set settings for Algolia\'s %s index: %s',
+                self.ALGOLIA_INDEX_NAME,
+                exc,
+            )
+
+    def partial_update_algolia_index(self, algolia_objects):
+        """
+        Performs a partial update of the Algolia index with the specified data.
+
+        If an object with the same `objectID` already exists in Algolia, it will be
+        updated. If Algolia is unaware of an object, a new one will be created.
+
+        Arguments:
+            algolia_objects (list): A list of payload objects to index into Algolia
+        """
+        if not self.algolia_index:
+            logger.error('Algolia index does not exist. Did you initialize it?')
+            return
+
+        try:
+            # Add algolia_objects to the Algolia index
+            response = self.algolia_index.partial_update_objects(algolia_objects, {
+                'createIfNotExists': True,
+            })
+            object_ids = []
+            for response in response.raw_responses:
+                object_ids += response.get('objectIDs', [])
+                logger.info(
+                    'Successfully indexed %d (%d unique) courses in Algolia\'s %s index: %s',
+                    len(object_ids),
+                    len(set(object_ids)),
+                    self.ALGOLIA_INDEX_NAME,
+                    object_ids,
+                )
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                'Could not index %d course(s) in Algolia\'s %s index: %s',
+                len(algolia_objects),
+                self.ALGOLIA_INDEX_NAME,
+                exc,
+            )

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -98,30 +98,20 @@ class DiscoveryApiClient:
         Returns:
             list: a list of the results, or None if there was an error calling the discovery service.
         """
-        if query_params is None:
-            query_params = {}
-
-        query_params.update({
-            **query_params,
-        })
+        request_params = {}
+        request_params.update(query_params or {})
 
         results = []
         offset = 0
         try:
-            response = self.client.get(
-                self.COURSES_ENDPOINT,
-                params=query_params,
-            ).json()
+            response = self.client.get(self.COURSES_ENDPOINT, params=request_params).json()
             results += response.get('results', [])
 
             # Traverse all results and concatenate results together
             while response.get('next'):
                 offset += OFFSET_SIZE
                 query_params.update({'offset': offset})
-                response = self.client.get(
-                    self.COURSES_ENDPOINT,
-                    params=query_params,
-                ).json()
+                response = self.client.get(self.COURSES_ENDPOINT, params=request_params).json()
                 results += response.get('results', [])
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.error(

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -8,18 +8,19 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from edx_rest_api_client.client import OAuthAPIClient
-from simplejson import JSONDecodeError
 
 
 LOGGER = logging.getLogger(__name__)
+
+OFFSET_SIZE = 100
 
 
 class DiscoveryApiClient:
     """
     Object builds an API client to make calls to the Discovery Service.
     """
-    SEARCH_ALL_EXTENSION = 'search/all/'
-    SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, SEARCH_ALL_EXTENSION)
+    SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
+    COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
 
     def __init__(self):
         self.client = OAuthAPIClient(
@@ -40,13 +41,14 @@ class DiscoveryApiClient:
         """
         Return results from the discovery service's search/all endpoint.
 
-        content_filter_query (dict): some elasticsearch filter
-            e.g. - {'aggregation_key': 'course-v1:some+key+here'}
-        query_params (dict): additional query params for the rest api endpoint
-             we're hitting. e.g. - {'page': 3}
+        Arguments:
+            content_filter_query (dict): some elasticsearch filter
+                e.g. - {'aggregation_key': 'course-v1:some+key+here'}
+            query_params (dict): additional query params for the rest api endpoint
+                we're hitting. e.g. - {'page': 3}
 
-        Returns a list of the results, or `None` if there was an error calling the
-        discovery service.
+        Returns:
+            list: a list of the results, or None if there was an error calling the discovery service.
         """
         if query_params is None:
             query_params = {}
@@ -71,7 +73,7 @@ class DiscoveryApiClient:
                     params=query_params
                 ).json()
                 results += response.get('results', [])
-        except JSONDecodeError as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             LOGGER.error(
                 'Could not retrieve content items from course-discovery (page %s) for catalog query %s: %s',
                 page,
@@ -80,6 +82,56 @@ class DiscoveryApiClient:
             )
             # if a request to discovery fails, return `None` so that callers of this
             # method are aware we weren't able to get all metadata for the given query
+            return None
+
+        return results
+
+    def get_courses(self, query_params=None):
+        """
+        Return results from the discovery service's /courses endpoint.
+
+        Arguments:
+            course_keys (list): list of course keys
+            query_params (dict): additional query params for the rest api endpoint
+                we're hitting. e.g. - {'limit': 100}
+
+        Returns:
+            list: a list of the results, or None if there was an error calling the discovery service.
+        """
+        if query_params is None:
+            query_params = {}
+
+        query_params.update({
+            **query_params,
+        })
+
+        results = []
+        offset = 0
+        try:
+            response = self.client.get(
+                self.COURSES_ENDPOINT,
+                params=query_params,
+            ).json()
+            results += response.get('results', [])
+
+            # Traverse all results and concatenate results together
+            while response.get('next'):
+                offset += OFFSET_SIZE
+                query_params.update({'offset': offset})
+                response = self.client.get(
+                    self.COURSES_ENDPOINT,
+                    params=query_params,
+                ).json()
+                results += response.get('results', [])
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.error(
+                'Could not get courses from course-discovery (offset %d) for query_params %s: %s',
+                offset,
+                query_params,
+                exc,
+            )
+            # if a request to discovery fails, return `None` so that callers of this
+            # method are aware we weren't able to get all the courses
             return None
 
         return results

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -1,0 +1,164 @@
+import json
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from enterprise_catalog.apps.api.tasks import (
+    index_enterprise_catalog_courses_in_algolia,
+)
+from enterprise_catalog.apps.api.v1.utils import initialize_algolia_index
+from enterprise_catalog.apps.catalog.constants import COURSE
+from enterprise_catalog.apps.catalog.models import (
+    CatalogQuery,
+    ContentMetadata,
+    EnterpriseCatalog,
+)
+
+
+logger = logging.getLogger(__name__)
+
+ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME')
+ALGOLIA_APPLICATION_ID = settings.ALGOLIA.get('APPLICATION_ID')
+ALGOLIA_API_KEY = settings.ALGOLIA.get('API_KEY')
+
+# keep attributes from course objects that we explicitly want in Algolia
+ALGOLIA_FIELDS = [
+    'availability',
+    'additional_information',
+    'card_image_url',
+    'enterprise_catalog_uuids',
+    'enterprise_customer_uuids',
+    'entitlements',
+    'expected_learning_items',
+    'extra_description',
+    'faq',
+    'full_description',
+    'key',  # for links to course about pages from the Learner Portal search page
+    'language',
+    'level_type',
+    'objectID',  # required by Algolia, e.g. "course-{uuid}"
+    'outcome',
+    'owners',
+    'programs',
+    'recent_enrollment_count',
+    'short_description',
+    'subjects',
+    'syllabus_raw',
+    'title',
+    'uuid',
+]
+
+# default configuration for the index
+ALGOLIA_INDEX_SETTINGS = {
+    'searchableAttributes': [
+        'unordered(title)',
+        'unordered(full_description)',
+        'unordered(short_description)',
+        'unordered(additional_information)',
+        'owners.name',
+    ],
+    'attributesForFaceting': [
+        'enterprise_catalog_uuids',
+        'enterprise_customer_uuids',
+        'availability',
+        'language',
+        'level_type',
+        'owners.name',
+        'programs.type',
+        'subjects.name',
+    ],
+    'unretrievableAttributes': [
+        'enterprise_catalog_uuids',
+        'enterprise_customer_uuids',
+    ],
+    'customRanking': [
+        'desc(recent_enrollment_count)',
+    ],
+}
+
+
+class Command(BaseCommand):
+    help = (
+        'Reindex course data in Algolia from course-discovery, adding on enterprise-specific metadata'
+    )
+
+    def batch(self, iterable, batch_size=1):
+        """
+        Break up an iterable into equal-sized batches.
+
+        Arguments:
+            iterable (e.g. list): an iterable to batch
+            batch_size (int): the size of each batch. Defaults to 1.
+
+        Returns:
+            generator: iterates through each batch of an iterable
+        """
+        iterable_len = len(iterable)
+        for index in range(0, iterable_len, batch_size):
+            yield iterable[index:min(index + batch_size, iterable_len)]
+
+    def set_algolia_index_settings(self):
+        """
+        Sets the settings for the Algolia index.
+        """
+        algolia_index = initialize_algolia_index(
+            index_name=ALGOLIA_INDEX_NAME,
+            app_id=ALGOLIA_APPLICATION_ID,
+            api_key=ALGOLIA_API_KEY,
+        )
+        if not algolia_index:
+            # without an Algolia index, we can't really do much here so exit early
+            return
+
+        try:
+            algolia_index.set_settings(ALGOLIA_INDEX_SETTINGS)
+        except Exception as exc:
+            logger.error(
+                'Unable to set settings for Algolia\'s %s index: %s',
+                index_name,
+                exc,
+            )
+
+    def handle(self, *args, **options):
+        """
+        Spin off tasks to fetch courses from the discovery service and index them in Algolia.
+        """
+        # find all ContentMetadata records with a content type of "course" that are
+        # also part of at least one EnterpriseCatalog
+        content_metadata = ContentMetadata.objects.filter(
+            content_type=COURSE,
+            catalog_queries__enterprise_catalogs__isnull=False,
+        ).distinct()
+
+        if not content_metadata:
+            message = (
+                'There are no ContentMetadata records of content type "%s" that are '
+                'part of at least one EnterpriseCatalog.'
+            )
+            logger.error(message, COURSE)
+            # we can't do much without content_metadata so return early
+            return
+
+        content_keys = [metadata.content_key for metadata in content_metadata]
+
+        # set default settings to use for the index. note: this will override manual updates
+        # to the index configuration on the Algolia dashboard but ensures consistent settings.
+        self.set_algolia_index_settings()
+
+        # break up the content_keys in smaller batches, where each batch will spin off its
+        # own celery task. this should help performance and prevent errors with having too
+        # many content_keys for a GET request to the discovery service's /courses endpoint
+        for keys in self.batch(content_keys, batch_size=250):
+            index_enterprise_catalog_courses_in_algolia.delay(
+                content_keys=keys,
+                index_name=ALGOLIA_INDEX_NAME,
+                app_id=ALGOLIA_APPLICATION_ID,
+                api_key=ALGOLIA_API_KEY,
+                algolia_fields=ALGOLIA_FIELDS,
+            )
+            message = (
+                'Spinning off index_enterprise_catalog_courses_in_algolia from reindex_algolia command'
+                ' to add %d courses to Algolia\'s %s index: %s'
+            )
+            logger.info(message, len(content_keys), ALGOLIA_INDEX_NAME, keys)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -312,8 +312,7 @@ def get_related_enterprise_catalogs_for_content_keys(content_keys):
 
     content_metadata = ContentMetadata.objects.filter(content_key__in=content_keys)
 
-    catalog_queries = CatalogQuery.objects.prefetch_related('contentmetadata_set')
-    catalog_queries = catalog_queries.prefetch_related('enterprise_catalogs')
+    catalog_queries = CatalogQuery.objects.prefetch_related('contentmetadata_set', 'enterprise_catalogs')
     catalog_queries = catalog_queries.filter(contentmetadata__in=content_metadata)
 
     for query in catalog_queries.all():

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -320,8 +320,16 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
+# URLs
 LMS_BASE_URL = os.environ.get('LMS_BASE_URL', '')
 DISCOVERY_SERVICE_API_URL = os.environ.get('DISCOVERY_SERVICE_API_URL', '')
+
+# Algolia
+ALGOLIA = {
+    'INDEX_NAME': '',
+    'APPLICATION_ID': '',
+    'API_KEY': '',
+}
 
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -27,3 +27,4 @@ rules
 zipp<2.0
 algoliasearch
 langcodes
+edx-celeryutils

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,3 +25,5 @@ celery==3.1.26.post2
 redis==2.8
 rules
 zipp<2.0
+algoliasearch
+langcodes

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+algoliasearch==2.3.0      # via -r requirements/base.in
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
@@ -20,13 +21,13 @@ django-model-utils==4.0.0  # via -r requirements/base.in, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.10.0  # via -r requirements/base.in
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.2.2   # via edx-drf-extensions
+edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.in
@@ -37,9 +38,11 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==3.0.37             # via celery
+langcodes==2.0.0          # via -r requirements/base.in
+marisa-trie==0.7.5        # via langcodes
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
-newrelic==5.12.1.141      # via edx-django-utils
+newrelic==5.14.0.142      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
@@ -54,7 +57,7 @@ pytz==2020.1              # via -r requirements/base.in, celery, django
 pyyaml==5.3.1             # via edx-django-release-util
 redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.23.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,8 @@ algoliasearch==2.3.0      # via -r requirements/base.in
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-celery==3.1.26.post2      # via -r requirements/base.in
-certifi==2020.4.5.1       # via requests
+celery==3.1.26.post2      # via -r requirements/base.in, edx-celeryutils
+certifi==2020.4.5.2       # via requests
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -17,26 +17,27 @@ defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-
 django-cors-headers==3.3.0  # via -r requirements/base.in
 django-crum==0.7.6        # via -r requirements/base.in, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.in
-django-model-utils==4.0.0  # via -r requirements/base.in, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.10.0  # via -r requirements/base.in
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
+edx-celeryutils==0.5.0    # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
-future==0.18.2            # via pyjwkest
+future==0.18.2            # via edx-celeryutils, pyjwkest
 idna==2.9                 # via requests
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
-jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 kombu==3.0.37             # via celery
 langcodes==2.0.0          # via -r requirements/base.in
 marisa-trie==0.7.5        # via langcodes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,8 +12,8 @@ astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/tes
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 autopep8==1.5.3           # via django-silk
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt
-certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/test.txt, requests
+celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
+certifi==2020.4.5.2       # via -r requirements/quality.txt, -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
@@ -30,16 +30,17 @@ django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/tes
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
-django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-silk==4.0.1        # via -r requirements/dev.in
 django-simple-history==2.10.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, django-silk, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, django-silk, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-celeryutils==0.5.0    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.2.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
@@ -51,7 +52,7 @@ edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/t
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
+future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
 gprof2dot==2019.11.30     # via django-silk
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
 importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
@@ -61,7 +62,7 @@ isort==4.3.21             # via -r requirements/quality.txt, -r requirements/tes
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, django-silk, jinja2-pluralize
-jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
+jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/quality.txt, -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
@@ -79,7 +80,7 @@ path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
-pip-tools==5.2.0          # via -r requirements/pip-tools.txt
+pip-tools==5.2.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
@@ -125,7 +126,7 @@ typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/tes
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
 virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.2.3            # via -r requirements/test.txt, pytest
+wcwidth==0.2.4            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+algoliasearch==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt
 amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
@@ -22,7 +23,7 @@ coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/tes
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
-diff-cover==2.6.1         # via -r requirements/dev.in
+diff-cover==3.0.1         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.3.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
@@ -34,13 +35,13 @@ django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/t
 django-silk==4.0.1        # via -r requirements/dev.in
 django-simple-history==2.10.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, django-silk, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, django-silk, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.2.2   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.2.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
@@ -53,7 +54,7 @@ filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 gprof2dot==2019.11.30     # via django-silk
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
@@ -62,13 +63,15 @@ jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, django-silk, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
+langcodes==2.0.0          # via -r requirements/quality.txt, -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
+marisa-trie==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.12.1.141      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
@@ -95,7 +98,7 @@ pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/tes
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, django-silk, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
@@ -103,7 +106,7 @@ pytz==2020.1              # via -r requirements/quality.txt, -r requirements/tes
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, django-silk, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, django-silk, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -117,12 +120,12 @@ sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/tes
 stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, autopep8, tox
-tox==3.15.1               # via -r requirements/test.txt
+tox==3.15.2               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
 virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.2.2            # via -r requirements/test.txt, pytest
+wcwidth==0.2.3            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.12            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,6 +5,7 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
+algoliasearch==2.3.0      # via -r requirements/test.txt
 amqp==1.4.9               # via -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
@@ -33,7 +34,7 @@ django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.10.0  # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
@@ -41,7 +42,7 @@ docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sp
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.2.2   # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.2.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.txt
 edx-opaque-keys==2.1.0    # via -r requirements/test.txt, edx-drf-extensions
@@ -54,20 +55,22 @@ filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jsonfield2==3.0.3         # via -r requirements/test.txt
 kombu==3.0.37             # via -r requirements/test.txt, celery
+langcodes==2.0.0          # via -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
+marisa-trie==0.7.5        # via -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
-newrelic==5.12.1.141      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
@@ -88,7 +91,7 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
@@ -97,9 +100,9 @@ pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-
 readme-renderer==26.0     # via -r requirements/doc.in
 redis==2.8                # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.23.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
+requests==2.23.0          # via -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
-restructuredtext-lint==1.3.0  # via doc8
+restructuredtext-lint==1.3.1  # via doc8
 rules==2.2                # via -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
@@ -119,12 +122,12 @@ sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.15.1               # via -r requirements/test.txt
+tox==3.15.2               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.2.2            # via -r requirements/test.txt, pytest
+wcwidth==0.2.3            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,8 +14,8 @@ attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-celery==3.1.26.post2      # via -r requirements/test.txt
-certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+celery==3.1.26.post2      # via -r requirements/test.txt, edx-celeryutils
+certifi==2020.4.5.2       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
@@ -30,17 +30,18 @@ django-cors-headers==3.3.0  # via -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/test.txt
-django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.10.0  # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
+edx-celeryutils==0.5.0    # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.2.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/test.txt, edx-rbac
@@ -52,7 +53,7 @@ edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-future==0.18.2            # via -r requirements/test.txt, pyjwkest
+future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
@@ -60,7 +61,7 @@ importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
-jsonfield2==3.0.3         # via -r requirements/test.txt
+jsonfield2==3.0.3         # via -r requirements/test.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
@@ -111,7 +112,7 @@ slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.0.4             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.1.0             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -127,7 +128,7 @@ typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.2.3            # via -r requirements/test.txt, pytest
+wcwidth==0.2.4            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.0          # via -r requirements/pip-tools.in
+pip-tools==5.2.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+algoliasearch==2.3.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
@@ -20,29 +21,31 @@ django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-gevent==20.5.2            # via -r requirements/production.in
-greenlet==0.4.15          # via gevent
+gevent==20.6.0            # via -r requirements/production.in
+greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
+langcodes==2.0.0          # via -r requirements/base.txt
+marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
@@ -58,7 +61,7 @@ pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,8 +8,8 @@ algoliasearch==2.3.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt
-certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
+certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
@@ -17,29 +17,30 @@ defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xm
 django-cors-headers==3.3.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-celeryutils==0.5.0    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, pyjwkest
+future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 gevent==20.6.0            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt
+jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,8 +9,8 @@ amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt
-certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
+certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
@@ -20,15 +20,16 @@ defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xm
 django-cors-headers==3.3.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-celeryutils==0.5.0    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
@@ -36,12 +37,12 @@ edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.2.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, pyjwkest
+future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt
+jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+algoliasearch==2.3.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
@@ -23,13 +24,13 @@ django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
@@ -42,11 +43,13 @@ itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
+langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
+marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
@@ -67,7 +70,7 @@ pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,8 +11,8 @@ appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt
-certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
+certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
@@ -27,7 +27,7 @@ django-cors-headers==3.3.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
 django-extensions==2.2.9  # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
@@ -35,6 +35,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-celeryutils==0.5.0    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
@@ -45,14 +46,14 @@ edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
-future==0.18.2            # via -r requirements/base.txt, pyjwkest
+future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
 importlib-metadata==1.6.1  # via importlib-resources, pluggy, pytest, tox, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
-jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
@@ -108,6 +109,6 @@ typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, requests
 virtualenv==20.0.21       # via tox
-wcwidth==0.2.3            # via pytest
+wcwidth==0.2.4            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+algoliasearch==2.3.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 appdirs==1.4.4            # via virtualenv
@@ -35,7 +36,7 @@ djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
@@ -46,20 +47,22 @@ faker==4.1.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.6.1  # via importlib-resources, pluggy, pytest, tox, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
+langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
+marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.3.0     # via pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest, tox
@@ -79,7 +82,7 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.9.0         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.2             # via pytest-cov, pytest-django
+pytest==5.4.3             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
@@ -87,7 +90,7 @@ pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
 redis==2.8                # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
@@ -100,11 +103,11 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.1              # via tox
-tox==3.15.1               # via -r requirements/test.in
+tox==3.15.2               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, requests
 virtualenv==20.0.21       # via tox
-wcwidth==0.2.2            # via pytest
+wcwidth==0.2.3            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-metadata==1.6.1  # via importlib-resources, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -16,6 +16,6 @@ pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/tox.in
-tox==3.15.1               # via -r requirements/tox.in, tox-battery
+tox==3.15.2               # via -r requirements/tox.in, tox-battery
 virtualenv==20.0.21       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description

This PR indexes course data in our own `enterprise_catalog` index within Algolia, a hosted a search provider. By indexing data using this approach, we don't need to rely on the implementation within course-discovery. One tradeoff with this approach, however, is that we need to calculate some Algolia fields ourselves, e.g. 'availability', 'language'. However, this means that we have full control over what gets included in our Algolia index.

A new management command `reindex_algolia` was created to spin off Celery tasks to traverse course-discovery's `/api/v1/courses/` endpoint for all content keys that are used by at least one EnterpriseCatalog. We add a few additionals fields (e.g., `enterprise_catalog_uuids`, `enterprise_customer_uuids`) to each course and then extract out all the necessary course fields for Algolia to search against, filter, and/or display in the UI.

---

When performing searches from the search page within the Learner Portal, we can use one of two approaches to filter content for a given Enterprise:
1. Use a "hidden" facet for `enterprise_catalog_uuids` to return only content that is contained by one or more specific EnterpriseCatalog(s);
2. Use a "hidden" facet for `enterprise_customer_uuids` to return only content that is contained by a specific EnterpriseCustomer.

---

How this looks in the Algolia UI:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/2828721/83949271-b93d1880-a7f0-11ea-816a-30c686c7e7fa.png">

## More information
https://docs.google.com/document/d/1MAsXS3QMpLaX49CrD3RNWvZ3-bSXGgJ6IgTHJou9Jc0/edit?usp=sharing

## Ticket Link

[ENT-2661](https://openedx.atlassian.net/browse/ENT-2661)

## Post-review

Squash commits into discrete sets of changes
