### PR TITLE
Upgrade celery to 4.4.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,8 +7,8 @@
 -e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/base.in
 algoliasearch==2.4.0      # via -r requirements/base.in
 amqp==2.6.1               # via kombu
-billiard==3.5.0.5         # via celery
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
+billiard==3.6.3.0         # via celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
 cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
@@ -18,7 +18,7 @@ cryptography==3.1         # via pyjwt
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.in
 django-crum==0.7.7        # via -r requirements/base.in, edx-rbac
-django-extensions==3.0.5  # via -r requirements/base.in
+django-extensions==3.0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
@@ -36,10 +36,11 @@ edx-rbac==1.3.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils, pyjwkest
 idna==2.10                # via requests
+importlib-metadata==1.7.0  # via kombu
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
-kombu==4.3.0              # via celery
+kombu==4.6.11             # via celery
 langcodes==2.0.0          # via -r requirements/base.in
 marisa-trie==0.7.5        # via langcodes
 markupsafe==1.1.1         # via jinja2
@@ -58,7 +59,7 @@ python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django
 pyyaml==5.3.1             # via edx-django-release-util
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.in
+redis==3.5.3              # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -73,5 +74,5 @@ sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.10          # via requests
-vine==1.3.0               # via amqp
-zipp==1.2.0               # via -r requirements/base.in
+vine==1.3.0               # via amqp, celery
+zipp==1.2.0               # via -r requirements/base.in, importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,4 @@ social-auth-core<3.3.0
 ddt<1.4.0
 
 
-celery<4.3     # Python 3.8 isn't officially supported until 4.4. Its a first steps towards latest celery version upgrade.
-
-redis==3.2.0   # celery 4.2.2 is working fine with the version. Further upgrades will be done in next PR.
+celery<5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,8 +10,8 @@ amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/tes
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
-billiard==3.5.0.5         # via -r requirements/quality.txt, -r requirements/test.txt, celery
-celery==4.2.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/quality.txt, -r requirements/test.txt, celery
+celery==4.4.7             # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
@@ -24,13 +24,13 @@ coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 cryptography==3.1         # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
 ddt==1.3.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
-diff-cover==3.0.1         # via -r requirements/dev.in
+diff-cover==4.0.0         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.5.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.5  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.6  # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
@@ -54,7 +54,7 @@ filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
 idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/test.txt, inflect, kombu, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
@@ -63,14 +63,14 @@ itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/tes
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/quality.txt, -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/quality.txt, -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/quality.txt, -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 marisa-trie==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
 newrelic==5.16.2.147      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
@@ -88,7 +88,7 @@ py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
-pydocstyle==5.1.0         # via -r requirements/quality.txt
+pydocstyle==5.1.1         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
@@ -106,14 +106,14 @@ python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-release-util, edx-i18n-tools
-redis==3.2.0              # via -r requirements/quality.txt, -r requirements/test.txt
+redis==3.5.3              # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
@@ -126,7 +126,7 @@ tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp
+vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp, celery
 virtualenv==20.0.31       # via -r requirements/test.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,9 +12,9 @@ appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-billiard==3.5.0.5         # via -r requirements/test.txt, celery
+billiard==3.6.3.0         # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-celery==4.2.2             # via -r requirements/test.txt, edx-celeryutils
+celery==4.4.7             # via -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
@@ -31,7 +31,7 @@ distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.5.0  # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.5  # via -r requirements/test.txt
+django-extensions==3.0.6  # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
@@ -57,21 +57,21 @@ filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, kombu, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jsonfield2==3.0.3         # via -r requirements/test.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/test.txt, celery
 langcodes==2.0.0          # via -r requirements/test.txt
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 marisa-trie==0.7.5        # via -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/test.txt
 newrelic==5.16.2.147      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
@@ -102,7 +102,7 @@ python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, babel, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
 readme-renderer==26.0     # via -r requirements/doc.in
-redis==3.2.0              # via -r requirements/test.txt
+redis==3.5.3              # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
@@ -130,7 +130,7 @@ tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp
+vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 virtualenv==20.0.31       # via -r requirements/test.txt, tox
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,8 +7,8 @@
 -e git+https://github.com/edx/edx-celeryutils.git@7ec43c5a9f5611b03d9b64b163a5c76165191162#egg=edx-celeryutils==0.5.2  # via -r requirements/base.txt
 algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==2.6.1               # via -r requirements/base.txt, kombu
-billiard==3.5.0.5         # via -r requirements/base.txt, celery
-celery==4.2.2             # via -r requirements/base.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+celery==4.4.7             # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -18,7 +18,7 @@ cryptography==3.1         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.5  # via -r requirements/base.txt
+django-extensions==3.0.6  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
@@ -39,10 +39,11 @@ gevent==20.6.2            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
@@ -62,7 +63,7 @@ python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
-redis==3.2.0              # via -r requirements/base.txt
+redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -77,8 +78,8 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp
-zipp==1.2.0               # via -r requirements/base.txt
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,8 +8,8 @@
 algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-billiard==3.5.0.5         # via -r requirements/base.txt, celery
-celery==4.2.2             # via -r requirements/base.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+celery==4.4.7             # via -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -21,7 +21,7 @@ cryptography==3.1         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.5  # via -r requirements/base.txt
+django-extensions==3.0.6  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
@@ -40,11 +40,12 @@ edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
@@ -59,7 +60,7 @@ psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
-pydocstyle==5.1.0         # via -r requirements/quality.in
+pydocstyle==5.1.1         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
@@ -71,7 +72,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
-redis==3.2.0              # via -r requirements/base.txt
+redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -88,6 +89,6 @@ stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,8 +10,8 @@ amqp==2.6.1               # via -r requirements/base.txt, kombu
 appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.1.0             # via pytest
-billiard==3.5.0.5         # via -r requirements/base.txt, celery
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -28,7 +28,7 @@ distlib==0.3.1            # via virtualenv
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.5  # via -r requirements/base.txt
+django-extensions==3.0.6  # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
@@ -49,21 +49,21 @@ faker==4.1.2              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 langcodes==2.0.0          # via -r requirements/base.txt
 lazy-object-proxy==1.4.3  # via astroid
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.4.0     # via pytest
+more-itertools==8.5.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.16.2.147      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
@@ -92,7 +92,7 @@ python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -111,7 +111,7 @@ tox==3.19.0               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 virtualenv==20.0.31       # via tox
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
BOM-1999

Upgrade celery to 4.4.7
upgrade redis.

## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
