### PR TITLE
Order content metadata by catalog_queries 

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -683,12 +683,9 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
         self.assertEqual(uuid.UUID(response_data['enterprise_customer']), self.enterprise_catalog.enterprise_uuid)
 
         # Check that the page contains all the metadata
-        expected_metadata = sorted([
-            self._get_expected_json_metadata(item)
-            for item in metadata
-        ], key=itemgetter('key'))
+        expected_metadata = [self._get_expected_json_metadata(item) for item in metadata]
         actual_metadata = response_data['results']
-        self.assertEqual(actual_metadata, expected_metadata)
+        self.assertCountEqual(actual_metadata, expected_metadata)
 
 
 class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -182,12 +182,10 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
     def get_queryset(self):
         """
         Returns all of the json of content metadata associated with the catalog.
-
-        Note that the metadata is ordered by content key.
         """
         enterprise_catalog = self.get_enterprise_catalog()
-        ordered_metadata = enterprise_catalog.content_metadata.order_by('content_key')
-        return ordered_metadata
+        # Avoids ordering the content metadata by any field on that model to avoid using a temporary table / filesort
+        return enterprise_catalog.content_metadata.order_by('catalog_queries')
 
     def get_response_with_enterprise_fields(self, response):
         """


### PR DESCRIPTION
Changing this ordering to see if it improves API performance for the
get_content_metadata view