### PR TITLE
batch uuids for algolia objects and enable distinct to reduce record size

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -12,12 +12,16 @@ from enterprise_catalog.apps.api.v1.utils import (
 )
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
-from enterprise_catalog.apps.catalog.constants import COURSE
+from enterprise_catalog.apps.catalog.constants import (
+    COURSE,
+    DEFAULT_UUID_BATCH_SIZE,
+)
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     content_metadata_with_type_course,
     update_contentmetadata_from_discovery,
 )
+from enterprise_catalog.apps.catalog.utils import batch
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +90,9 @@ def update_full_content_metadata_task(*args, **kwargs):  # pylint: disable=unuse
 
 
 @shared_task(base=LoggedTask)
-def index_enterprise_catalog_courses_in_algolia_task(algolia_fields, content_keys):
+def index_enterprise_catalog_courses_in_algolia_task(
+    algolia_fields, content_keys, uuid_batch_size=DEFAULT_UUID_BATCH_SIZE
+):
     """
     Index course data in Algolia with enterprise-related fields.
 
@@ -134,8 +140,12 @@ def index_enterprise_catalog_courses_in_algolia_task(algolia_fields, content_key
         customer_uuids_by_course_key[course_content_key].update(enterprise_customer_uuids)
 
     # iterate through only the courses, retrieving the enterprise-related uuids from the
-    # dictionary created above, and append each course to the list of courses with the added
-    # fields (e.g., objectID, enterprise_customer_uuids).
+    # dictionary created above. there is at least 2 duplicate course records per course,
+    # each including the catalog uuids and customer uuids respectively.
+    #
+    # if the number of uuids for both catalogs/customers exceeds uuid_batch_size, then
+    # create duplicate course records, batching the uuids (flattened records) to reduce
+    # the payload size of the Algolia objects.
     course_content_metadata = content_metadata.filter(content_type=COURSE)
     for metadata in course_content_metadata:
         content_key = metadata.content_key
@@ -143,10 +153,44 @@ def index_enterprise_catalog_courses_in_algolia_task(algolia_fields, content_key
         json_metadata = copy.deepcopy(metadata.json_metadata)
         json_metadata.update({
             'objectID': get_algolia_object_id(json_metadata.get('uuid')),
-            'enterprise_catalog_uuids': sorted(list(catalog_uuids_by_course_key[content_key])),
-            'enterprise_customer_uuids': sorted(list(customer_uuids_by_course_key[content_key])),
         })
-        courses.append(json_metadata)
+
+        catalog_uuid_count = len(catalog_uuids_by_course_key[content_key])
+        customer_uuid_count = len(customer_uuids_by_course_key[content_key])
+
+        if catalog_uuid_count <= uuid_batch_size:
+            json_metadata_with_uuids = copy.deepcopy(json_metadata)
+            json_metadata_with_uuids.update({
+                'objectID': '{}-catalog-uuids-0'.format(json_metadata['objectID']),
+                'enterprise_catalog_uuids': sorted(list(catalog_uuids_by_course_key[content_key])),
+            })
+            courses.append(json_metadata_with_uuids)
+        else:
+            catalog_uuids = sorted(list(catalog_uuids_by_course_key[content_key]))
+            for batch_index, catalog_uuid_batch in enumerate(batch(catalog_uuids, batch_size=uuid_batch_size)):
+                updated_json_metadata = copy.deepcopy(json_metadata)
+                updated_json_metadata.update({
+                    'objectID': '{}-catalog-uuids-{}'.format(json_metadata['objectID'], batch_index),
+                    'enterprise_catalog_uuids': catalog_uuid_batch,
+                })
+                courses.append(updated_json_metadata)
+
+        if customer_uuid_count <= uuid_batch_size:
+            updated_json_metadata = copy.deepcopy(json_metadata)
+            updated_json_metadata.update({
+                'objectID': '{}-customer-uuids-0'.format(json_metadata['objectID']),
+                'enterprise_customer_uuids': sorted(list(customer_uuids_by_course_key[content_key])),
+            })
+            courses.append(updated_json_metadata)
+        else:
+            customer_uuids = sorted(list(customer_uuids_by_course_key[content_key]))
+            for batch_index, customer_uuid_batch in enumerate(batch(customer_uuids, batch_size=uuid_batch_size)):
+                json_metadata_with_uuids = copy.deepcopy(json_metadata)
+                json_metadata_with_uuids.update({
+                    'objectID': '{}-customer-uuids-{}'.format(json_metadata['objectID'], batch_index),
+                    'enterprise_customer_uuids': customer_uuid_batch,
+                })
+                courses.append(json_metadata_with_uuids)
 
     # extract out only the fields we care about and send to Algolia index
     algolia_objects = create_algolia_objects_from_courses(courses, algolia_fields)

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -262,7 +262,9 @@ def _algolia_object_from_course(course, algolia_fields):
 
     algolia_object = {}
     for field in algolia_fields:
-        algolia_object[field] = searchable_course.get(field)
+        field_value = searchable_course.get(field)
+        if field_value:
+            algolia_object[field] = field_value
 
     return algolia_object
 

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -35,6 +35,8 @@ SYSTEM_ENTERPRISE_OPERATOR_ROLE = 'enterprise_openedx_operator'
 
 ACCESS_TO_ALL_ENTERPRISES_TOKEN = '*'
 
+DEFAULT_UUID_BATCH_SIZE = 100
+
 
 def json_serialized_course_modes():
     """

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -35,7 +35,7 @@ SYSTEM_ENTERPRISE_OPERATOR_ROLE = 'enterprise_openedx_operator'
 
 ACCESS_TO_ALL_ENTERPRISES_TOKEN = '*'
 
