### PR TITLE
ENT-3363: 'enrollment_url' points to Learner Portal course page if LP enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ dev.stop: ## Stops containers so they can be restarted
 %-logs: ## View the logs of the specified service container
 	docker-compose logs -f --tail=500 $*
 
-attach: ## Runs docker attach enterprise.catalog.app
-	docker attach enterprise.catalog.app
+%-attach: ## Attach terminal I/O to the specified service container
+	docker attach enterprise.catalog.$*
 
 docker_build: ## Builds with the latest enterprise catalog
 	docker build . --target app -t "openedx/enterprise-catalog:latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
     # ports:
     #  - "3307:3306"
 
+  memcached:
+    image: memcached:1.6.6
+    container_name: enterprise.catalog.memcached
+    networks:
+      - devstack_default
+
   app:
     # Uncomment this line to use the official catalog base image
     # image: edxops/enterprise_catalog:devstack
@@ -32,6 +38,7 @@ services:
     ports:
       - "18160:18160"
     depends_on:
+      - memcached
       - mysql
       - worker
     networks:

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -25,7 +25,7 @@ class EnterpriseCatalogCeleryTaskTests(TestCase):
         tasks.update_catalog_metadata_task(catalog_query.id)
         update_contentmetadata_from_discovery_mock.assert_called_with(catalog_query.id)
 
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_update_full_metadata(self, mock_oauth_client):
         """
         Assert that full course metadata is merged with original json_metadata for all ContentMetadata records.

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -18,8 +18,7 @@ from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     EnterpriseCatalog,
 )
-from enterprise_catalog.apps.catalog.utils import get_content_filter_hash
-
+from enterprise_catalog.apps.catalog.utils import get_content_filter_hash, get_parent_content_key
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +141,7 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
         json_metadata = instance.json_metadata.copy()
         marketing_url = json_metadata.get('marketing_url')
         content_key = json_metadata.get('key')
+        parent_content_key = get_parent_content_key(json_metadata)
 
         if marketing_url:
             marketing_url = update_query_parameters(
@@ -152,25 +152,28 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
 
         if content_type in (COURSE, COURSE_RUN):
             json_metadata['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
-                content_resource='course',
+                content_resource=COURSE,
                 content_key=content_key,
+                parent_content_key=parent_content_key,
             )
             json_metadata['xapi_activity_id'] = enterprise_catalog.get_xapi_activity_id(
                 content_resource=content_type,
                 content_key=content_key,
             )
-            if content_type == COURSE:
+            if content_type is COURSE:
                 course_runs = json_metadata.get('course_runs', [])
                 json_metadata['active'] = is_any_course_run_enrollable(course_runs)
                 for course_run in course_runs:
                     course_run['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
-                        content_resource='course',
+                        content_resource=COURSE,
                         content_key=course_run.get('key'),
+                        parent_content_key=content_key,
                     )
         elif content_type == PROGRAM:
             json_metadata['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
-                content_resource='program',
+                content_resource=PROGRAM,
                 content_key=content_key,
+                parent_content_key=parent_content_key,
             )
 
         return json_metadata

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -173,7 +173,8 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
                         content_key=course_run.get('key'),
                         parent_content_key=content_key,
                     )
-        elif content_type == PROGRAM:
+        elif content_type is PROGRAM:
+            # This URL will always be blank because json_metadata['key'] doesn't exist for programs
             json_metadata['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
                 content_resource=PROGRAM,
                 content_key=content_key,

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -164,7 +164,7 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
                 content_resource=content_type,
                 content_key=content_key,
             )
-            if content_type is COURSE:
+            if content_type == COURSE:
                 course_runs = json_metadata.get('course_runs', [])
                 json_metadata['active'] = is_any_course_run_enrollable(course_runs)
                 for course_run in course_runs:
@@ -173,7 +173,7 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
                         content_key=course_run.get('key'),
                         parent_content_key=content_key,
                     )
-        elif content_type is PROGRAM:
+        elif content_type == PROGRAM:
             # This URL will always be blank because json_metadata['key'] doesn't exist for programs
             json_metadata['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
                 content_resource=PROGRAM,

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -18,7 +18,11 @@ from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     EnterpriseCatalog,
 )
-from enterprise_catalog.apps.catalog.utils import get_content_filter_hash, get_parent_content_key
+from enterprise_catalog.apps.catalog.utils import (
+    get_content_filter_hash,
+    get_parent_content_key,
+)
+
 
 logger = logging.getLogger(__name__)
 

--- a/enterprise_catalog/apps/api/v1/tests/mixins.py
+++ b/enterprise_catalog/apps/api/v1/tests/mixins.py
@@ -77,6 +77,7 @@ class APITestMixin(JwtMixin, APITestCase):
         super(APITestMixin, self).setUp()
         self.enterprise_uuid = uuid.uuid4()
         self.enterprise_name = 'Test Enterprise'
+        self.enterprise_slug = 'test-enterprise'
 
     def set_up_staff(self):
         """

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -675,7 +675,11 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
             'slug': self.enterprise_slug,
             'enable_learner_portal': learner_portal_enabled,
         }
