### PR TITLE
Script robustness improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ dev.up.build:  ## Runs docker-compose -up -d --build
 	docker-compose up -d --build
 
 dev.down: ## Kills containers and all of their data that isn't in volumes
-	docker-compose downing
+	docker-compose down
 
 dev.destroy: dev.down ## Kills containers and destroys volumes. If you get an error after running this, also run: docker volume rm portal-designer_designer_mysql
 	docker volume rm enterprise-catalog_enterprise_catalog_mysql
@@ -205,4 +205,4 @@ travis_docker_push: travis_docker_tag travis_docker_auth ## push to docker hub
 	docker push openedx/enterprise-catalog:${GITHUB_SHA}-newrelic
 
 shellcheck:
-	shellcheck *.sh -x
+	shellcheck --external-sources decentralized_devstack/*.sh

--- a/decentralized_devstack/provision.sh
+++ b/decentralized_devstack/provision.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
+# Change working directory to the root of the repo
+DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"; pwd)"
+cd -- "$DIR"/..
+
 # Include utilities.
+# shellcheck source=provisioning-utils.sh
 source decentralized_devstack/provisioning-utils.sh
 
 log_step "Starting provisioning process..."

--- a/docs/getting_started_with_decentralized_devstack.rst
+++ b/docs/getting_started_with_decentralized_devstack.rst
@@ -18,7 +18,6 @@ Initialize and Provision
 
     .. code-block:: bash
 
-        $ docker-compose pull --include-deps app && docker ps
         $ ./decentralized_devstack/provision.sh
 
 Viewing Enterprise Catalog


### PR DESCRIPTION
Safer argument handling in provisioning utils file:

- Use command directly with `exec` rather than indirection through bash
- Use `$@` rather than `$*` so we can quote the args
- Use an array for service variant so it can be included as an arg rather
  than spliced in (not strictly necessary, but the alternative was a bare
  variable that people would be tempted to quote, which would then break)
- Pipe python code into `service_exec` rather than having to escape it as
  an argument

And some miscellaneous fixes:

- Fix typo in Makefile
- Point shellcheck at moved scripts, and use full option name for clarity
- Set working directory in scripts so they can be called from any directory
- Fix shellcheck warning
- Re-remove line in instructions