### PR TITLE
further reduce batch_size

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -74,7 +74,7 @@ def update_full_content_metadata_task(*args, **kwargs):  # pylint: disable=unuse
         metadata_record.json_metadata = json_metadata
         updated_metadata.append(metadata_record)
 
-    ContentMetadata.objects.bulk_update(updated_metadata, ['json_metadata'], batch_size=100)
+    ContentMetadata.objects.bulk_update(updated_metadata, ['json_metadata'], batch_size=10)
 
     logger.info(
         'Successfully updated %d of %d ContentMetadata records with full metadata from course-discovery.',


### PR DESCRIPTION
## Description

Adding `batch_size` of 100 to the `bulk_update` operation is still causing the `django.db.utils:OperationalError: (2006, 'MySQL server has gone away')` error.

This PR further reduces the `batch_size` to 10 to hopefully get around this error.

## Post-review

Squash commits into discrete sets of changes
