### PR TITLE
Add get_catalog_list option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ style: ## run Python style checker
 lint: ## run Python code linting
 	pylint --rcfile=pylintrc enterprise_catalog *.py
 
-quality: style isort_check lint ## check code style and import sorting, then lint
+quality: travis_clean style isort_check lint ## check code style and import sorting, then lint
 
 pii_check: ## check for PII annotations on all Django models
 	DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.test \
@@ -179,6 +179,9 @@ docker_build: ## Builds with the latest enterprise catalog
 	docker build . --target app -t openedx/enterprise-catalog:latest
 	docker build . --target devstack -t openedx/enterprise-catalog:latest-devstack
 	docker build . --target newrelic -t openedx/enterprise-catalog:latest-newrelic
+
+travis_clean:
+	find . -name '*.pyc' -delete
 
 travis_docker_auth:
 	echo "$$DOCKER_PASSWORD" | docker login -u "$$DOCKER_USERNAME" --password-stdin

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -912,7 +912,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
 
     def test_contains_catalog_list_parent_key(self):
         """
-        Verify the contains_content_items endpoint returns a list of catalogs the course is in for multiple catalogs
+        Verify the contains_content_items endpoint returns a list of catalogs the course is in
         """
         content_metadata = ContentMetadataFactory()
         self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -890,9 +890,10 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         response = self.client.get(url)
         assert 'catalog_list' not in response.json().keys()
 
-    def test_contains_catalog_list_parent_key(self):
+    def test_contains_catalog_list(self):
         """
-        Verify the contains_content_items endpoint returns a list of catalogs the course is in if the correct parameter is passed
+        Verify the contains_content_items endpoint returns a list of catalogs the course is in if the correct
+        parameter is passed
         """
         content_metadata = ContentMetadataFactory()
         self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])
@@ -929,7 +930,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
 
         url = self._get_contains_content_base_url() + '?course_run_ids=' + parent_content_key + '&get_catalog_list=True'
         response = self.client.get(url).json()
-        assert response['contains_content_items'] == True
+        assert response['contains_content_items'] is True
         catalog_list = response['catalog_list']
         assert set(catalog_list) == set([str(second_catalog.uuid), str(third_catalog.uuid)])
 

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -796,6 +796,13 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         # Set up catalog.has_learner_access permissions
         self.set_up_catalog_learner()
 
+    def tearDown(self):
+        super(EnterpriseCustomerViewSetTests, self).tearDown()
+        # clean up any stale test objects
+        CatalogQuery.objects.all().delete()
+        ContentMetadata.objects.all().delete()
+        EnterpriseCatalog.objects.all().delete()
+
     def _get_contains_content_base_url(self, enterprise_uuid=None):
         """
         Helper to construct the base url for the contains_content_items endpoint
@@ -866,3 +873,76 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
 
         url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key
         self.assert_correct_contains_response(url, True)
+
+    def test_no_catalog_list_given_without_get_catalog_list_query(self):
+        """
+        Verify that the contains_content_items endpoint does not return a list of catalogs without a querystring
+        """
+        content_metadata = ContentMetadataFactory()
+        self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])
+
+        # Create a second catalog that has the content we're looking for
+        content_key = 'fake-key+101x'
+        second_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+        relevant_content = ContentMetadataFactory(content_key=content_key)
+        self.add_metadata_to_catalog(second_catalog, [relevant_content])
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key
+        response = self.client.get(url)
+        assert 'catalog_list' not in response.json().keys()
+
+    def test_contains_catalog_list_parent_key(self):
+        """
+        Verify the contains_content_items endpoint returns a list of catalogs the course is in if the correct parameter is passed
+        """
+        content_metadata = ContentMetadataFactory()
+        self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])
+
+        # Create a two catalogs that have the content we're looking for
+        content_key = 'fake-key+101x'
+        second_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+        relevant_content = ContentMetadataFactory(content_key=content_key)
+        self.add_metadata_to_catalog(second_catalog, [relevant_content])
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + '&get_catalog_list=True'
+        self.assert_correct_contains_response(url, True)
+
+        response = self.client.get(url)
+        catalog_list = response.json()['catalog_list']
+        assert set(catalog_list) == set([str(second_catalog.uuid)])
+
+    def test_contains_catalog_list_parent_key(self):
+        """
+        Verify the contains_content_items endpoint returns a list of catalogs the course is in for multiple catalogs
+        """
+        content_metadata = ContentMetadataFactory()
+        self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])
+
+        # Create a two catalogs that have the content we're looking for
+        parent_content_key = 'fake-parent-key+105x'
+        content_key = 'fake-key+101x'
+        second_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+        relevant_content = ContentMetadataFactory(content_key=content_key, parent_content_key=parent_content_key)
+        self.add_metadata_to_catalog(second_catalog, [relevant_content])
+        content_key_2 = 'fake-key+102x'
+        third_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+        relevant_content = ContentMetadataFactory(content_key=content_key_2, parent_content_key=parent_content_key)
+        self.add_metadata_to_catalog(third_catalog, [relevant_content])
+
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + parent_content_key + '&get_catalog_list=True'
+        response = self.client.get(url).json()
+        assert response['contains_content_items'] == True
+        catalog_list = response['catalog_list']
+        assert set(catalog_list) == set([str(second_catalog.uuid), str(third_catalog.uuid)])
+
+    def test_contains_catalog_list_content_items_not_in_catalog(self):
+        """
+        Verify the contains_content_items endpoint returns a list of catalogs the course is in for multiple catalogs
+        """
+        content_metadata = ContentMetadataFactory()
+        self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])
+
+        content_key = 'fake-key+101x'
+
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + '&get_catalog_list=True'
+        response = self.client.get(url)
+        catalog_list = response.json()['catalog_list']
+        assert catalog_list == []

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -281,6 +281,17 @@ class EnterpriseCustomerViewSet(BaseViewSet):
     def contains_content_items(self, request, enterprise_uuid, course_run_ids, program_uuids, **kwargs):
         """
         Returns whether or not the specified content is available for the given enterprise.