-        # Reset sequence to 10 to avoid sorting issue with 0, 1, 10, 2
+        # The ContentMetadataFactory creates content with keys that are generated using a string builder with a
+        # factory sequence (index is appended onto each content key). The results are sorted by key which creates
+        # an unexpected sorting of [key0, key1, key10, key2, ...] so the test fails on
+        # self.assertEqual(actual_metadata, expected_metadata[:-1]). By resetting the factory sequence to start at
+        # 10 we avoid that sorting issue.
         ContentMetadataFactory.reset_sequence(10)
         # Create enough metadata to force pagination
         metadata = ContentMetadataFactory.create_batch(api_settings.PAGE_SIZE + 1)

--- a/enterprise_catalog/apps/api_client/base_oauth.py
+++ b/enterprise_catalog/apps/api_client/base_oauth.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from edx_rest_api_client.client import OAuthAPIClient
+
+
+class BaseOAuthClient:
+    """
+    Base class for OAuth API clients.
+    """
+    def __init__(self):
+        self.client = OAuthAPIClient(
+            settings.SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT.strip('/'),
+            self.oauth2_client_id,
+            self.oauth2_client_secret
+        )
+
+    @property
+    def oauth2_client_id(self):
+        return settings.BACKEND_SERVICE_EDX_OAUTH2_KEY
+
+    @property
+    def oauth2_client_secret(self):
+        return settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET

--- a/enterprise_catalog/apps/api_client/constants.py
+++ b/enterprise_catalog/apps/api_client/constants.py
@@ -14,3 +14,4 @@ OFFSET_SIZE = 100
 # Enterprise API Client Constants
 ENTERPRISE_API_URL = urljoin(settings.LMS_BASE_URL, '/enterprise/api/v1/')
 ENTERPRISE_CUSTOMER_ENDPOINT = urljoin(ENTERPRISE_API_URL, 'enterprise-customer/')
+ENTERPRISE_CUSTOMER_CACHE_KEY_TPL = 'customer:{uuid}'

--- a/enterprise_catalog/apps/api_client/constants.py
+++ b/enterprise_catalog/apps/api_client/constants.py
@@ -1,0 +1,16 @@
+"""
+Constants for each API Client.
+"""
+from urllib.parse import urljoin
+
+from django.conf import settings
+
+
+# Discovery API Client Constants
+SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
+COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
+OFFSET_SIZE = 100
+
+# Enterprise API Client Constants
+ENTERPRISE_API_URL = urljoin(settings.LMS_BASE_URL, '/enterprise/api/v1/')
+ENTERPRISE_CUSTOMER_ENDPOINT = urljoin(ENTERPRISE_API_URL, 'enterprise-customer/')

--- a/enterprise_catalog/apps/api_client/constants.py
+++ b/enterprise_catalog/apps/api_client/constants.py
@@ -7,9 +7,9 @@ from django.conf import settings
 
 
 # Discovery API Client Constants
-SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
-COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
-OFFSET_SIZE = 100
+DISCOVERY_SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
+DISCOVERY_COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
+DISCOVERY_OFFSET_SIZE = 100
 
 # Enterprise API Client Constants
 ENTERPRISE_API_URL = urljoin(settings.LMS_BASE_URL, '/enterprise/api/v1/')

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -4,7 +4,11 @@ Discovery service api client code.
 import logging
 
 from .base_oauth import BaseOAuthClient
