### PR TITLE
clean up reindex-algolia job to spin off multiple tasks instead of just one

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -100,11 +100,10 @@ def index_enterprise_catalog_courses_in_algolia_task(algolia_fields, content_key
     algolia_client.init_index()
 
     # retrieve ContentMetadata records in bulk
-    content_metadata_records = ContentMetadata.objects.in_bulk(
+    content_metadata = list(ContentMetadata.objects.in_bulk(
         content_keys,
         field_name='content_key'
-    ).values()
-    content_metadata = list(content_metadata_records)
+    ).values())
 
     courses = []
     # iterate through ContentMetadata records, retrieving the enterprise catalog uuids and

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -70,17 +70,15 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
     @mock.patch('enterprise_catalog.apps.api.tasks.AlgoliaSearchClient')
     def test_index_algolia(self, mock_search_client):
         ALGOLIA_FIELDS = ['key', 'objectID', 'enterprise_customer_uuids', 'enterprise_catalog_uuids']
-        ALGOLIA_INDEX_SETTINGS = {'searchableAttributes': []}
 
         enterprise_catalog = EnterpriseCatalogFactory()
         catalog_query = enterprise_catalog.catalog_query
         metadata = ContentMetadataFactory(content_type=COURSE, content_key='fakeX')
         metadata.catalog_queries.set([catalog_query])
 
-        tasks.index_enterprise_catalog_courses_in_algolia_task(ALGOLIA_FIELDS, ALGOLIA_INDEX_SETTINGS)
+        tasks.index_enterprise_catalog_courses_in_algolia_task(ALGOLIA_FIELDS, content_keys=['fakeX'])
 
         mock_search_client.return_value.init_index.assert_called_once_with()
-        mock_search_client.return_value.set_index_settings.assert_called_once_with(ALGOLIA_INDEX_SETTINGS)
 
         algolia_objects = []
         algolia_objects.append({

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -141,6 +141,72 @@ def get_course_availability(course_runs):
     return list(availability)
 
 
+def get_course_partners(course):
+    """
+    Gets list of partners associated with the course. Used for the "Partners" facet and
+    searchable attribute in Algolia.
+
+    Arguments:
+        course (dict): a dictionary representing a course
+
+    Returns:
+        list: a list of partners associated with the course
+    """
+    partners = set()
+    owners = course.get('owners', [])
+
+    for owner in owners:
+        partner_name = owner.get('name')
+        if partner_name:
+            partners.add(partner_name)
+
+    return list(partners)
+
+
+def get_course_program_types(course):
+    """
+    Gets list of program types associated with the course. Used for the "Programs"
+    facet in Algolia.
+
+    Arguments:
+        course (dict): a dictionary representing a course
+
+    Returns:
+        list: a list of program types associated with the course
+    """
+    program_types = set()
+    programs = course.get('programs', [])
+
+    for program in programs:
+        program_type = program.get('type')
+        if program_type:
+            program_types.add(program_type)
+
+    return list(program_types)
+
+
+def get_course_subjects(course):
+    """
+    Gets list of subject names associated with the course. Used for the "Subjects"
+    facet in Algolia.
+
+    Arguments:
+        course (dict): a dictionary representing a course
+
+    Returns:
+        list: a list of subject names associated with the course
+    """
+    subject_names = set()
+    subjects = course.get('subjects', [])
+
+    for subject in subjects:
+        subject_name = subject.get('name')
+        if subject_name:
+            subject_names.add(subject_name)
+
+    return list(subject_names)
+
+
 def _algolia_object_from_course(course, algolia_fields):
     """
     Transforms a course into an Algolia object.
@@ -160,6 +226,9 @@ def _algolia_object_from_course(course, algolia_fields):
     searchable_course.update({
         'language': get_course_language(published_course_runs),
         'availability': get_course_availability(published_course_runs),
+        'partners': get_course_partners(searchable_course),
+        'programs': get_course_program_types(searchable_course),
+        'subjects': get_course_subjects(searchable_course),
     })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -99,11 +99,9 @@ class AlgoliaSearchClient:
             for response in response.raw_responses:
                 object_ids += response.get('objectIDs', [])
                 logger.info(
-                    'Successfully indexed %d (%d unique) courses in Algolia\'s %s index: %s',
+                    'Successfully indexed %d courses in Algolia\'s %s index.',
                     len(object_ids),
-                    len(set(object_ids)),
                     self.ALGOLIA_INDEX_NAME,
-                    object_ids,
                 )
         except Exception as exc:  # pylint: disable=broad-except
             logger.error(

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -2,16 +2,54 @@ import mock
 from django.core.management import call_command
 from django.test import TestCase
 
+from enterprise_catalog.apps.catalog.constants import COURSE
+from enterprise_catalog.apps.catalog.management.commands.reindex_algolia import (
+    ALGOLIA_INDEX_SETTINGS,
+    ALGOLIA_FIELDS,
+    BATCH_SIZE,
+)
+from enterprise_catalog.apps.catalog.tests.factories import ContentMetadataFactory
+
 
 class ReindexAlgoliaCommandTests(TestCase):
     command_name = 'reindex_algolia'
 
     @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.AlgoliaSearchClient'
+    )
+    @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.index_enterprise_catalog_courses_in_algolia_task'
     )
-    def test_reindex_algolia(self, mock_task):
+    def test_reindex_algolia(self, mock_task, mock_search_client):
         """
-        Verify that the job spins off the index_enterprise_catalog_courses_in_algolia_task
+        Verify that the job spins off the correct number of index_enterprise_catalog_courses_in_algolia_task
         """
+        # create enough ContentMetadata records to force more than 1 batch of content keys
+        content_metadata = ContentMetadataFactory.create_batch(
+            BATCH_SIZE + 1,
+            content_type=COURSE,
+        )
+        content_keys = [metadata.content_key for metadata in content_metadata]
+
         call_command(self.command_name)
-        mock_task.delay.assert_called_once()
+
+        # verify Algolia index is initialized and configured
+        mock_search_client.return_value.init_index.assert_called_once()
+        mock_search_client.return_value.set_index_settings.assert_called_once_with(ALGOLIA_INDEX_SETTINGS)
+
+        # verify batching of content keys works as expected
+        expected_call_args = []
+        mock_task_calls = mock_task.delay.call_args_list
+        assert len(mock_task_calls) == 2
+
+        # verify both calls are made with correct kwargs
+        __, kwargs = mock_task_calls[0]
+        assert kwargs == {
+            'algolia_fields': ALGOLIA_FIELDS,
+            'content_keys': content_keys[:-1],
+        }
+        __, kwargs = mock_task_calls[1]
+        assert kwargs == {
+            'algolia_fields': ALGOLIA_FIELDS,
+            'content_keys': [content_keys[-1]],
+        }

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -4,11 +4,13 @@ from django.test import TestCase
 
 from enterprise_catalog.apps.catalog.constants import COURSE
 from enterprise_catalog.apps.catalog.management.commands.reindex_algolia import (
-    ALGOLIA_INDEX_SETTINGS,
     ALGOLIA_FIELDS,
+    ALGOLIA_INDEX_SETTINGS,
     BATCH_SIZE,
 )
-from enterprise_catalog.apps.catalog.tests.factories import ContentMetadataFactory
+from enterprise_catalog.apps.catalog.tests.factories import (
+    ContentMetadataFactory,
+)
 
 
 class ReindexAlgoliaCommandTests(TestCase):

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -305,39 +305,6 @@ class ContentMetadata(TimeStampedModel):
         )
 
 
-def related_enterprise_catalogs_for_content_metadata(content_metadata):
-    """
-    Get enterprise_catalog_uuids and enterprise_customer_uuids for the specified ContentMetadata records.
-
-    Arguments:
-        content_metadata (list): list of ContentMetadata records
-    """
-    related_catalogs_for_keys = {}
-
-    catalog_queries = CatalogQuery.objects.prefetch_related('contentmetadata_set', 'enterprise_catalogs')
-    catalog_queries = catalog_queries.filter(contentmetadata__in=content_metadata)
-
-    for query in catalog_queries.all():
-        enterprise_catalogs = query.enterprise_catalogs.all()
-        metadata_for_query = query.contentmetadata_set.all()
-
-        for metadata in metadata_for_query:
-            enterprise_catalog_uuids = set()
-            enterprise_customer_uuids = set()
-
-            for catalog in enterprise_catalogs:
-                enterprise_catalog_uuids.add(str(catalog.uuid))
-                enterprise_customer_uuids.add(str(catalog.enterprise_uuid))
-
-            content_key = metadata.content_key
-            related_catalogs_for_keys[content_key] = {
-                'enterprise_catalog_uuids': list(enterprise_catalog_uuids),
-                'enterprise_customer_uuids': list(enterprise_customer_uuids),
-            }
-
-    return related_catalogs_for_keys
-
-
 def content_metadata_with_type_course():
     """
     Find all ContentMetadata records with a content type of "course".


### PR DESCRIPTION
## Description

Before, the `reindex-algolia` job before was only spinning off a single task to do all the work of reindexing data into Algolia. However, this caused the task to linger for 21 minutes and spike the memory usage / CPU of the worker app instances significantly (up to nearly 5GB on the memory 😬).

Instead, I am now batching the `content_keys` of ContentMetadata records to reindex courses in chunks. I replicated all of the ContentMetadata records on stage in my local DB so that I could run the management command "at scale" locally. 

At a batch_size of 250 content_keys, the management command spins off several tasks, completing each in 15-35 seconds for a total of ~4 minutes to reindex all the courses in Algolia.

I'm also trimming down the amount of data for each course object within Algolia since while iterating through my copy of stage data, a few courses failed to be indexed due to being over the max allowable payload size from Algolia (i.e., max 10kb per object).

![image](https://user-images.githubusercontent.com/2828721/84773162-03b95480-afaa-11ea-8ed4-ffee15076f7b.png)

## Ticket Link

Link to the associated ticket
[ENT-2661](https://openedx.atlassian.net/browse/ENT-2661)

## Post-review

Squash commits into discrete sets of changes
