### PR TITLE
Remove temporary logging and make get_course_subjects more flexible

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -1,7 +1,11 @@
 import ddt
 from django.test import TestCase
 
-from enterprise_catalog.apps.api.v1.utils import get_course_subjects
+from enterprise_catalog.apps.api.v1.utils import (
+    get_course_card_image_url,
+    get_course_partners,
+    get_course_subjects,
+)
 
 
 @ddt.ddt
@@ -9,6 +13,74 @@ class EnterpriseCatalogApiUtilsTests(TestCase):
     """
     Tests for enterprise_catalog.apps.api.v1.utils.
     """
+
+    @ddt.data(
+        (
+            {'original_image': {'src': 'https://fake.image'}},
+            'https://fake.image',
+        ),
+        (
+            {'original_image': None},
+            None,
+        ),
+        (
+            {'original_image': {}},
+            None,
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_card_image_url(self, course_metadata, expected_image_url):
+        """
+        Assert get_course_partners returns the expected partner metadata for various inputs.
+        """
+        card_image_url = get_course_card_image_url(course_metadata)
+        assert card_image_url == card_image_url
+
+
+    @ddt.data(
+        (
+            {'owners': None},
+            [],
+        ),
+        (
+            {'owners': []},
+            [],
+        ),
+        (
+            {
+                'owners': [
+                    {
+                        'name': 'Test Org Name',
+                        'logo_image_url': 'https://fake.image1',
+                        'ignored_attr': None,
+                    },
+                    {
+                        'name': 'Another Org Name',
+                        'logo_image_url': 'https://fake.image2',
+                        'ignored_attr': None,
+                    },
+                ]
+            },
+            [
+                {
+                    'name': 'Test Org Name',
+                    'logo_image_url': 'https://fake.image1',
+                },
+                {
+                    'name': 'Another Org Name',
+                    'logo_image_url': 'https://fake.image2',
+                },
+            ],
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_partners(self, course_metadata, expected_partners):
+        """
+        Assert get_course_partners returns the expected partner metadata for various inputs.
+        """
+        course_partners = get_course_partners(course_metadata)
+        assert course_partners == expected_partners
+
 
     @ddt.data(
         (

--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -1,0 +1,43 @@
+import ddt
+from django.test import TestCase
+
+from enterprise_catalog.apps.api.v1.utils import get_course_subjects
+
+
+@ddt.ddt
+class EnterpriseCatalogApiUtilsTests(TestCase):
+    """
+    Tests for enterprise_catalog.apps.api.v1.utils.
+    """
+
+    @ddt.data(
+        (
+            {'subjects': ['Computer Science', 'Communication']},
+            ['Computer Science', 'Communication'],
+        ),
+        (
+            {
+                'subjects': [
+                    {'name': 'Computer Science'},
+                    {'name': 'Communication'},
+                ],
+            },
+            ['Computer Science', 'Communication'],
+        ),
+        (
+            {'subjects': None},
+            [],
+        ),
+        (
+            {'subjects': []},
+            [],
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_subjects(self, course_metadata, expected_subjects):
+            """
+            Assert get_course_subjects is flexible enough to support both a list of strings
+            and a list of dictionaries.
+            """
+            course_subjects = get_course_subjects(course_metadata)
+            assert sorted(course_subjects) == sorted(expected_subjects)

--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -31,11 +31,10 @@ class EnterpriseCatalogApiUtilsTests(TestCase):
     @ddt.unpack
     def test_get_course_card_image_url(self, course_metadata, expected_image_url):
         """
-        Assert get_course_partners returns the expected partner metadata for various inputs.
+        Assert get_course_card_image_url returns the expected course card image url.
         """
         card_image_url = get_course_card_image_url(course_metadata)
-        assert card_image_url == card_image_url
-
+        assert card_image_url == expected_image_url
 
     @ddt.data(
         (
@@ -80,7 +79,6 @@ class EnterpriseCatalogApiUtilsTests(TestCase):
         """
         course_partners = get_course_partners(course_metadata)
         assert course_partners == expected_partners
-
 
     @ddt.data(
         (

--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -35,9 +35,9 @@ class EnterpriseCatalogApiUtilsTests(TestCase):
     )
     @ddt.unpack
     def test_get_course_subjects(self, course_metadata, expected_subjects):
-            """
-            Assert get_course_subjects is flexible enough to support both a list of strings
-            and a list of dictionaries.
-            """
-            course_subjects = get_course_subjects(course_metadata)
-            assert sorted(course_subjects) == sorted(expected_subjects)
+        """
+        Assert get_course_subjects is flexible enough to support both a list of strings
+        and a list of dictionaries.
+        """
+        course_subjects = get_course_subjects(course_metadata)
+        assert sorted(course_subjects) == sorted(expected_subjects)

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -194,6 +194,10 @@ def get_course_subjects(course):
     Gets list of subject names associated with the course. Used for the "Subjects"
     facet in Algolia.
 
+    `course.get('subjects')` may be either:
+        - a list of strings, e.g. ['Communication']
+        - a list of dictionaries, e.g. [{'name': 'Communication'}]
+
     Arguments:
         course (dict): a dictionary representing a course
 
@@ -204,6 +208,10 @@ def get_course_subjects(course):
     subjects = course.get('subjects') or []
 
     for subject in subjects:
+        if isinstance(subject, str):
+            subject_names.add(subject)
+            continue
+
         subject_name = subject.get('name')
         if subject_name:
             subject_names.add(subject_name)

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -201,10 +201,7 @@ def get_course_subjects(course):
         list: a list of subject names associated with the course
     """
     subject_names = set()
-    subjects = course.get('subjects', [])
-
-    if len(subjects) > 0 and isinstance(subjects[0], str):
-        logger.info('Subjects for course %s: %s', course.get('key'), subjects)
+    subjects = course.get('subjects') or []
 
     for subject in subjects:
         subject_name = subject.get('name')

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -153,7 +153,7 @@ def get_course_partners(course):
         list: a list of partner metadata associated with the course
     """
     partners = []
-    owners = course.get('owners', [])
+    owners = course.get('owners') or []
 
     for owner in owners:
         partner_name = owner.get('name')


### PR DESCRIPTION
## Description

Remove temporary logging that was added for debug purposes, and makes `get_course_subjects` more flexible by supporting the following cases, where `course.get('subjects')` may be:
* a list of strings, e.g. `['Communication']`
* a list of dictionaries, e.g. `[{'name': 'Communication']`
* Empty array
* `NoneType`

Also, adds tests for `get_course_card_image_url` and `get_course_partners`.

## Post-review

Squash commits into discrete sets of changes
