### PR TITLE
Partial revert of 0b6d22e09f3580 -- Mac Bash complains about empty array

### DIFF
--- a/decentralized_devstack/provisioning-utils.sh
+++ b/decentralized_devstack/provisioning-utils.sh
@@ -63,13 +63,15 @@ service_exec_management(){
 	service="$1"
 	shift
 	# If LMS/Studio, handle weird manage.py that expects lms/cms argument.
-        declare -a edxapp_service_args
 	if [[ "$service" == lms ]]; then
-		edxapp_service_args=(lms)
+		edxapp_service_variant=lms
 	elif [[ "$service" == studio ]]; then
-		edxapp_service_args=(cms)
+		edxapp_service_variant=cms
+	else
+		edxapp_service_variant=""
 	fi
-	service_exec "$service" python ./manage.py "${edxapp_service_args[@]}" "$@"
+	# $edxapp_service_variant has to be unquoted here
+	service_exec "$service" python ./manage.py $edxapp_service_variant "$@"
 }
 
 # Execute Python code through the Django shell of a service's container.
@@ -81,13 +83,15 @@ service_exec_python(){
 	service="$1"
 	python_code="$2"
 	# If LMS/Studio, handle weird manage.py that expects lms/cms argument.
-        declare -a edxapp_service_args
 	if [[ "$service" == lms ]]; then
-		edxapp_service_args=(lms)
+		edxapp_service_variant=lms
 	elif [[ "$service" == studio ]]; then
-		edxapp_service_args=(cms)
+		edxapp_service_variant=cms
+	else
+		edxapp_service_variant=""
 	fi
-	echo "${python_code}" | service_exec "$service" python ./manage.py "${edxapp_service_args[@]}" shell
+	# $edxapp_service_variant has to be unquoted here
+	echo "${python_code}" | service_exec "$service" python ./manage.py $edxapp_service_variant shell
 }
 
 # TODO document


### PR DESCRIPTION
People on Mac were getting `edxapp_service_args[@]: unbound variable`
even though that was working on Linux; this is likely due to Apple
packaging an older version of Bash where `-u` treats empty arrays as unset.

This restores the use of an unquoted variable but adds a comment to warn
people away from quoting it.