### PR TITLE
Add content filter validation

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -16,6 +16,13 @@ CONTENT_TYPE_CHOICES = [
     (PROGRAM, 'Program'),
 ]
 
+# ContentFilter field types for validation.
+CONTENT_FILTER_FIELD_TYPES = {
+    'key': {'type': list, 'subtype': str},
+    'aggregation_key': {'type': list, 'subtype': str},
+    'first_enrollable_paid_seat_price__lte': {'type': str}
+}
+
 # Course mode sorting based on slug
 COURSE_MODE_SORT_ORDER = ['verified', 'professional', 'no-id-professional', 'audit', 'honor']
 

--- a/enterprise_catalog/apps/catalog/forms.py
+++ b/enterprise_catalog/apps/catalog/forms.py
@@ -6,6 +6,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from edx_rbac.admin import UserRoleAssignmentAdminForm
 
+from enterprise_catalog.apps.catalog.constants import CONTENT_FILTER_FIELD_TYPES
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     EnterpriseCatalogRoleAssignment,
@@ -22,8 +23,25 @@ class CatalogQueryForm(forms.ModelForm):
         model = CatalogQuery
         fields = ('content_filter',)
 
+    def validate_content_filter_fields(self, content_filter):
+        for key in CONTENT_FILTER_FIELD_TYPES:
+            if key in content_filter.keys():
+                if not isinstance(content_filter[key], CONTENT_FILTER_FIELD_TYPES[key]['type']):
+                    raise ValidationError(
+                        "Content filter '%s' must be of type %s" % (key, CONTENT_FILTER_FIELD_TYPES[key]['type'])
+                    )
+                if CONTENT_FILTER_FIELD_TYPES[key]['type'] == list:
+                    if not all(isinstance(x, str) for x in content_filter[key]):
+                        raise ValidationError(
+                            "Content filter '%s' must contain values of type %s" % (
+                                key, CONTENT_FILTER_FIELD_TYPES[key]['subtype']
+                            )
+                        )
+
     def clean_content_filter(self):
         content_filter = self.cleaned_data['content_filter']
+        self.validate_content_filter_fields(content_filter)
+
         content_filter_hash = get_content_filter_hash(content_filter)
         if CatalogQuery.objects.filter(content_filter_hash=content_filter_hash).exists():
             raise ValidationError('Catalog Query with this Content filter already exists.')

--- a/enterprise_catalog/apps/catalog/tests/test_forms.py
+++ b/enterprise_catalog/apps/catalog/tests/test_forms.py
@@ -1,0 +1,36 @@
+import ddt
+from django.test import TestCase
+
+from enterprise_catalog.apps.catalog.forms import CatalogQueryForm
+
+
+@ddt.ddt
+class TestCatalogQueryAdmin(TestCase):
+    @ddt.data(
+        ({'content_filter': {'key': 'coursev1:course1'}}, ["Content filter 'key' must be of type <class 'list'>"]),
+        (
+            {'content_filter': {'aggregation_key': 'courserun:course'}},
+            ["Content filter 'aggregation_key' must be of type <class 'list'>"],
+        ),
+        (
+            {'content_filter': {'first_enrollable_paid_seat_price__lte': [12]}},
+            ["Content filter 'first_enrollable_paid_seat_price__lte' must be of type <class 'str'>"]
+        ),
+        ({'content_filter': {'key': [3, 'course']}}, ["Content filter 'key' must contain values of type <class 'str'>"])
+    )
+    @ddt.unpack
+    def test_catalog_query_form_failure(self, cfdata, error):
+        form = CatalogQueryForm(data=cfdata)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['content_filter'], error)
+
+    @ddt.data(
+        ({'content_filter': {'key': ['coursev1:course1', 'coursev1:course2']}},),
+        ({'content_filter': {'aggregation_key': ['courserun:course', 'courserun:course2']}},),
+        ({'content_filter': {'first_enrollable_paid_seat_price__lte': '12'}},),
+        ({'content_filter': {'key': ['coursev1:course1'], 'first_enrollable_paid_seat_price__lte': '50'}},)
+    )
+    @ddt.unpack
+    def test_catalog_query_form_success(self, cfdata):
+        form = CatalogQueryForm(data=cfdata)
+        self.assertTrue(form.is_valid())

--- a/manage.py
+++ b/manage.py
@@ -7,6 +7,7 @@ Django administration utility.
 import os
 import sys
 
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "enterprise_catalog.settings.local")
 


### PR DESCRIPTION
## Description

The purpose of this is to add validation to sub-fields within the content filter field if those fields are present. Per ticket ENT-2828, there are currently 3 known filter fields: `key`, `aggregation_key`, and `first_enrollable_paid_seat_price__lte`. The first two should be lists of strings and the last should be a string.

I structured it in a way that it _should_ be easy to add further fields should we discover and/or add them.

## Ticket Link
[Validate the Catalog model's content_filter field](https://openedx.atlassian.net/browse/ENT-2828)

## Post-review

Squash commits into discrete sets of changes