-from .constants import COURSES_ENDPOINT, OFFSET_SIZE, SEARCH_ALL_ENDPOINT
+from .constants import (
+    DISCOVERY_COURSES_ENDPOINT,
+    DISCOVERY_OFFSET_SIZE,
+    DISCOVERY_SEARCH_ALL_ENDPOINT,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -22,7 +26,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         """
         LOGGER.info('Retrieving results from course-discovery for page {}...'.format(page))
         response = self.client.post(
-            SEARCH_ALL_ENDPOINT,
+            DISCOVERY_SEARCH_ALL_ENDPOINT,
             json=content_filter,
             params=request_params,
         ).json()
@@ -75,7 +79,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         """
         LOGGER.info('Retrieving courses from course-discovery for offset {}...'.format(offset))
         response = self.client.get(
-            COURSES_ENDPOINT,
+            DISCOVERY_COURSES_ENDPOINT,
             params=request_params,
         ).json()
         return response
@@ -91,7 +95,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         Returns:
             list: a list of the results, or None if there was an error calling the discovery service.
         """
-        request_params = {'limit': OFFSET_SIZE}
+        request_params = {'limit': DISCOVERY_OFFSET_SIZE}
         request_params.update(query_params or {})
 
         courses = []
@@ -101,7 +105,7 @@ class DiscoveryApiClient(BaseOAuthClient):
             courses += response.get('results')
             # Traverse all pages and concatenate results
             while response.get('next'):
-                offset += OFFSET_SIZE
+                offset += DISCOVERY_OFFSET_SIZE
                 request_params.update({'offset': offset})
                 response = self._retrieve_courses(offset, request_params)
                 courses += response.get('results', [])

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
 
+
 LOGGER = logging.getLogger(__name__)
 
 OFFSET_SIZE = 100

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -3,12 +3,8 @@ Discovery service api client code.
 """
 import logging
 
-from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
-from enterprise_catalog.apps.api_client.constants import (
-    COURSES_ENDPOINT,
-    OFFSET_SIZE,
-    SEARCH_ALL_ENDPOINT,
-)
+from .base_oauth import BaseOAuthClient
+from .constants import COURSES_ENDPOINT, OFFSET_SIZE, SEARCH_ALL_ENDPOINT
 
 
 LOGGER = logging.getLogger(__name__)

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -1,26 +1,23 @@
-# -*- coding: utf-8 -*-
 """
 Discovery service api client code.
 """
 import logging
-from urllib.parse import urljoin
-
-from django.conf import settings
 
 from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
+from enterprise_catalog.apps.api_client.constants import (
+    COURSES_ENDPOINT,
+    OFFSET_SIZE,
+    SEARCH_ALL_ENDPOINT,
+)
 
 
 LOGGER = logging.getLogger(__name__)
-
-OFFSET_SIZE = 100
 
 
 class DiscoveryApiClient(BaseOAuthClient):
     """
     Object builds an API client to make calls to the Discovery Service.
     """
-    SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
-    COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
 
     def _retrieve_metadata_for_content_filter(self, content_filter, page, request_params):
         """
@@ -29,7 +26,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         """
         LOGGER.info('Retrieving results from course-discovery for page {}...'.format(page))
         response = self.client.post(
-            self.SEARCH_ALL_ENDPOINT,
+            SEARCH_ALL_ENDPOINT,
             json=content_filter,
             params=request_params,
         ).json()
@@ -82,7 +79,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         """
         LOGGER.info('Retrieving courses from course-discovery for offset {}...'.format(offset))
         response = self.client.get(
-            self.COURSES_ENDPOINT,
+            COURSES_ENDPOINT,
             params=request_params,
         ).json()
         return response

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -6,35 +6,20 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
-from edx_rest_api_client.client import OAuthAPIClient
 
+from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
 
 LOGGER = logging.getLogger(__name__)
 
 OFFSET_SIZE = 100
 
 
-class DiscoveryApiClient:
+class DiscoveryApiClient(BaseOAuthClient):
     """
     Object builds an API client to make calls to the Discovery Service.
     """
     SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
     COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
-
-    def __init__(self):
-        self.client = OAuthAPIClient(
-            settings.SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT.strip('/'),
-            self.oauth2_client_id,
-            self.oauth2_client_secret
-        )
-
-    @property
-    def oauth2_client_id(self):
-        return settings.BACKEND_SERVICE_EDX_OAUTH2_KEY
-
-    @property
-    def oauth2_client_secret(self):
-        return settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET
 
     def _retrieve_metadata_for_content_filter(self, content_filter, page, request_params):
         """

--- a/enterprise_catalog/apps/api_client/enterprise.py
+++ b/enterprise_catalog/apps/api_client/enterprise.py
@@ -1,7 +1,5 @@
-from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
-from enterprise_catalog.apps.api_client.constants import (
-    ENTERPRISE_CUSTOMER_ENDPOINT,
-)
+from .base_oauth import BaseOAuthClient
+from .constants import ENTERPRISE_CUSTOMER_ENDPOINT
 
 
 class EnterpriseApiClient(BaseOAuthClient):

--- a/enterprise_catalog/apps/api_client/enterprise.py
+++ b/enterprise_catalog/apps/api_client/enterprise.py
@@ -1,16 +1,13 @@
-from urllib.parse import urljoin
-
-from django.conf import settings
-
 from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
+from enterprise_catalog.apps.api_client.constants import (
+    ENTERPRISE_CUSTOMER_ENDPOINT,
+)
 
 
 class EnterpriseApiClient(BaseOAuthClient):
     """
     API client to make calls to edx-enterprise API endpoints.
     """
-    ENTERPRISE_API_URL = urljoin(settings.LMS_BASE_URL, '/enterprise/api/v1/')
-    CUSTOMER_ENDPOINT = urljoin(ENTERPRISE_API_URL, 'enterprise-customer/')
 
     def get_enterprise_customer(self, customer_uuid):
         """
@@ -25,7 +22,7 @@ class EnterpriseApiClient(BaseOAuthClient):
         """
         query_params = {'uuid': customer_uuid}
         response = self.client.get(
-            self.CUSTOMER_ENDPOINT,
+            ENTERPRISE_CUSTOMER_ENDPOINT,
             params=query_params
         ).json()
         results = response.get('results', [])

--- a/enterprise_catalog/apps/api_client/enterprise.py
+++ b/enterprise_catalog/apps/api_client/enterprise.py
@@ -1,0 +1,36 @@
+import logging
+from urllib.parse import urljoin
+
+from django.conf import settings
+
+from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EnterpriseApiClient(BaseOAuthClient):
+    """
+    API client to make calls to edx-enterprise API endpoints.
+    """
+    ENTERPRISE_API_URL = urljoin(settings.LMS_BASE_URL, '/enterprise/api/v1/')
+    CUSTOMER_ENDPOINT = urljoin(ENTERPRISE_API_URL, 'enterprise-customer/')
+
+    def get_enterprise_customer(self, customer_uuid):
+        """
+        Retrieve an Enterprise Customer record from the edx-enterprise API.
+
+        Arguments:
+            customer_uuid: string representation of the customer's uuid
+
+        Returns:
+            enterprise_customer: dictionary record for customer with given uuid or
+                                 empty dictionary if no customer record found
+        """
+        query_params = {'uuid': customer_uuid}
+        response = self.client.get(
+            self.CUSTOMER_ENDPOINT,
+            params=query_params
+        ).json()
+        results = response.get('results', [])
+        enterprise_customer = results[0] if results else {}
+        return enterprise_customer

--- a/enterprise_catalog/apps/api_client/enterprise.py
+++ b/enterprise_catalog/apps/api_client/enterprise.py
@@ -1,11 +1,8 @@
-import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
 
 from enterprise_catalog.apps.api_client.base_oauth import BaseOAuthClient
-
-LOGGER = logging.getLogger(__name__)
 
 
 class EnterpriseApiClient(BaseOAuthClient):

--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -4,9 +4,8 @@ Interface to Enterprise Customer details from edx-enterprise API using a volatil
 from django.conf import settings
 from django.core.cache import cache
 
-from enterprise_catalog.apps.api_client.enterprise import EnterpriseApiClient
-
 from .constants import ENTERPRISE_CUSTOMER_CACHE_KEY_TPL
+from .enterprise import EnterpriseApiClient
 
 
 class EnterpriseCustomerDetails:

--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -26,6 +26,20 @@ class EnterpriseCustomerDetails:
         self.uuid = uuid
         self.customer_data = _get_enterprise_customer_data(uuid)
 
+    @property
+    def learner_portal_enabled(self):
+        """
+        Return if Enterprise Customer Learner Portal is enabled OR False if unavailable.
+        """
+        return self.customer_data.get('enable_learner_portal', False)
+
+    @property
+    def slug(self):
+        """
+        Return Enterprise Customer slug OR empty string if unavailable.
+        """
+        return self.customer_data.get('slug', '')
+
 
 def _get_enterprise_customer_data(uuid):
     """

--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -1,0 +1,51 @@
+"""
+Interface to Enterprise Customer details from edx-enterprise API using a volatile cache.
+"""
+from django.conf import settings
+from django.core.cache import cache
+
+from enterprise_catalog.apps.api_client.enterprise import EnterpriseApiClient
+
+from .constants import ENTERPRISE_CUSTOMER_CACHE_KEY_TPL
+
+
+class EnterpriseCustomerDetails:
+    """
+    Details about an Enterprise Customer from the edx-enterprise API.
+
+    Data is cached for 'settings.ENTERPRISE_CUSTOMER_CACHE_TIMEOUT' seconds.
+    """
+
+    def __init__(self, uuid):
+        """
+        Initialize an Enterprise Customer details instance and load data from
+        cache or by using the Enterprise API client.
+
+        Arguments:
+            uuid (str): Unique identifier for the Enterprise Customer
+        """
+        self.uuid = uuid
+        self.customer_data = _get_enterprise_customer_data(uuid)
+
+
+def _get_enterprise_customer_data(uuid):
+    """
+    Retrieve JSON data containing Enterprise Customer details for given uuid.
+    Look in cache first, make call to Enterprise API Client if not found.
+
+    Arguments:
+        uuid (str): UUID of the Enterprise Customer
+
+    Returns:
+        customer_data (dict): Enterprise Customer details OR
+            Empty dictionary if no data found in cache or from API.
+    """
+    cache_key = ENTERPRISE_CUSTOMER_CACHE_KEY_TPL.format(uuid=uuid)
+    customer_data = cache.get(cache_key)
+    if not isinstance(customer_data, dict):
+        client = EnterpriseApiClient()
+        customer_data = client.get_enterprise_customer(uuid)
+        if not isinstance(customer_data, dict):
+            customer_data = {}
+        cache.set(cache_key, customer_data, settings.ENTERPRISE_CUSTOMER_CACHE_TIMEOUT)
+    return customer_data

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -11,7 +11,7 @@ from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
 class TestDiscoveryApiClient(TestCase):
     """ DiscoveryApiClient tests. """
 
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_metadata_by_query_with_results(self, mock_oauth_client):
         """
         get_metadata_by_query should call discovery endpoint, but not call
@@ -31,7 +31,7 @@ class TestDiscoveryApiClient(TestCase):
         expected_response = [{'key': 'fakeX'}]
         self.assertEqual(actual_response, expected_response)
 
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_metadata_by_query_with_error(self, mock_oauth_client):
         """
         get_metadata_by_query should return None when a call to discovery endpoint fails.
@@ -48,7 +48,7 @@ class TestDiscoveryApiClient(TestCase):
         expected_response = None
         self.assertEqual(actual_response, expected_response)
 
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_courses_with_results(self, mock_oauth_client):
         """
         get_courses should call discovery endpoint to fetch all courses
@@ -66,7 +66,7 @@ class TestDiscoveryApiClient(TestCase):
         expected_response = [{'key': 'fakeX'}]
         self.assertEqual(actual_response, expected_response)
 
-    @mock.patch('enterprise_catalog.apps.api_client.discovery.OAuthAPIClient')
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_courses_with_error(self, mock_oauth_client):
         """
         get_courses should return empty list when a call to discovery endpoint fails.

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -4,8 +4,9 @@ import mock
 from django.test import TestCase
 from simplejson import JSONDecodeError
 
-from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
+
+from ..discovery import DiscoveryApiClient
 
 
 class TestDiscoveryApiClient(TestCase):

--- a/enterprise_catalog/apps/api_client/tests/test_enterprise.py
+++ b/enterprise_catalog/apps/api_client/tests/test_enterprise.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 import ddt
 from django.test import TestCase
 
-from enterprise_catalog.apps.api_client.constants import ENTERPRISE_CUSTOMER_ENDPOINT
-from enterprise_catalog.apps.api_client.enterprise import EnterpriseApiClient
+from ..constants import ENTERPRISE_CUSTOMER_ENDPOINT
+from ..enterprise import EnterpriseApiClient
 
 
 @ddt.ddt

--- a/enterprise_catalog/apps/api_client/tests/test_enterprise.py
+++ b/enterprise_catalog/apps/api_client/tests/test_enterprise.py
@@ -1,0 +1,57 @@
+from unittest import mock
+from uuid import uuid4
+
+import ddt
+from django.test import TestCase
+
+from enterprise_catalog.apps.api_client.constants import ENTERPRISE_CUSTOMER_ENDPOINT
+from enterprise_catalog.apps.api_client.enterprise import EnterpriseApiClient
+
+
+@ddt.ddt
+class TestEnterpriseApiClient(TestCase):
+    """
+    Tests for the edx-enterprise API client.
+    """
+
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
+    @ddt.data(
+        [],
+        [
+            {
+                # 'uuid' is set within test
+                'name': 'Test Enterprise',
+                'slug': 'test-enterprise',
+                'active': True,
+                'enable_learner_portal': True,
+            },
+        ],
+    )
+    def test_get_enterprise_customer(self, mock_response_results, mock_api_client):
+        """
+        Tests get_enterprise_customer when a customer record is or isn't found.
+        """
+        customer_uuid = uuid4()
+        mock_api_client.return_value.get.return_value.json.return_value = {
+            "count": len(mock_response_results),
+            'results': mock_response_results,
+            "num_pages": 1,
+            "next": None,
+            "previous": None,
+            "current_page": 1,
+            "start": 0,
+        }
+        if mock_response_results:
+            mock_response_results[0]['uuid'] = customer_uuid
+
+        client = EnterpriseApiClient()
+        customer_data = client.get_enterprise_customer(customer_uuid)
+
+        mock_api_client.return_value.get.assert_called_with(
+            ENTERPRISE_CUSTOMER_ENDPOINT,
+            params={'uuid': customer_uuid}
+        )
+        if mock_response_results:
+            self.assertEqual(customer_data, mock_response_results[0])
+        else:
+            self.assertEqual(customer_data, {})

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -2,7 +2,6 @@ import mock
 from django.core.management import call_command
 from django.test import TestCase
 
-from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
 from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     EnterpriseCatalogFactory,

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -240,8 +240,8 @@ class EnterpriseCatalog(TimeStampedModel):
         if self.publish_audit_enrollment_urls:
             params['audit'] = 'true'
 
-        enterprise_customer = EnterpriseCustomerDetails(self.enterprise_uuid).customer_data
-        learner_portal_enabled = enterprise_customer.get('enable_learner_portal', False)
+        enterprise_customer = EnterpriseCustomerDetails(self.enterprise_uuid)
+        learner_portal_enabled = enterprise_customer.learner_portal_enabled
         if learner_portal_enabled and content_resource is not PROGRAM:
             # parent_content_key is our way of telling if this is a course run
             # since this function is never called with COURSE_RUN as content_resource
@@ -254,7 +254,7 @@ class EnterpriseCatalog(TimeStampedModel):
                 course_key = content_key
             url = '{}/{}/course/{}'.format(
                 settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
-                enterprise_customer['slug'],
+                enterprise_customer.slug,
                 course_key
             )
         else:

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -22,7 +22,8 @@ from enterprise_catalog.apps.catalog.constants import (
     ACCESS_TO_ALL_ENTERPRISES_TOKEN,
     CONTENT_TYPE_CHOICES,
     COURSE,
-    json_serialized_course_modes, PROGRAM,
+    PROGRAM,
+    json_serialized_course_modes,
 )
 from enterprise_catalog.apps.catalog.utils import (
     get_content_filter_hash,

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -324,6 +324,7 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 # URLs
 LMS_BASE_URL = os.environ.get('LMS_BASE_URL', '')
 DISCOVERY_SERVICE_API_URL = os.environ.get('DISCOVERY_SERVICE_API_URL', '')
+ENTERPRISE_LEARNER_PORTAL_BASE_URL = os.environ.get('ENTERPRISE_LEARNER_PORTAL_BASE_URL', '')
 
 # Algolia
 ALGOLIA = {

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -321,6 +321,10 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
+# How long we keep Enterprise Customer details from edx-enterprise in cache. (seconds)
+# Default = 1 hour.
+ENTERPRISE_CUSTOMER_CACHE_TIMEOUT = 60 * 60
+
 # URLs
 LMS_BASE_URL = os.environ.get('LMS_BASE_URL', '')
 DISCOVERY_SERVICE_API_URL = os.environ.get('DISCOVERY_SERVICE_API_URL', '')

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -52,6 +52,7 @@ ALLOWED_HOSTS = ['*']
 
 LMS_BASE_URL = 'http://edx.devstack.lms:18000'
 DISCOVERY_SERVICE_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
+ENTERPRISE_LEARNER_PORTAL_BASE_URL = 'http://localhost:8734'
 
 CELERYD_HIJACK_ROOT_LOGGER = True
 CELERY_ALWAYS_EAGER = (

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -4,6 +4,7 @@ from enterprise_catalog.settings.base import *
 
 LMS_BASE_URL = 'https://edx.test.lms'
 DISCOVERY_SERVICE_API_URL = 'https://edx.test.discovery/'
+ENTERPRISE_LEARNER_PORTAL_BASE_URL = 'https://edx.test.learnerportal'
 
 # IN-MEMORY TEST DATABASE
 DATABASES = {


### PR DESCRIPTION
## Description

* Added edx-enterprise API Client to retrieve Enterprise Customer records
* Added memcached container to docker-compose file
* Updated get_content_enrollment_url to return LP course page if LP enabled
* Added EnterpriseCustomerDetails interface for caching Enterprise Customer data

## Associated PRs

* https://github.com/edx/frontend-app-learner-portal-enterprise/pull/91
* https://github.com/edx/edx-internal/pull/2943

## Ticket Link

[ENT-3363](https://openedx.atlassian.net/browse/ENT-3363)

## Testing Instructions

### Containers you will need running: 
* Course Discovery
* LMS
* Enterprise Catalog
* Enterprise Learner Portal (LP)

### Enterprise Catalog Testing
Ensure the content metadata existing in your devstack has been migrated to your enterprise-catalog container. If not, run the `update_content_metadata` management command from your enterprise-catalog app shell. 

Lookup the UUID for a catalog associated with your Test Enterprise and ensure its LP is enabled. Hit the get_content_metadata endpoint in enterprise-catalog. Example URL: `http://localhost:18160/api/v1/enterprise-catalogs/<uuid>/get_content_metadata/`

Inspect the value for the `enrollment_url` key in each content item. The enrollment URL for Courses should point to the LP course page with UTM params, for Course Runs should point to the LP course page for the parent course with a `course_run_id` param and UTM params, and for Programs should be blank.

### Learner Portal Testing
**You will need an Enterprise Learner that is not yet enrolled in your local demonstration course.** Link the learner to your Test Enterprise and assign an Activated License to their email address.

**You will also need your demonstration course to have multiple course runs.** Navigate to the Discovery service Django Admin page ( localhost:18381/admin ). Create 2 new course runs for the demonstration course using the existing course run as prior art - I suggest using various start dates and prices (this will come in handy later). [Reindex elasticssearch for the Discovery service](https://github.com/edx/course-discovery#using-elasticsearch-locally). Use the update_content_metadata management command from the enterprise-catalog app shell to fetch the newly created course runs.

Use each enrollment_url for your demonstration course and new course runs. Observe the start date and price on the LP Course Page for each URL to verify that the data used for the page is correctly updated. 

Enrollment will fail due to the way course run data was created, that is expected. Publisher should have been used to create course runs in a way that would be fully testable - full enrollment will be tested on stage. Still, attempt to enroll and observe the failure flow correctly redirect you back to the LP course page with the 'enrollment_failed' param in the URL and the enrollment failure message rendered at the top. 

## Post-review

Squash commits into discrete sets of changes
