### PR TITLE
Remove all Django Silk references and update requirements.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,41 +13,6 @@ Getting Started
 
 Check out the `initial steps <docs/getting_started.rst>`_ for getting started with the Enterprise catalog service.
 
-Using ``django-silk`` for database/performance profiling
---------------------------------------------------------
-
-``django-silk`` provides middleware to intercept/store HTTP requests and database queries for the purpose of profiling and inspection. For example,
-you may want to examine the response times, number of database queries made, and the raw SQL the Django ORM creates to make database queries.
-
-To use ``django-silk`` during local development to profile requests and database queries:
-
-#. ``make dev.up.build`` (this will install ``django-silk`` if it hasn't already been installed)
-#. ``make app-shell``
-#. ``./manage.py migrate silk`` to run ``django-silk``'s migrations.
-#. Navigate to http://localhost:18160/silk/ for the Django Silk UI.
-#. Make any request (e.g., http://localhost:18160/api/v1/enterprise-catalogs/) and check back on the Silk UI.
-#. The request you made should appear in the Django Silk UI. From here, click on the request to view its details.
-
-``django-silk`` can also be used to profile specific code blocks within a function/method through the `silk_profile` decorator and/or context manager. Example:
-
-.. code-block:: python
-
-    from silk.profiling.profiler import silk_profile
-
-    class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
-        @silk_profile(name='get_enterprise_catalog')
-        def get_enterprise_catalog(self):
-            uuid = self.kwargs.get('uuid')
-            return get_object_or_404(EnterpriseCatalog, uuid=uuid)
-
-    class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
-        def get_enterprise_catalog(self):
-            with silk_profile(name='get_enterprise_catalog'):
-                uuid = self.kwargs.get('uuid')
-                return get_object_or_404(EnterpriseCatalog, uuid=uuid)
-
-See https://github.com/jazzband/django-silk for more advanced usage.
-
 License
 -------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       CELERY_BROKER_PASSWORD: password
       DJANGO_SETTINGS_MODULE: enterprise_catalog.settings.devstack
       ENABLE_DJANGO_TOOLBAR: 1
-      ENABLE_DJANGO_SILK: 1
 
   worker:
     build:

--- a/enterprise_catalog/settings/local.py
+++ b/enterprise_catalog/settings/local.py
@@ -46,18 +46,6 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
 INTERNAL_IPS = ('127.0.0.1',)
 # END TOOLBAR CONFIGURATION
 
-# DJANGO-SILK CONFIGURATION
-# See: https://github.com/jazzband/django-silk
-if os.environ.get('ENABLE_DJANGO_SILK', False):
-    MIDDLEWARE += (
-        'silk.middleware.SilkyMiddleware',
-    )
-
-    INSTALLED_APPS += (
-        'silk',
-    )
-# END OF DJANGO-SILK CONFIGURATION
-
 # AUTHENTICATION
 # Use a non-SSL URL for authorization redirects
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -5,8 +5,6 @@ from enterprise_catalog.settings.base import *
 LMS_BASE_URL = 'https://edx.test.lms'
 DISCOVERY_SERVICE_API_URL = 'https://edx.test.discovery/'
 
