### PR TITLE
fix mismatching keys and secrets with what is provisioned

### DIFF
--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -4,8 +4,8 @@ from enterprise_catalog.settings.local import *
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 
 # OAuth2 variables specific to social-auth/SSO login use case.
-SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise-catalog-sso-key')
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise-catalog-sso-secret')
+SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise_catalog-sso-key')
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise_catalog-sso-secret')
 SOCIAL_AUTH_EDX_OAUTH2_ISSUER = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_ISSUER', 'http://localhost:18000')
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT', 'http://edx.devstack.lms:18000')
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL', 'http://localhost:18000/logout')
@@ -14,8 +14,8 @@ SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
 )
 
 # OAuth2 variables specific to backend service API calls.
-BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise-catalog-backend-service-key')
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise-catalog-backend-service-secret')
+BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise_catalog-backend-service-key')
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise_catalog-backend-service-secret')
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',


### PR DESCRIPTION
## Description

The provision-catalog.sh script in enterprise-catalog creates an oauth application using an underscore (`enterprise_catalog-backend-service-key`), yet the default client id/secret specified in devstack.py uses a hyphen (`enterprise-catalog-backend-service-key`). This results in a 401 until I change the default setting to use an underscore over a hyphen, or update the client id/secret to no longer use an underscore.

This PR does the former, changing the default settings to use snakecase `enterprise_catalog` in the keys/secrets over the hyphen. FWIW, license-manager also uses underscores in devstack.py settings.

## Post-review

Squash commits into discrete sets of changes
