### PR TITLE
Adding redis as dependency to worker

### DIFF
--- a/decentralized-docker-compose.yml
+++ b/decentralized-docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - discovery
       - lms
       - mysql
+      - redis
     environment:
       CELERY_ALWAYS_EAGER: 'false'
       CELERY_BROKER_TRANSPORT: redis


### PR DESCRIPTION
Worker is failing in decentralized devstack without redis, this should fix that.