### PR TITLE
upgrade celery to 4.2.2

### DIFF
--- a/enterprise_catalog/celery.py
+++ b/enterprise_catalog/celery.py
@@ -9,7 +9,8 @@ app = Celery('enterprise_catalog', )
 
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.config_from_object(settings)
+app.conf.task_protocol = 1
+app.config_from_object('django.conf:settings')
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -1,6 +1,7 @@
 import os
 
 from enterprise_catalog.settings.base import *
+import tempfile
 
 LMS_BASE_URL = 'https://edx.test.lms'
 DISCOVERY_SERVICE_API_URL = 'https://edx.test.discovery/'
@@ -21,3 +22,6 @@ DATABASES = {
 # CELERY
 CELERY_ALWAYS_EAGER = True
 # END CELERY
+
+results_dir = tempfile.TemporaryDirectory()
+CELERY_RESULT_BACKEND = 'file://{}'.format(results_dir.name)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -21,10 +21,10 @@ edx-rest-api-client==1.9.2
 mysqlclient
 pytz
 jsonfield2==3.0.3
-celery==3.1.26.post2
-redis==2.8
+celery
+redis
 rules
 zipp<2.0
 algoliasearch
 langcodes
-edx-celeryutils
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2   # celery-utils has upgrade celery version and it can break other services

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/base.in
 algoliasearch==2.4.0      # via -r requirements/base.in
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
-billiard==3.3.0.23        # via celery
-celery==3.1.26.post2      # via -r requirements/base.in, edx-celeryutils
+amqp==2.6.1               # via kombu
+billiard==3.5.0.5         # via celery
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
 cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
@@ -28,7 +28,6 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.11.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.1           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
-edx-celeryutils==0.5.1    # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.7.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
@@ -40,7 +39,7 @@ idna==2.10                # via requests
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
-kombu==3.0.37             # via celery
+kombu==4.3.0              # via celery
 langcodes==2.0.0          # via -r requirements/base.in
 marisa-trie==0.7.5        # via langcodes
 markupsafe==1.1.1         # via jinja2
@@ -59,7 +58,7 @@ python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django
 pyyaml==5.3.1             # via edx-django-release-util
-redis==2.8                # via -r requirements/base.in
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -74,4 +73,5 @@ sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.10          # via requests
+vine==1.3.0               # via amqp
 zipp==1.2.0               # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,3 +18,8 @@ social-auth-core<3.3.0
 
 # pinned until https://github.com/datadriventests/ddt/issues/83 is resolved
 ddt<1.4.0
+
+
+celery<4.3     # Python 3.8 isn't officially supported until 4.4 and 4.3 requires redis version 3.2.0 or above.
+
+redis==3.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,6 @@ social-auth-core<3.3.0
 ddt<1.4.0
 
 
-celery<4.3     # Python 3.8 isn't officially supported until 4.4 and 4.3 requires redis version 3.2.0 or above.
+celery<4.3     # Python 3.8 isn't officially supported until 4.4. Its a first steps towards latest celery version upgrade.
 
-redis==3.2.0
+redis==3.2.0   # celery 4.2.2 is working fine with the version. Further upgrades will be done in next PR.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,14 +4,14 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/quality.txt, -r requirements/test.txt
 algoliasearch==2.4.0      # via -r requirements/quality.txt, -r requirements/test.txt
-amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
-billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/quality.txt, -r requirements/test.txt, celery
+celery==4.2.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
@@ -40,7 +40,6 @@ djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requiremen
 djangorestframework==3.11.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-celeryutils==0.5.1    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.7.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
@@ -64,7 +63,7 @@ itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/tes
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
+kombu==4.3.0              # via -r requirements/quality.txt, -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/quality.txt, -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 marisa-trie==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, langcodes
@@ -107,7 +106,7 @@ python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
-redis==2.8                # via -r requirements/quality.txt, -r requirements/test.txt
+redis==3.2.0              # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -127,6 +126,7 @@ tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, requests
+vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp
 virtualenv==20.0.31       # via -r requirements/test.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/test.txt
 alabaster==0.7.12         # via sphinx
 algoliasearch==2.4.0      # via -r requirements/test.txt
-amqp==1.4.9               # via -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-billiard==3.3.0.23        # via -r requirements/test.txt, celery
+billiard==3.5.0.5         # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-celery==3.1.26.post2      # via -r requirements/test.txt, edx-celeryutils
+celery==4.2.2             # via -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
@@ -43,7 +43,6 @@ doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.17.1           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
-edx-celeryutils==0.5.1    # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.7.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
@@ -65,7 +64,7 @@ isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jsonfield2==3.0.3         # via -r requirements/test.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/test.txt, celery
+kombu==4.3.0              # via -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 marisa-trie==0.7.5        # via -r requirements/test.txt, langcodes
@@ -103,7 +102,7 @@ python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, babel, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
 readme-renderer==26.0     # via -r requirements/doc.in
-redis==2.8                # via -r requirements/test.txt
+redis==3.2.0              # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
@@ -131,6 +130,7 @@ tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/test.txt, requests
+vine==1.3.0               # via -r requirements/test.txt, amqp
 virtualenv==20.0.31       # via -r requirements/test.txt, tox
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/base.txt
 algoliasearch==2.4.0      # via -r requirements/base.txt
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
+amqp==2.6.1               # via -r requirements/base.txt, kombu
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+celery==4.2.2             # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -28,7 +28,6 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
@@ -43,7 +42,7 @@ idna==2.10                # via -r requirements/base.txt, requests
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
@@ -63,7 +62,7 @@ python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
-redis==2.8                # via -r requirements/base.txt
+redis==3.2.0              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -78,6 +77,7 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 zipp==1.2.0               # via -r requirements/base.txt
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,12 +4,12 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/base.txt
 algoliasearch==2.4.0      # via -r requirements/base.txt
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
+amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+celery==4.2.2             # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -31,7 +31,6 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
@@ -45,7 +44,7 @@ isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
@@ -72,7 +71,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
-redis==2.8                # via -r requirements/base.txt
+redis==3.2.0              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -89,5 +88,6 @@ stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,14 +4,14 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/base.txt
 algoliasearch==2.4.0      # via -r requirements/base.txt
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
+amqp==2.6.1               # via -r requirements/base.txt, kombu
 appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.1.0             # via pytest
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -37,7 +37,6 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
@@ -57,7 +56,7 @@ isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
@@ -93,7 +92,7 @@ python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
-redis==2.8                # via -r requirements/base.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -112,6 +111,7 @@ tox==3.19.0               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 virtualenv==20.0.31       # via tox
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1999
Upgrade celery to 4.2.2
Using edx-celery-utils hash instead of releasing it.
upgrade redis redis==3.1.0   

@jmbowman instead of releasing the edx-celery-utils I am using hash. That packages is in use at several places and releasing is risky.

**NOTE: Before merging this branch deploy this [PR](https://github.com/edx/enterprise-catalog/pull/170/files) on prod**