### PR TITLE
add CELERY_RESULT_BACKEND to production.py

### DIFF
--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -59,6 +59,7 @@ BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
     CELERY_BROKER_HOSTNAME,
     CELERY_BROKER_VHOST
 )
+CELERY_RESULT_BACKEND = BROKER_URL
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value


### PR DESCRIPTION
## Description

Similar situation as removing `BROKER_URL` from production.py causing an issue when running the `update_content_metadata` job, I believe `CELERY_RESULT_BACKEND` also needs to be specified in production.py to prevent this error:

```
AttributeError: 'DisabledBackend' object has no attribute '_get_task_meta_for'non-zero return code
```

## Post-review

Squash commits into discrete sets of changes
