### PR TITLE
Adding target to docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,12 @@
 version: "3.7"
 
-# TODO: Stop naming containers.
-
 services:
 
   app:
-    # Uncomment this line to use the official catalog base image
-    # image: edxops/enterprise_catalog:devstack
+    image: openedx/enterprise_catalog:latest-devstack
     build:
       context: "."
       target: devstack
-    image: kdmccormick96/enterprise-catalog  # TODO: Change to openedx.
     container_name: edx.devstack.enterprise-catalog
     hostname: app.catalog.enterprise
     volumes:
@@ -36,12 +32,10 @@ services:
       ENABLE_DJANGO_TOOLBAR: 1
 
   worker:
-    # Uncomment this line to use the official catalog base image
-    # image: edxops/enterprise_catalog:devstack
+    image: openedx/enterprise_catalog:latest-devstack
     build:
       context: "."
       target: devstack
-    image: kdmccormick96/enterprise-catalog  # TODO: Change to openedx.
     command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG'
     container_name: edx.devstack.enterprise-catalog-worker
     depends_on:
@@ -66,6 +60,7 @@ services:
       - .:/edx/app/enterprise_catalog/enterprise_catalog
 
   discovery:
+    image: openedx/discovery:latest-devstack
     container_name: edx.devstack.discovery
     hostname: discovery.devstack.edx
     depends_on:
@@ -78,7 +73,6 @@ services:
     environment:
       TEST_ELASTICSEARCH_URL: http://edx.devstack.elasticsearch:9200
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: kdmccormick96/course-discovery:latest
     ports:
       - "8381:1381"
     volumes:
@@ -93,6 +87,7 @@ services:
       - elasticsearch_data:/usr/share/elasticsearch/logs
 
   lms:
+    image: openedx/edx-platform:latest-devstack
     container_name: edx.devstack.lms
     hostname: lms.devstack.edx
     depends_on:
@@ -104,8 +99,6 @@ services:
     environment:
       NO_INSTALL_PREREQS: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    # TODO(jinder): I temporarily put a "-devstack" below, it was necessary to run locally, there must be a better way
-    image: kdmccormick96/edx-platform:latest-devstack
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.7"
 services:
 
   app:
-    image: openedx/enterprise_catalog:latest-devstack
     build:
       context: "."
       target: devstack
@@ -32,7 +31,6 @@ services:
       ENABLE_DJANGO_TOOLBAR: 1
 
   worker:
-    image: openedx/enterprise_catalog:latest-devstack
     build:
       context: "."
       target: devstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     # image: edxops/enterprise_catalog:devstack
     build:
       context: "."
+      target: devstack
     image: kdmccormick96/enterprise-catalog  # TODO: Change to openedx.
     container_name: edx.devstack.enterprise-catalog
     hostname: app.catalog.enterprise
@@ -39,6 +40,7 @@ services:
     # image: edxops/enterprise_catalog:devstack
     build:
       context: "."
+      target: devstack
     image: kdmccormick96/enterprise-catalog  # TODO: Change to openedx.
     command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG'
     container_name: edx.devstack.enterprise-catalog-worker


### PR DESCRIPTION
This would allow us to build service images with "docker-compose build". And changed images to point to openedx instead of kdmccormick dockerhub
