### PR TITLE
ARCHBOM-1488: Standardizing build tags and exposed ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,8 @@ FROM app as newrelic
 RUN pip3 install newrelic
 CMD ["newrelic-admin", "run-program", "gunicorn", "--workers=2", "--name", "enterprise_catalog", "-c", "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/docker_gunicorn_configuration.py", "--log-file", "-", "--max-requests=1000", "enterprise_catalog.wsgi:application"]
 
-FROM app as devapp
-# Dev ports
-EXPOSE 18160
-EXPOSE 18161
+FROM app as devstack
 USER root
 RUN pip3 install -r /edx/app/enterprise_catalog/enterprise_catalog/requirements/dev.txt
 USER app
-CMD ["gunicorn", "--reload", "--workers=2", "--name", "enterprise_catalog", "-b", ":18160", "-c", "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/docker_gunicorn_configuration.py", "--log-file", "-", "--max-requests=1000", "enterprise_catalog.wsgi:application"]
+CMD ["gunicorn", "--reload", "--workers=2", "--name", "enterprise_catalog", "-b", ":8160", "-c", "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/docker_gunicorn_configuration.py", "--log-file", "-", "--max-requests=1000", "enterprise_catalog.wsgi:application"]

--- a/Makefile
+++ b/Makefile
@@ -184,21 +184,25 @@ attach: ## Runs docker attach enterprise.catalog.app
 	docker attach enterprise.catalog.app
 
 docker_build: ## Builds with the latest enterprise catalog
-	docker build . --target app -t "openedx/enterprise-catalog:latest"
-	docker build . --target newrelic -t "openedx/enterprise-catalog:latest-newrelic"
+	docker build . --target app -t openedx/enterprise-catalog:latest
+	docker build . --target devstack -t openedx/enterprise-catalog:latest-devstack
+	docker build . --target newrelic -t openedx/enterprise-catalog:latest-newrelic
 
 travis_docker_auth:
 	echo "$$DOCKER_PASSWORD" | docker login -u "$$DOCKER_USERNAME" --password-stdin
 
 travis_docker_tag: docker_build
-	docker build . --target app -t "openedx/enterprise-catalog:$$TRAVIS_COMMIT"
-	docker build . --target newrelic -t "openedx/enterprise-catalog:$$TRAVIS_COMMIT-newrelic"
+	docker tag openedx/enterprise-catalog:latest openedx/enterprise-catalog:${GITHUB_SHA}
+	docker tag openedx/enterprise-catalog:latest-devstack openedx/enterprise-catalog:${GITHUB_SHA}-devstack
+	docker tag openedx/enterprise-catalog:latest-newrelic openedx/enterprise-catalog:${GITHUB_SHA}-newrelic
 
 travis_docker_push: travis_docker_tag travis_docker_auth ## push to docker hub
-	docker push "openedx/enterprise-catalog:latest"
-	docker push "openedx/enterprise-catalog:$$TRAVIS_COMMIT"
-	docker push "openedx/enterprise-catalog:latest-newrelic"
-	docker push "openedx/enterprise-catalog:$$TRAVIS_COMMIT-newrelic"
+	docker push openedx/enterprise-catalog:latest
+	docker push openedx/enterprise-catalog:${GITHUB_SHA}
+	docker push openedx/enterprise-catalog:latest-devstack
+	docker push openedx/enterprise-catalog:${GITHUB_SHA}-devstack
+	docker push openedx/enterprise-catalog:latest-newrelic
+	docker push openedx/enterprise-catalog:${GITHUB_SHA}-newrelic
 
 shellcheck:
 	shellcheck *.sh -x

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - .:/edx/app/enterprise_catalog/enterprise_catalog
       - ../src:/edx/src:cached
     ports:
-      - "18160:18160"
+      - "8160:8160"
     depends_on:
       - discovery
       - worker
@@ -55,7 +55,7 @@ services:
       DJANGO_SETTINGS_MODULE: enterprise_catalog.settings.devstack
     hostname: worker.catalog.enterprise
     ports:
-      - "18161:18161"
+      - "8161:8161"
     restart: always
     # Allows attachment to this container using 'docker attach <containerID>'.
     stdin_open: true
@@ -78,7 +78,7 @@ services:
       DJANGO_WATCHMAN_TIMEOUT: 30
     image: kdmccormick96/course-discovery:latest
     ports:
-      - "18381:18381"
+      - "8381:1381"
     volumes:
       - discovery_assets:/edx/var/discovery/
 
@@ -105,7 +105,7 @@ services:
     # TODO(jinder): I temporarily put a "-devstack" below, it was necessary to run locally, there must be a better way
     image: kdmccormick96/edx-platform:latest-devstack
     ports:
-      - "18000:18000"
+      - "8000:8000"
     volumes:
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
 


### PR DESCRIPTION
docker targets in Makefile have been modified to match standards.

Exposed port for devstack is now **** instead of 1****. This will match port in production.

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ARCHBOM-1488)
