### PR TITLE
add batch_size kwarg to bulk update of json_metadata

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -74,7 +74,7 @@ def update_full_content_metadata_task(*args, **kwargs):  # pylint: disable=unuse
         metadata_record.json_metadata = json_metadata
         updated_metadata.append(metadata_record)
 
-    ContentMetadata.objects.bulk_update(updated_metadata, ['json_metadata'])
+    ContentMetadata.objects.bulk_update(updated_metadata, ['json_metadata'], batch_size=100)
 
     logger.info(
         'Successfully updated %d of %d ContentMetadata records with full metadata from course-discovery.',

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -155,7 +155,7 @@ def _algolia_object_from_course(course, algolia_fields):
     searchable_course = copy.deepcopy(course)
     published_course_runs = [
         course_run for course_run in searchable_course.get('course_runs', [])
-        if course_run['status'].lower() == 'published'
+        if course_run.get(['status'], '').lower() == 'published'
     ]
     searchable_course.update({
         'language': get_course_language(published_course_runs),


### PR DESCRIPTION
## Description

In a previous PR, I switched from doing individual updates thousands of time to a single bulk_update. However, I believe this is causing MySQL to timeout and throw this error:

![image](https://user-images.githubusercontent.com/2828721/84675136-d614d280-aef9-11ea-9178-b95759a2bf19.png)

In this PR, I am adding `batch_size` to bulk_update to only update 100 objects at a time. Not sure what the "correct" batch size should be here, but 100 feels reasonable.

## Post-review

Squash commits into discrete sets of changes