-DEFAULT_UUID_BATCH_SIZE = 100
+ALGOLIA_UUID_BATCH_SIZE = 100
 
 
 def json_serialized_course_modes():

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -90,3 +90,18 @@ def get_sorted_string_from_json(json_metadata):
         string: The json metadata as a sorted string
     """
     return sorted(json.dumps(json_metadata))
+
+
+def batch(iterable, batch_size=1):
+    """
+    Break up an iterable into equal-sized batches.
+
+    Arguments:
+        iterable (e.g. list): an iterable to batch
+        batch_size (int): the size of each batch. Defaults to 1.
+    Returns:
+        generator: iterates through each batch of an iterable
+    """
+    iterable_len = len(iterable)
+    for index in range(0, iterable_len, batch_size):
+        yield iterable[index:min(index + batch_size, iterable_len)]


### PR DESCRIPTION
## Description

The course records that get indexed into the Algolia search index currently combine 2 lists of uuids: `enterprise_catalog_uuids` and `enterprise_customer_uuids`. Taken together, these significantly add to the avg record size. For example, CS50's record for production is 80kb where the recommended size (per Algolia) is 10kb and the max size is 100kb.

As more catalogs/customers are created, it won't be too long before we hit that max 100kb.

To address this issue, this PR does the following:
1. Splits up the `enterprise_catalog_uuids` and `enterprise_customer_uuids` into two otherwise duplicate course records. Each record will now have either `enterprise_catalog_uuids` or `enterprise_customer_uuids`, but not both. This trims the record size in half.
2. To trim down the record further, introduces logic to batch the catalog/customer uuids in several other duplicate course records. For example, if a course is associated with 880+ Enterprise Customers, as in the case of CS50, we will index 9 course records, each containing an individual batch of the uuids (up to 100).
3. Adds the `attributeForDistinct` and `distinct` settings to the Algolia index so Algolia knows how to group results (i.e., by the course `key`).

### Testing Instructions
1. To run locally, you need the stage Algolia API keys. Reach if out if you want these to manually test.
2. Ensure you have course records in your enterprise-catalog DB that are linked to catalog(s) and customer(s).
3. Run the `reindex_algolia` management command from the app container.
4. Verify results in Algolia.

## Ticket Link

[ENT-3059](https://openedx.atlassian.net/browse/ENT-3059)

## Post-review

Squash commits into discrete sets of changes
