### PR TITLE
index the correct image for course cards and include partner logo img url

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -60,12 +60,14 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
             'aggregation_key': 'course:fakeX',
             'marketing_url': metadata_1.json_metadata.get('marketing_url'),
             'original_image': metadata_1.json_metadata.get('original_image'),
+            'owners': metadata_1.json_metadata.get('owners'),
         })
         course_data_2.update({
             'uuid': metadata_2.json_metadata.get('uuid'),
             'aggregation_key': 'course:testX',
             'marketing_url': metadata_2.json_metadata.get('marketing_url'),
             'original_image': metadata_2.json_metadata.get('original_image'),
+            'owners': metadata_2.json_metadata.get('owners'),
         })
 
         assert metadata_1.json_metadata == course_data_1
@@ -78,7 +80,7 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
         catalog and enterprise customer associations.
         """
         ALGOLIA_FIELDS = [
-            'key', 'objectID', 'card_image_url',
+            'key', 'objectID', 'card_image_url', 'partners',
             'enterprise_customer_uuids', 'enterprise_catalog_uuids',
         ]
 
@@ -106,13 +108,19 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
             enterprise_catalog_course_runs.enterprise_uuid,
         ]
         expected_course_card_image = course_metadata.json_metadata.get('original_image')
+        course_owners = course_metadata.json_metadata.get('owners')
+        expected_partners = [{
+            'name': course_owners[0]['name'],
+            'logo_image_url': course_owners[0]['logo_image_url'],
+        }]
         expected_algolia_objects = []
         expected_algolia_objects.append({
             'key': course_metadata.content_key,
             'objectID': 'course-{}'.format(course_metadata.json_metadata.get('uuid')),
             'enterprise_catalog_uuids': [str(uuid) for uuid in sorted(expected_catalog_uuids)],
             'enterprise_customer_uuids': [str(uuid) for uuid in sorted(expected_customer_uuids)],
-            'card_image_url': expected_course_card_image.get('src')
+            'card_image_url': expected_course_card_image.get('src'),
+            'partners': expected_partners,
         })
 
         # verify partially_update_index is called with the correct Algolia object data

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -58,10 +58,14 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
         course_data_1.update({
             'uuid': metadata_1.json_metadata.get('uuid'),
             'aggregation_key': 'course:fakeX',
+            'marketing_url': metadata_1.json_metadata.get('marketing_url'),
+            'original_image': metadata_1.json_metadata.get('original_image'),
         })
         course_data_2.update({
             'uuid': metadata_2.json_metadata.get('uuid'),
             'aggregation_key': 'course:testX',
+            'marketing_url': metadata_2.json_metadata.get('marketing_url'),
+            'original_image': metadata_2.json_metadata.get('original_image'),
         })
 
         assert metadata_1.json_metadata == course_data_1
@@ -73,7 +77,10 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
         Assert that the correct data is sent to Algolia index, with the expected enterprise
         catalog and enterprise customer associations.
         """
-        ALGOLIA_FIELDS = ['key', 'objectID', 'enterprise_customer_uuids', 'enterprise_catalog_uuids']
+        ALGOLIA_FIELDS = [
+            'key', 'objectID', 'card_image_url',
+            'enterprise_customer_uuids', 'enterprise_catalog_uuids',
+        ]
 
         # set up new catalog, query, and metadata for a course
         enterprise_catalog_courses = EnterpriseCatalogFactory()
@@ -98,12 +105,14 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
             enterprise_catalog_courses.enterprise_uuid,
             enterprise_catalog_course_runs.enterprise_uuid,
         ]
+        expected_course_card_image = course_metadata.json_metadata.get('original_image')
         expected_algolia_objects = []
         expected_algolia_objects.append({
             'key': course_metadata.content_key,
             'objectID': 'course-{}'.format(course_metadata.json_metadata.get('uuid')),
             'enterprise_catalog_uuids': [str(uuid) for uuid in sorted(expected_catalog_uuids)],
             'enterprise_customer_uuids': [str(uuid) for uuid in sorted(expected_customer_uuids)],
+            'card_image_url': expected_course_card_image.get('src')
         })
 
         # verify partially_update_index is called with the correct Algolia object data

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -207,6 +207,22 @@ def get_course_subjects(course):
     return list(subject_names)
 
 
