### PR TITLE
Match B2C course indexing for algolia

### DIFF
--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -17,10 +17,10 @@ class AlgoliaSearchClient:
     Object builds an API client to make calls to an Algolia index.
     """
 
+    ALGOLIA_APPLICATION_ID = settings.ALGOLIA.get('APPLICATION_ID')
+    ALGOLIA_API_KEY = settings.ALGOLIA.get('API_KEY')
     # Temporarily prefer the new algolia index if it exists
-    ALGOLIA_APPLICATION_ID = settings.ALGOLIA_NEW.get('APPLICATION_ID') or settings.ALGOLIA.get('APPLICATION_ID')
-    ALGOLIA_API_KEY = settings.ALGOLIA_NEW.get('API_KEY') or settings.ALGOLIA.get('API_KEY')
-    ALGOLIA_INDEX_NAME = settings.ALGOLIA_NEW.get('INDEX_NAME') or settings.ALGOLIA.get('INDEX_NAME')
+    ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME_NEW') or settings.ALGOLIA.get('INDEX_NAME')
 
     def __init__(self):
         self._client = None

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -17,9 +17,10 @@ class AlgoliaSearchClient:
     Object builds an API client to make calls to an Algolia index.
     """
 
-    ALGOLIA_APPLICATION_ID = settings.ALGOLIA.get('APPLICATION_ID')
-    ALGOLIA_API_KEY = settings.ALGOLIA.get('API_KEY')
-    ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME')
+    # Temporarily prefer the new algolia index if it exists
+    ALGOLIA_APPLICATION_ID = settings.ALGOLIA_NEW.get('APPLICATION_ID') or settings.ALGOLIA.get('APPLICATION_ID')
+    ALGOLIA_API_KEY = settings.ALGOLIA_NEW.get('API_KEY') or settings.ALGOLIA.get('API_KEY')
+    ALGOLIA_INDEX_NAME = settings.ALGOLIA_NEW.get('INDEX_NAME') or settings.ALGOLIA.get('INDEX_NAME')
 
     def __init__(self):
         self._client = None

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -67,6 +67,40 @@ ALGOLIA_INDEX_SETTINGS = {
 }
 
 
