### PR TITLE
include every Algolia field in Algolia records, unless it's value is `NoneType`

### DIFF
--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -263,7 +263,7 @@ def _algolia_object_from_course(course, algolia_fields):
     algolia_object = {}
     for field in algolia_fields:
         field_value = searchable_course.get(field)
-        if field_value:
+        if field_value is not None:
             algolia_object[field] = field_value
 
     return algolia_object


### PR DESCRIPTION
## Description

While testing on stage, I noticed that when its determined there are no partners associated for a course (i.e., empty list), the empty list does not get added to the Algolia record due to a conditional (i.e., `[]` evaluates to falsey in Python).

## Ticket Link

N/A

## Post-review

Squash commits into discrete sets of changes
