### PR TITLE
xAPI: Include Activity ID in course(run) metadata.

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -155,6 +155,10 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
                 content_resource='course',
                 content_key=content_key,
             )
+            json_metadata['xapi_activity_id'] = enterprise_catalog.get_xapi_activity_id(
+                content_resource=content_type,
+                content_key=content_key,
+            )
             if content_type == COURSE:
                 course_runs = json_metadata.get('course_runs', [])
                 json_metadata['active'] = is_any_course_run_enrollable(course_runs)

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -559,6 +559,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
 
         enrollment_url = '{}/enterprise/{}/{}/{}/enroll/?catalog={}&utm_medium=enterprise&utm_source={}'
         marketing_url = '{}?utm_medium=enterprise&utm_source={}'
+        xapi_activity_id = '{}/xapi/activities/{}/{}'
 
         if updated_json_metadata.get('uuid'):
             updated_json_metadata['uuid'] = str(updated_json_metadata.get('uuid'))
@@ -577,6 +578,11 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
                 updated_json_metadata['key'],
                 self.enterprise_catalog.uuid,
                 self.enterprise_catalog.enterprise_name,
+            )
+            updated_json_metadata['xapi_activity_id'] = xapi_activity_id.format(
+                settings.LMS_BASE_URL,
+                content_type,
+                updated_json_metadata['key'],
             )
             if content_type == COURSE:
                 updated_json_metadata['active'] = False

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -241,6 +241,28 @@ class EnterpriseCatalog(TimeStampedModel):
 
         return update_query_parameters(url, params)
 
+    def get_xapi_activity_id(self, content_resource, content_key):
+        """
+        Return enterprise xAPI activity identifier with the catalog information
+        for the given content key.  Note that the xAPI activity identifier is a
+        well-formed IRI/URI but not necessarily a resolvable URL.
+
+        Arguments:
+            content_resource (str): The content resource to use in the URL (i.e., "course", "program")
+            content_key (str): The content key for the course to be displayed.
+
+        Returns:
+            (str): Enterprise landing page url.
+        """
+        if not content_key or not content_resource:
+            return None
+        xapi_activity_id = '{}/xapi/activities/{}/{}'.format(
+            settings.LMS_BASE_URL,
+            content_resource,
+            content_key,
+        )
+        return xapi_activity_id
+
 
 class ContentMetadata(TimeStampedModel):
     """


### PR DESCRIPTION
## Description

In order to enable third party systems to close the loop on learner enrollments, it's necessary to provide the xAPI Activity ID value up-front with the course metadata.  This allows the system to watch for related xAPI events to arrive from the edX system to the third party LRS with the corresponding Activity ID.

## Ticket Link

N/A

## Post-review

Squash commits into discrete sets of changes