+def should_index(course_metadata):
+    """
+    Replicates the B2C index check of whether a certain course should be indexed for search.
+
+    A course should only be indexed for algolia search if it has a non-indexed advertiseable course run, at least
+    one owner, and a marketing url slug.
+    The course-discovery check that the course's partner is edX is included by default as the discovery API filters
+    to the request's site's partner.
+    The discovery check that the course has an availability level was decided to be a duplicate check that the
+    website team plans on removing.
+    Original code:
+    https://github.com/edx/course-discovery/blob/c6ac5329225e2f32cdf1d1da855d7c9d905b2576/course_discovery/apps/course_metadata/algolia_models.py#L218-L227
+
+    Args:
+        course (ContentMetadata): The ContentMetadata representing a course object.
+
+    Returns:
+        bool: Whether or not the course should be indexed by algolia.
+    """
+    course_json_metadata = course_metadata.json_metadata
+    advertised_course_run_uuid = course_json_metadata.get('advertised_course_run_uuid')
+    course_runs = course_json_metadata.get('course_runs')
+    try:
+        advertised_course_run = [run for run in course_runs if run.get('uuid') == advertised_course_run_uuid][0]
+    except IndexError:
+        # If there is no advertised course run we can immediately return False
+        return False
+
+    owners = course_json_metadata.get('owners', [])
+    return (len(owners) > 0
+            and bool(course_json_metadata.get('url_slug'))
+            and not advertised_course_run.get('hidden'))
+
+
 class Command(BaseCommand):
     help = (
         'Reindex course data in Algolia, adding on enterprise-specific metadata'
@@ -85,16 +119,13 @@ class Command(BaseCommand):
         algolia_client.set_index_settings(ALGOLIA_INDEX_SETTINGS)
 
         # retrieve content_keys for all ContentMetadata records with a content type of "course"
-        course_content_metadata = content_metadata_with_type_course()
-        content_metadata_keys = []
-        if course_content_metadata:
-            content_metadata_keys = [
-                metadata['content_key']
-                for metadata in course_content_metadata.values('content_key')
-            ]
+        all_course_content_metadata = content_metadata_with_type_course()
+        # Only use the course content metadata that should be indexed for Algolia using the B2C logic
+        indexable_content_keys = [course_content_metadata.content_key for course_content_metadata
+                                  in all_course_content_metadata if should_index(course_content_metadata)]
 
         # batch the content keys and spin off a new task for each batch
-        for content_keys_batch in batch(content_metadata_keys, batch_size=BATCH_SIZE):
+        for content_keys_batch in batch(indexable_content_keys, batch_size=BATCH_SIZE):
             async_task = index_enterprise_catalog_courses_in_algolia_task.delay(
                 algolia_fields=ALGOLIA_FIELDS,
                 content_keys=content_keys_batch,

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -67,7 +67,7 @@ ALGOLIA_INDEX_SETTINGS = {
 }
 
 
-def should_index(course_metadata):
+def should_index_course(course_metadata):
     """
     Replicates the B2C index check of whether a certain course should be indexed for search.
 
@@ -122,7 +122,7 @@ class Command(BaseCommand):
         all_course_content_metadata = content_metadata_with_type_course()
         # Only use the course content metadata that should be indexed for Algolia using the B2C logic
         indexable_content_keys = [course_content_metadata.content_key for course_content_metadata
-                                  in all_course_content_metadata if should_index(course_content_metadata)]
+                                  in all_course_content_metadata if should_index_course(course_content_metadata)]
 
         # batch the content keys and spin off a new task for each batch
         for content_keys_batch in batch(indexable_content_keys, batch_size=BATCH_SIZE):

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -1,3 +1,6 @@
+from uuid import uuid4
+
+import ddt
 import mock
 from django.core.management import call_command
 from django.test import TestCase
@@ -7,25 +10,73 @@ from enterprise_catalog.apps.catalog.management.commands.reindex_algolia import 
     ALGOLIA_FIELDS,
     ALGOLIA_INDEX_SETTINGS,
     BATCH_SIZE,
+    should_index,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
 )
 
 
+@ddt.ddt
 class ReindexAlgoliaCommandTests(TestCase):
     command_name = 'reindex_algolia'
 
+    @ddt.data(
+        {'expected_result': False, 'has_advertised_course_run': False},
+        {'expected_result': False, 'has_owners': False},
+        {'expected_result': False, 'has_url_slug': False},
+        {'expected_result': False, 'advertised_course_run_hidden': True},
+        {'expected_result': True},
+    )
+    @ddt.unpack
+    def test_should_index(
+        self,
+        expected_result,
+        has_advertised_course_run=True,
+        has_owners=True,
+        has_url_slug=True,
+        advertised_course_run_hidden=False,
+    ):
+        """
+        Verify that only a course that has a non-hidden advertised course run, at least one owner, and a marketing slug
+        is marked as indexable.
+        """
+        advertised_course_run_uuid = uuid4()
+        course_run_uuid = advertised_course_run_uuid if has_advertised_course_run else uuid4()
+        owners = [{'name': 'edX'}] if has_owners else []
+        url_slug = 'test-slug' if has_url_slug else ''
+        json_metadata = {
+            'advertised_course_run_uuid': advertised_course_run_uuid,
+            'course_runs': [
+                {
+                    'hidden': advertised_course_run_hidden,
+                    'uuid': course_run_uuid,
+                },
+            ],
+            'owners': owners,
+            'url_slug': url_slug,
+        }
+        course_metadata = ContentMetadataFactory.create(
+            content_type=COURSE,
+            json_metadata=json_metadata,
+        )
+        assert should_index(course_metadata) is expected_result
+
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.should_index'
+    )
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.AlgoliaSearchClient'
     )
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.index_enterprise_catalog_courses_in_algolia_task'
     )
-    def test_reindex_algolia(self, mock_task, mock_search_client):
+    def test_reindex_algolia(self, mock_task, mock_search_client, mock_should_index):
         """
         Verify that the job spins off the correct number of index_enterprise_catalog_courses_in_algolia_task
         """
+        # Mock that all courses should be indexed
+        mock_should_index.return_value = True
         # create enough ContentMetadata records to force more than 1 batch of content keys
         content_metadata = ContentMetadataFactory.create_batch(
             BATCH_SIZE + 1,

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -10,7 +10,7 @@ from enterprise_catalog.apps.catalog.management.commands.reindex_algolia import 
     ALGOLIA_FIELDS,
     ALGOLIA_INDEX_SETTINGS,
     BATCH_SIZE,
-    should_index,
+    should_index_course,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
@@ -29,7 +29,7 @@ class ReindexAlgoliaCommandTests(TestCase):
         {'expected_result': True},
     )
     @ddt.unpack
-    def test_should_index(
+    def test_should_index_course(
         self,
         expected_result,
         has_advertised_course_run=True,
@@ -60,10 +60,10 @@ class ReindexAlgoliaCommandTests(TestCase):
             content_type=COURSE,
             json_metadata=json_metadata,
         )
-        assert should_index(course_metadata) is expected_result
+        assert should_index_course(course_metadata) is expected_result
 
     @mock.patch(
-        'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.should_index'
+        'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.should_index_course'
     )
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.AlgoliaSearchClient'
@@ -71,12 +71,12 @@ class ReindexAlgoliaCommandTests(TestCase):
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.reindex_algolia.index_enterprise_catalog_courses_in_algolia_task'
     )
-    def test_reindex_algolia(self, mock_task, mock_search_client, mock_should_index):
+    def test_reindex_algolia(self, mock_task, mock_search_client, mock_should_index_course):
         """
         Verify that the job spins off the correct number of index_enterprise_catalog_courses_in_algolia_task
         """
         # Mock that all courses should be indexed
-        mock_should_index.return_value = True
+        mock_should_index_course.return_value = True
         # create enough ContentMetadata records to force more than 1 batch of content keys
         content_metadata = ContentMetadataFactory.create_batch(
             BATCH_SIZE + 1,

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -327,13 +327,8 @@ DISCOVERY_SERVICE_API_URL = os.environ.get('DISCOVERY_SERVICE_API_URL', '')
 
 # Algolia
 ALGOLIA = {
-    'INDEX_NAME': '',
-    'APPLICATION_ID': '',
-    'API_KEY': '',
-}
-
-# Temporary algolia settings for new index
-ALGOLIA_NEW = {
+    # Temporary algolia setting for new index
+    'INDEX_NAME_NEW': '',
     'INDEX_NAME': '',
     'APPLICATION_ID': '',
     'API_KEY': '',

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -332,6 +332,13 @@ ALGOLIA = {
     'API_KEY': '',
 }
 
+# Temporary algolia settings for new index
+ALGOLIA_NEW = {
+    'INDEX_NAME': '',
+    'APPLICATION_ID': '',
+    'API_KEY': '',
+}
+
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE: [ENTERPRISE_CATALOG_ADMIN_ROLE],


### PR DESCRIPTION
Replicates the logic from course-discovery that restricts which courses
are indexed for algolia search.
Some pieces of the logic look a little bit different as we use fields
coming from the API whereas they use fields in the discovery database.
Additionally, there is some logic in discovery that the website team
felt was duplicated that has been omitted here.

ENT-2992