+def get_course_card_image_url(course):
+    """
+    Gets the appropriate image to use for course cards.
+
+    Arguments:
+        course (dict): a dictionary representing a course
+
+    Returns:
+        str: the url for the course card image
+    """
+    original_image = course.get('original_image')
+    if original_image:
+        return original_image.get('src')
+    return None
+
+
 def _algolia_object_from_course(course, algolia_fields):
     """
     Transforms a course into an Algolia object.
@@ -229,6 +245,7 @@ def _algolia_object_from_course(course, algolia_fields):
         'partners': get_course_partners(searchable_course),
         'programs': get_course_program_types(searchable_course),
         'subjects': get_course_subjects(searchable_course),
+        'card_image_url': get_course_card_image_url(searchable_course),
     })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -150,17 +150,21 @@ def get_course_partners(course):
         course (dict): a dictionary representing a course
 
     Returns:
-        list: a list of partners associated with the course
+        list: a list of partner metadata associated with the course
     """
-    partners = set()
+    partners = []
     owners = course.get('owners', [])
 
     for owner in owners:
         partner_name = owner.get('name')
         if partner_name:
-            partners.add(partner_name)
+            partner_metadata = {
+                'name': partner_name,
+                'logo_image_url': owner.get('logo_image_url'),
+            }
+            partners.append(partner_metadata)
 
-    return list(partners)
+    return partners
 
 
 def get_course_program_types(course):

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -23,7 +23,7 @@ ALGOLIA_FIELDS = [
     'enterprise_catalog_uuids',
     'enterprise_customer_uuids',
     'full_description',
-    'key',  # for links to course about pages from the Learner Portal search page
+    'key',  # for links to Course about pages from the Learner Portal search page
     'language',
     'level_type',
     'objectID',  # required by Algolia, e.g. "course-{uuid}"

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -50,7 +50,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'enterprise_customer_uuids',
         'language',
         'level_type',
-        'partners',
+        'partners.name',
         'programs',
         'subjects',
     ],

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -19,6 +19,7 @@ from enterprise_catalog.apps.core.models import User
 
 
 USER_PASSWORD = 'password'
+FAKE_IMAGE_URL = 'https://fake.url/image.jpg'
 
 
 class CatalogQueryFactory(factory.DjangoModelFactory):
@@ -66,9 +67,14 @@ class ContentMetadataFactory(factory.DjangoModelFactory):
             'uuid': str(uuid4()),
         }
         if self.content_type == COURSE:
+            owners = [{
+                'name': 'Partner Name',
+                'logo_image_url': FAKE_IMAGE_URL,
+            }]
             json_metadata.update({
                 'marketing_url': 'https://marketing.url/{}'.format(self.content_key),
-                'original_image': {'src': 'https://fake.url/image.jpg'},
+                'original_image': {'src': FAKE_IMAGE_URL},
+                'owners': owners,
             })
         return json_metadata
 

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -65,9 +65,10 @@ class ContentMetadataFactory(factory.DjangoModelFactory):
             'key': self.content_key,
             'uuid': str(uuid4()),
         }
-        if self.content_key == COURSE:
+        if self.content_type == COURSE:
             json_metadata.update({
-                'marketing_url': 'http://marketing.url/{}'.format(self.content_key),
+                'marketing_url': 'https://marketing.url/{}'.format(self.content_key),
+                'original_image': {'src': 'https://fake.url/image.jpg'},
             })
         return json_metadata
 


### PR DESCRIPTION
## Description

* Updates the `card_image_url` Algolia field to pull from the correct field in the /api/v1/courses metadata, i.e. `original_image`.
* Includes partner logo img url in the index records so the LP can display the logo

## Ticket Link

[ENT-3061](https://openedx.atlassian.net/browse/ENT-3061)

## Post-review

Squash commits into discrete sets of changes