+        ---
+        parameters:
+            - name: course_run_ids
+              description: Ids of the course runs to check availability of
+              paramType: query
+            - name: program_uuids
+              description: Uuids of the programs to check availability of
+              paramType: query
+            - name: get_catalog_list
+              description: Return a list of catalogs in which the course / program is present
+              paramType: query
         """
         get_catalog_list = request.GET.get('get_catalog_list', False)
         course_run_ids = unquote_course_keys(course_run_ids)

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -6,9 +6,14 @@ from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     EnterpriseCatalogFactory,
 )
+from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     EnterpriseCatalog,
+)
+from enterprise_catalog.apps.catalog.tests.factories import (
+    CatalogQueryFactory,
+    EnterpriseCatalogFactory,
 )
 
 

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -2,10 +2,6 @@ import mock
 from django.core.management import call_command
 from django.test import TestCase
 
-from enterprise_catalog.apps.catalog.tests.factories import (
-    CatalogQueryFactory,
-    EnterpriseCatalogFactory,
-)
 from enterprise_catalog.apps.api.tasks import update_catalog_metadata_task
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -6,10 +6,20 @@ from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     EnterpriseCatalogFactory,
 )
+from enterprise_catalog.apps.catalog.models import (
+    ContentMetadata,
+    EnterpriseCatalog,
+)
 
 
 class UpdateContentMetadataCommandTests(TestCase):
     command_name = 'update_content_metadata'
+
+    def tearDown(self):
+        super(UpdateContentMetadataCommandTests, self).tearDown()
+        # clean up any stale test objects
+        ContentMetadata.objects.all().delete()
+        EnterpriseCatalog.objects.all().delete()
 
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.chord')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -29,7 +29,7 @@ class CatalogQueryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CatalogQuery
 
-    content_filter = factory.Dict({'content_type': factory.Faker('word')})
+    content_filter = factory.Dict({'content_type': factory.Faker('words', nb=3)})
 
 
 class EnterpriseCatalogFactory(factory.django.DjangoModelFactory):

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -62,4 +62,7 @@ CELERY_ALWAYS_EAGER = (
 CORS_ORIGIN_WHITELIST = [
     # Enterprise learner portal MFE
     'http://localhost:8734',
+    'http://localhost:18160',
+    'http://localhost:18000',
+    'http://localhost:18130',
 ]


### PR DESCRIPTION
## Description

Adds an option to the endpoint to see if content is available that returns a list of what catalogs the content is available for. This will allow us to ensure that we are applying the correct coupon for a course.
Fixes intermittently failing tests.
Adds more services to the CORS whitelist for development (necessary for testing with the frontend.)

## Ticket Link

Link to the associated ticket
[ENT-3238](https://openedx.atlassian.net/browse/ENT-3238)

## Post-review

Squash commits into discrete sets of changes
