### PR TITLE
explicitly include csrf urls

### DIFF
--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -29,6 +29,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'', include(oauth2_urlpatterns)),
+    url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls), name='api'),
     url(r'^api-docs/', get_swagger_view(title='Enterprise Catalog API')),


### PR DESCRIPTION
## Description

Includes csrf urls from edx-drf-extensions so that the /csrf/api/v1/token endpoint exists for MFE `POST` requests.

## Post-review

Squash commits into discrete sets of changes