-ENABLE_DJANGO_SILK = False
-
 # IN-MEMORY TEST DATABASE
 DATABASES = {
     'default': {

--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -40,6 +40,3 @@ urlpatterns = [
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
     import debug_toolbar
     urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
-
-if os.environ.get('ENABLE_DJANGO_SILK', False):  # pragma: no cover
-    urlpatterns.append(url(r'^silk/', include('silk.urls', namespace='silk')))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.3.0  # via -r requirements/base.in
+django-cors-headers==3.4.0  # via -r requirements/base.in
 django-crum==0.7.6        # via -r requirements/base.in, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
@@ -31,7 +31,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-edx-rbac==1.2.1           # via -r requirements/base.in
+edx-rbac==1.3.1           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils, pyjwkest
 idna==2.9                 # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,7 +9,7 @@
 # linking to it here is good.
 
 # Because we don't support latest version yet
-drf-jwt==1.15.1
+drf-jwt<1.15.0
 
 # jsonfield2 > 3.0.3 dropped support for python 3.5
 jsonfield2==3.0.3

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,4 +11,3 @@ django-debug-toolbar      # For debugging Django
 #transifex-client         # For managing translations
 inflect<4.0.0             # Inflect 4.0.0 requires python>=3.6
 ddt
-django-silk               # For SQL query and performance profiling

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,6 @@ anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/tes
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
-autopep8==1.5.3           # via django-silk
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
 celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.4.5.2       # via -r requirements/quality.txt, -r requirements/test.txt, requests
@@ -25,17 +24,16 @@ ddt==1.3.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 diff-cover==3.0.1         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
-django-cors-headers==3.3.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-cors-headers==3.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-silk==4.0.1        # via -r requirements/dev.in
 django-simple-history==2.10.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, django-silk, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.13            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -47,21 +45,20 @@ edx-drf-extensions==6.0.0  # via -r requirements/quality.txt, -r requirements/te
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.0    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.2.1           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-rbac==1.3.1           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.0              # via -r requirements/test.txt, factory-boy
+faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
-gprof2dot==2019.11.30     # via django-silk
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
 importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+importlib-resources==2.0.1  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, django-silk, jinja2-pluralize
+jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/quality.txt, -r requirements/test.txt
@@ -70,7 +67,7 @@ marisa-trie==0.7.5        # via -r requirements/quality.txt, -r requirements/tes
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
 newrelic==5.14.0.142      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
@@ -84,11 +81,11 @@ pip-tools==5.2.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
-pycodestyle==2.6.0        # via -r requirements/quality.txt, autopep8
+py==1.8.2                 # via -r requirements/test.txt, pytest, tox
+pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycryptodomex==3.9.7      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.txt
-pygments==2.6.1           # via diff-cover, django-silk
+pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
@@ -97,17 +94,17 @@ pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/tes
 pylint==2.4.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.9.0         # via -r requirements/test.txt
+pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, django-silk, edx-drf-extensions, faker
+python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-silk
+pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, django-silk, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -117,15 +114,15 @@ slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/tes
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar, django-silk
+sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar
 stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, autopep8, tox
+toml==0.10.1              # via -r requirements/test.txt, tox
 tox==3.15.2               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
+virtualenv==20.0.23       # via -r requirements/test.txt, tox
 wcwidth==0.2.4            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,7 +26,7 @@ coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
-django-cors-headers==3.3.0  # via -r requirements/test.txt
+django-cors-headers==3.4.0  # via -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/test.txt
@@ -47,17 +47,17 @@ edx-django-utils==3.2.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.txt
 edx-opaque-keys==2.1.0    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.2.1           # via -r requirements/test.txt
+edx-rbac==1.3.1           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.0              # via -r requirements/test.txt, factory-boy
+faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+importlib-resources==2.0.1  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
@@ -69,7 +69,7 @@ marisa-trie==0.7.5        # via -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
 newrelic==5.14.0.142      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
@@ -79,7 +79,7 @@ pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.8.2                 # via -r requirements/test.txt, pytest, tox
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
@@ -90,7 +90,7 @@ pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-
 pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.9.0         # via -r requirements/test.txt
+pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
@@ -112,7 +112,7 @@ slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.1.0             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.1.1             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -127,7 +127,7 @@ tox==3.15.2               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
+virtualenv==20.0.23       # via -r requirements/test.txt, tox
 wcwidth==0.2.4            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.3.0  # via -r requirements/base.txt
+django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
@@ -31,10 +31,10 @@ edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.2.1           # via -r requirements/base.txt
+edx-rbac==1.3.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
-gevent==20.6.0            # via -r requirements/production.in
+gevent==20.6.2            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -17,7 +17,7 @@ click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.3.0  # via -r requirements/base.txt
+django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
@@ -35,7 +35,7 @@ edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.2.1           # via -r requirements/base.txt
+edx-rbac==1.3.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,7 +23,7 @@ coverage==5.1             # via -r requirements/test.in, pytest-cov
 ddt==1.3.1                # via -c requirements/constraints.txt, -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
-django-cors-headers==3.3.0  # via -r requirements/base.txt
+django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
 django-extensions==2.2.9  # via -r requirements/base.txt
@@ -41,15 +41,15 @@ edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.2.1           # via -r requirements/base.txt
+edx-rbac==1.3.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.0              # via factory-boy
+faker==4.1.1              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.9                 # via -r requirements/base.txt, requests
 importlib-metadata==1.6.1  # via importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+importlib-resources==2.0.1  # via virtualenv
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
@@ -61,7 +61,7 @@ marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.3.0     # via pytest
+more-itertools==8.4.0     # via pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
 newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
@@ -71,7 +71,7 @@ pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
-py==1.8.1                 # via pytest, tox
+py==1.8.2                 # via pytest, tox
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
@@ -81,7 +81,7 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.9.0         # via -r requirements/test.in
+pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.3             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
@@ -108,7 +108,7 @@ tox==3.15.2               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, requests
-virtualenv==20.0.21       # via tox
+virtualenv==20.0.23       # via tox
 wcwidth==0.2.4            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -8,14 +8,14 @@ appdirs==1.4.4            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.6.1  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+importlib-resources==2.0.1  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.8.2                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/tox.in
 tox==3.15.2               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.21       # via tox
+virtualenv==20.0.23       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description

- Remove Django-silk package and all references to it.
- Run make upgrade to update all requirements files to remove this package as well as any other updates.

## Ticket Link

Link to the associated ticket
[Remove Django-Silk from Enterprise-Catalog](https://openedx.atlassian.net/browse/ENT-3048)

## Post-review

Squash commits into discrete sets of changes
