### PR TITLE
Decrease batch size to 50 to retrieve less courses from discovery

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -35,7 +35,6 @@ def index_enterprise_catalog_courses_in_algolia(content_keys, algolia_fields):
 
     query_params = {
         'keys': ','.join(content_keys),
-        'limit': 100,
         'ordering': 'key',
     }
     try:

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
         # break up the content_keys in smaller batches, where each batch will spin off its
         # own celery task. this should help performance and prevent errors with having too
         # many content_keys for a GET request to the discovery service's /courses endpoint
-        for keys in self.batch(content_keys, batch_size=250):
+        for keys in self.batch(content_keys, batch_size=50):
             index_enterprise_catalog_courses_in_algolia.delay(
                 content_keys=keys,
                 algolia_fields=ALGOLIA_FIELDS,


### PR DESCRIPTION
## Description

After the first run of the new `reindex_algolia` management command, I noticed the call to discovery was erroring due to have too many course keys in the `keys` query parameter causing a "Request line too long" error.

62 courses did manage to make their way over to Algolia, though! 🎉 

To resolve that, the batch size of how many course keys we send at a time needs to be reduced ~50.

## Ticket Link

Link to the associated ticket
[ENT-2661](https://openedx.atlassian.net/browse/ENT-2661)

## Post-review

Squash commits into discrete sets of changes
