### PR TITLE
Ignore health endpoint check in newrelic

### DIFF
--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -22,7 +22,7 @@ USER_PASSWORD = 'password'
 FAKE_IMAGE_URL = 'https://fake.url/image.jpg'
 
 
-class CatalogQueryFactory(factory.DjangoModelFactory):
+class CatalogQueryFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `CatalogQuery` model
     """
@@ -32,7 +32,7 @@ class CatalogQueryFactory(factory.DjangoModelFactory):
     content_filter = factory.Dict({'content_type': factory.Faker('word')})
 
 
-class EnterpriseCatalogFactory(factory.DjangoModelFactory):
+class EnterpriseCatalogFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `EnterpriseCatalog` model
     """
@@ -48,7 +48,7 @@ class EnterpriseCatalogFactory(factory.DjangoModelFactory):
     publish_audit_enrollment_urls = False   # Default to False
 
 
-class ContentMetadataFactory(factory.DjangoModelFactory):
+class ContentMetadataFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `ContentMetadata` model
     """
@@ -79,7 +79,7 @@ class ContentMetadataFactory(factory.DjangoModelFactory):
         return json_metadata
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     username = factory.Faker('user_name')
     password = factory.PostGenerationMethodCall('set_password', USER_PASSWORD)
     email = factory.Faker('email')
@@ -93,7 +93,7 @@ class UserFactory(factory.DjangoModelFactory):
         model = User
 
 
-class EnterpriseCatalogFeatureRoleFactory(factory.DjangoModelFactory):
+class EnterpriseCatalogFeatureRoleFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `EnterpriseCatalogFeatureRole` model.
     """
@@ -103,7 +103,7 @@ class EnterpriseCatalogFeatureRoleFactory(factory.DjangoModelFactory):
         model = EnterpriseCatalogFeatureRole
 
 
-class EnterpriseCatalogRoleAssignmentFactory(factory.DjangoModelFactory):
+class EnterpriseCatalogRoleAssignmentFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `EnterpriseCatalogRoleAssignment` model.
     """

--- a/enterprise_catalog/apps/core/views.py
+++ b/enterprise_catalog/apps/core/views.py
@@ -8,6 +8,7 @@ from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View
+from edx_django_utils.monitoring import ignore_transaction
 
 from enterprise_catalog.apps.core.constants import Status
 
@@ -33,6 +34,8 @@ def health(_):
         >>> response.content
         '{"overall_status": "OK", "detailed_status": {"database_status": "OK", "lms_status": "OK"}}'
     """
+    # Ignores health check in performance monitoring so as to not artifically inflate our response time metrics
+    ignore_transaction()
 
     try:
         cursor = connection.cursor()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,36 +4,36 @@
 #
 #    make upgrade
 #
-algoliasearch==2.3.1      # via -r requirements/base.in
+algoliasearch==2.4.0      # via -r requirements/base.in
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==2.9.2       # via pyjwt
+cryptography==3.0         # via pyjwt
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.in
-django-crum==0.7.6        # via -r requirements/base.in, edx-rbac
-django-extensions==3.0.3  # via -r requirements/base.in
+django-crum==0.7.7        # via -r requirements/base.in, edx-rbac
+django-extensions==3.0.5  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.15            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.in
-djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via edx-drf-extensions
+djangorestframework==3.11.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.0           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-celeryutils==0.5.1    # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.3.0   # via edx-drf-extensions
+edx-django-utils==3.7.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.in
+edx-rbac==1.3.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils, pyjwkest
 idna==2.10                # via requests
@@ -45,16 +45,16 @@ langcodes==2.0.0          # via -r requirements/base.in
 marisa-trie==0.7.5        # via langcodes
 markupsafe==1.1.1         # via jinja2
 mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.14.1.144      # via edx-django-utils
+newrelic==5.16.1.146      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
-psutil==1.2.1             # via edx-django-utils
+psutil==5.7.2             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django
@@ -66,12 +66,12 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger
-six==1.15.0               # via cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via cryptography, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via requests
 zipp==1.2.0               # via -r requirements/base.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,6 +8,7 @@
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
 django-debug-toolbar      # For debugging Django
+gunicorn                  # For running the application locally
 #transifex-client         # For managing translations
 inflect<4.0.0             # Inflect 4.0.0 requires python>=3.6
 ddt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-algoliasearch==2.3.1      # via -r requirements/quality.txt, -r requirements/test.txt
+algoliasearch==2.4.0      # via -r requirements/quality.txt, -r requirements/test.txt
 amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
@@ -13,50 +13,51 @@ attrs==19.3.0             # via -r requirements/test.txt, pytest
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
 celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
-cffi==1.14.0              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
+cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.3.4   # via -r requirements/test.txt
+code-annotations==0.5.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.2             # via -r requirements/test.txt, pytest-cov
-cryptography==2.9.2       # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
+coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.0         # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
 ddt==1.3.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 diff-cover==3.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.3  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.5  # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.15            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
-djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+djangorestframework==3.11.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-celeryutils==0.5.1    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.3.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.0           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-rbac==1.3.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
-factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.1              # via -r requirements/test.txt, factory-boy
+factory-boy==3.0.1        # via -r requirements/test.txt
+faker==4.1.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/test.txt, inflect, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -71,18 +72,18 @@ mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/tes
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.14.1.144      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
-path.py==12.4.0           # via edx-i18n-tools
+path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
-pip-tools==5.2.1          # via -r requirements/pip-tools.txt
+pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
@@ -95,11 +96,11 @@ pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/tes
 pylint-django==2.0.11     # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/test.txt
+pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
@@ -112,21 +113,20 @@ rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/tes
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar
-stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.17.1               # via -r requirements/test.txt
+toml==0.10.1              # via -r requirements/test.txt, pytest, tox
+tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-virtualenv==20.0.27       # via -r requirements/test.txt, tox
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
+urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, requests
+virtualenv==20.0.31       # via -r requirements/test.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.14            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.15            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-algoliasearch==2.3.1      # via -r requirements/test.txt
+algoliasearch==2.4.0      # via -r requirements/test.txt
 amqp==1.4.9               # via -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
@@ -16,50 +16,51 @@ billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
 celery==3.1.26.post2      # via -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.0              # via -r requirements/test.txt, cryptography
+cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.3.4   # via -r requirements/test.txt
+code-annotations==0.5.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.2             # via -r requirements/test.txt, pytest-cov
-cryptography==2.9.2       # via -r requirements/test.txt, pyjwt
+coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.0         # via -r requirements/test.txt, pyjwt
 ddt==1.3.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.4.0  # via -r requirements/test.txt
-django-crum==0.7.6        # via -r requirements/test.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.3  # via -r requirements/test.txt
+django-extensions==3.0.5  # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.15            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/test.txt
-djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-celeryutils==0.5.1    # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.3.0   # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.5.0           # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/test.txt
+edx-rbac==1.3.2           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.1              # via -r requirements/test.txt, factory-boy
+factory-boy==3.0.1        # via -r requirements/test.txt
+faker==4.1.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
@@ -73,14 +74,14 @@ mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
@@ -91,11 +92,11 @@ pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/test.txt
+pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
@@ -110,12 +111,12 @@ restructuredtext-lint==1.3.1  # via doc8
 rules==2.2                # via -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.2.1             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -123,15 +124,14 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.17.1               # via -r requirements/test.txt
+toml==0.10.1              # via -r requirements/test.txt, pytest, tox
+tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.9           # via -r requirements/test.txt, requests
-virtualenv==20.0.27       # via -r requirements/test.txt, tox
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
+urllib3==1.25.10          # via -r requirements/test.txt, requests
+virtualenv==20.0.31       # via -r requirements/test.txt, tox
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.1          # via -r requirements/pip-tools.in
+pip-tools==5.3.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,36 +4,36 @@
 #
 #    make upgrade
 #
-algoliasearch==2.3.1      # via -r requirements/base.txt
+algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
 celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.0              # via -r requirements/base.txt, cryptography
+cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
+cryptography==3.0         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.3  # via -r requirements/base.txt
+django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.15            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.3.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.txt
+edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 gevent==20.6.2            # via -r requirements/production.in
@@ -48,16 +48,16 @@ langcodes==2.0.0          # via -r requirements/base.txt
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
@@ -70,14 +70,14 @@ rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, cryptography, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.9           # via -r requirements/base.txt, requests
+urllib3==1.25.10          # via -r requirements/base.txt, requests
 zipp==1.2.0               # via -r requirements/base.txt
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,40 +4,40 @@
 #
 #    make upgrade
 #
-algoliasearch==2.3.1      # via -r requirements/base.txt
+algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
 celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.0              # via -r requirements/base.txt, cryptography
+cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
+cryptography==3.0         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.3  # via -r requirements/base.txt
+django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.15            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.3.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.0           # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.txt
+edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
@@ -52,11 +52,11 @@ marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
@@ -67,7 +67,7 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
@@ -79,15 +79,15 @@ rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.9           # via -r requirements/base.txt, requests
+urllib3==1.25.10          # via -r requirements/base.txt, requests
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-algoliasearch==2.3.1      # via -r requirements/base.txt
+algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 appdirs==1.4.4            # via virtualenv
@@ -13,45 +13,46 @@ attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
 celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.0              # via -r requirements/base.txt, cryptography
+cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.3.4   # via -r requirements/test.in
+code-annotations==0.5.0   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.2             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
+coverage==5.2.1           # via -r requirements/test.in, pytest-cov
+cryptography==3.0         # via -r requirements/base.txt, pyjwt
 ddt==1.3.1                # via -c requirements/constraints.txt, -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.1            # via virtualenv
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.3  # via -r requirements/base.txt
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.3.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.0           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.3.1           # via -r requirements/base.txt
+edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.1              # via factory-boy
+factory-boy==3.0.1        # via -r requirements/test.in
+faker==4.1.2              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
+iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
@@ -65,14 +66,14 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.4.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest, tox
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest, tox
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest, tox
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
@@ -82,11 +83,11 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
+pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov, pytest-django
+pytest==6.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
@@ -99,19 +100,18 @@ rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
-toml==0.10.1              # via tox
-tox==3.17.1               # via -r requirements/test.in
+toml==0.10.1              # via pytest, tox
+tox==3.19.0               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.9           # via -r requirements/base.txt, requests
-virtualenv==20.0.27       # via tox
-wcwidth==0.2.5            # via pytest
+urllib3==1.25.10          # via -r requirements/base.txt, requests
+virtualenv==20.0.31       # via tox
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -16,6 +16,6 @@ pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/tox.in
-tox==3.17.1               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.27       # via tox
+tox==3.19.0               # via -r requirements/tox.in, tox-battery
+virtualenv==20.0.31       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
Performance monitoring was being thrown off by many successful & fast
health check calls which was hiding the application's true performance.

ENT-3292