### PR TITLE
Consider catalog and customer associations for catalogs that only contain course runs in Algolia indexing

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -10,6 +10,7 @@ from enterprise_catalog.apps.api.v1.utils import (
 )
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
+from enterprise_catalog.apps.catalog.constants import COURSE
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     content_metadata_with_type_course,
@@ -99,31 +100,54 @@ def index_enterprise_catalog_courses_in_algolia_task(algolia_fields, content_key
     algolia_client = AlgoliaSearchClient()
     algolia_client.init_index()
 
-    # retrieve ContentMetadata records in bulk
-    content_metadata = list(ContentMetadata.objects.in_bulk(
-        content_keys,
-        field_name='content_key'
-    ).values())
-
     courses = []
-    # iterate through ContentMetadata records, retrieving the enterprise catalog uuids and
-    # enterprise customer uuids associated with each ContentMetadata record
-    for metadata_record in content_metadata:
-        enterprise_customer_uuids = set()
-        enterprise_catalog_uuids = set()
-        associated_queries = metadata_record.catalog_queries.all()
+    enterprise_uuids_for_courses = {}
+
+    # retrieve ContentMetadata records that match the specified content_keys in the
+    # content_key or parent_content_key. returns both courses and course runs.
+    query = Q(content_key__in=content_keys) | Q(parent_content_key__in=content_keys)
+    content_metadata = ContentMetadata.objects.filter(query)
+
+    # iterate through ContentMetadata records, retrieving the enterprise_catalog_uuids and
+    # enterprise_customer_uuids associated with each ContentMetadata record, storing them
+    # in a dictionary with the course's content_key as a key for later retrieval.
+    for metadata in content_metadata:
+        is_course_content_type = metadata.content_type == COURSE
+        course_content_key = metadata.content_key if is_course_content_type else metadata.parent_content_key
+        associated_queries = metadata.catalog_queries.all()
         for query in associated_queries:
             associated_catalogs = query.enterprise_catalogs.values('uuid', 'enterprise_uuid')
             for catalog in associated_catalogs:
-                enterprise_catalog_uuids.add(str(catalog['uuid']))
-                enterprise_customer_uuids.add(str(catalog['enterprise_uuid']))
+                enterprise_uuids = {}
 
+                if hasattr(enterprise_uuids_for_courses, course_content_key):
+                    enterprise_uuids = enterprise_uuids_for_courses[course_content_key]
+
+                # add to existing set of uuids, if it exists, for both catalogs and customers
+                catalog_uuids = enterprise_uuids.get('enterprise_catalog_uuids', set())
+                catalog_uuids.add(str(catalog['uuid']))
+                customer_uuids = enterprise_uuids.get('enterprise_customer_uuids', set())
+                customer_uuids.add(str(catalog['enterprise_uuid']))
+
+                # override the existing value with the newly added set of uuids
+                enterprise_uuids_for_courses[course_content_key] = {
+                    'enterprise_catalog_uuids': catalog_uuids,
+                    'enterprise_customer_uuids': customer_uuids,
+                }
+
+    # iterate through only the courses, retrieving the enterprise-related uuids from the
+    # dictionary created above, and append each course to the list of courses with the added
+    # fields (e.g., objectID, enterprise_customer_uuids).
+    course_content_metadata = content_metadata.filter(content_type=COURSE)
+    for metadata in course_content_metadata:
+        content_key = metadata.content_key
+        enterprise_uuids = enterprise_uuids_for_courses[content_key]
         # add enterprise-related uuids to json_metadata
-        json_metadata = copy.deepcopy(metadata_record.json_metadata)
+        json_metadata = copy.deepcopy(metadata.json_metadata)
         json_metadata.update({
             'objectID': get_algolia_object_id(json_metadata.get('uuid')),
-            'enterprise_catalog_uuids': list(enterprise_catalog_uuids),
-            'enterprise_customer_uuids': list(enterprise_customer_uuids),
+            'enterprise_catalog_uuids': list(enterprise_uuids['enterprise_catalog_uuids']),
+            'enterprise_customer_uuids': list(enterprise_uuids['enterprise_customer_uuids']),
         })
         courses.append(json_metadata)
 

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -1,9 +1,9 @@
 import copy
 import logging
+from collections import defaultdict
 
 from celery import shared_task
 from celery_utils.logged_task import LoggedTask
-from collections import defaultdict
 from django.db.models import Q
 
 from enterprise_catalog.apps.api.v1.utils import (
@@ -143,8 +143,8 @@ def index_enterprise_catalog_courses_in_algolia_task(algolia_fields, content_key
         json_metadata = copy.deepcopy(metadata.json_metadata)
         json_metadata.update({
             'objectID': get_algolia_object_id(json_metadata.get('uuid')),
-            'enterprise_catalog_uuids': sorted(list(catalog_uuids_by_course_key[course_content_key])),
-            'enterprise_customer_uuids': sorted(list(customer_uuids_by_course_key[course_content_key])),
+            'enterprise_catalog_uuids': sorted(list(catalog_uuids_by_course_key[content_key])),
+            'enterprise_customer_uuids': sorted(list(customer_uuids_by_course_key[content_key])),
         })
         courses.append(json_metadata)
 


### PR DESCRIPTION
## Description

Before, the `reindex-algolia` job was only retrieving the associated enterprise_catalog_uuids and enterprise_customer_uuids for catalogs/customers that explicitly have courses in their catalog(s). This means we were missing all the associations where a course's course run may be in an enterprise's catalog(s), but not the top-level course.

This PR ensures that for any given course, we account for catalogs/customers that have any of that course's course runs as part of its catalog as well before sending data to Algolia.

This now follows the [same logic as the `contains_content_items` endpoints](https://github.com/edx/enterprise-catalog/blob/9daaac7cf098c3353d0426a9c8ead0a89a851523/enterprise_catalog/apps/catalog/models.py#L196) which consider a course to be part of a catalog that contains only course runs if the course key matches any of the `parent_content_keys` of the course runs in the catalog.

**Example:**
Enterprise A has a single course in its catalog. Enterprise B has a single course run in its catalog, related to the course in Enterprise A's catalog. 

This means that for the course object we send to Algolia, it should contain both Enterprise A's and Enterprise B's catalog/customer uuids, not just Enterprise A's (like it was doing before).

## Ticket Link

[ENT-2661](https://openedx.atlassian.net/browse/ENT-2661)

## Post-review

Squash commits into discrete sets of changes
