### PR TITLE
ENH: Update content_filter functionality to match edx-enterprise

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -19,7 +19,6 @@ CONTENT_TYPE_CHOICES = [
 # ContentFilter field types for validation.
 CONTENT_FILTER_FIELD_TYPES = {
     'key': {'type': list, 'subtype': str},
-    'aggregation_key': {'type': list, 'subtype': str},
     'first_enrollable_paid_seat_price__lte': {'type': str}
 }
 

--- a/enterprise_catalog/apps/catalog/forms.py
+++ b/enterprise_catalog/apps/catalog/forms.py
@@ -6,7 +6,8 @@ from django import forms
 from django.core.exceptions import ValidationError
 from edx_rbac.admin import UserRoleAssignmentAdminForm
 
-from enterprise_catalog.apps.catalog.constants import CONTENT_FILTER_FIELD_TYPES as cftypes
+from enterprise_catalog.apps.catalog.constants import \
+    CONTENT_FILTER_FIELD_TYPES as cftypes
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     EnterpriseCatalogRoleAssignment,

--- a/enterprise_catalog/apps/catalog/forms.py
+++ b/enterprise_catalog/apps/catalog/forms.py
@@ -6,7 +6,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from edx_rbac.admin import UserRoleAssignmentAdminForm
 
-from enterprise_catalog.apps.catalog.constants import CONTENT_FILTER_FIELD_TYPES
+from enterprise_catalog.apps.catalog.constants import CONTENT_FILTER_FIELD_TYPES as cftypes
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     EnterpriseCatalogRoleAssignment,
@@ -24,17 +24,17 @@ class CatalogQueryForm(forms.ModelForm):
         fields = ('content_filter',)
 
     def validate_content_filter_fields(self, content_filter):
-        for key in CONTENT_FILTER_FIELD_TYPES:
+        for key in cftypes:
             if key in content_filter.keys():
-                if not isinstance(content_filter[key], CONTENT_FILTER_FIELD_TYPES[key]['type']):
+                if not isinstance(content_filter[key], cftypes[key]['type']):
                     raise ValidationError(
-                        "Content filter '%s' must be of type %s" % (key, CONTENT_FILTER_FIELD_TYPES[key]['type'])
+                        "Content filter '%s' must be of type %s" % (key, cftypes[key]['type'])
                     )
-                if CONTENT_FILTER_FIELD_TYPES[key]['type'] == list:
-                    if not all(isinstance(x, str) for x in content_filter[key]):
+                if cftypes[key]['type'] == list:
+                    if not all(cftypes[key]['subtype'] == type(x) for x in content_filter[key]):
                         raise ValidationError(
                             "Content filter '%s' must contain values of type %s" % (
-                                key, CONTENT_FILTER_FIELD_TYPES[key]['subtype']
+                                key, cftypes[key]['subtype']
                             )
                         )
 

--- a/enterprise_catalog/apps/catalog/tests/test_forms.py
+++ b/enterprise_catalog/apps/catalog/tests/test_forms.py
@@ -9,10 +9,6 @@ class TestCatalogQueryAdmin(TestCase):
     @ddt.data(
         ({'content_filter': {'key': 'coursev1:course1'}}, ["Content filter 'key' must be of type <class 'list'>"]),
         (
-            {'content_filter': {'aggregation_key': 'courserun:course'}},
-            ["Content filter 'aggregation_key' must be of type <class 'list'>"],
-        ),
-        (
             {'content_filter': {'first_enrollable_paid_seat_price__lte': [12]}},
             ["Content filter 'first_enrollable_paid_seat_price__lte' must be of type <class 'str'>"]
         ),


### PR DESCRIPTION
## Description

Upon review of edx-enterprise's PR to add content_filter validation, there were a few changes made that should be reflected here as well, thus this just updates the validation logic to match what we have in edx-enterprise.

## Ticket Link

Link to the associated ticket
[https://github.com/edx/edx-enterprise/pull/807](https://openedx.atlassian.net/browse/ENT-2828)

## Post-review

Squash commits into discrete sets of changes
