### PR TITLE
give entcatalog001* user access to test_enterprise_catalog database

### DIFF
--- a/decentralized-docker-compose.yml
+++ b/decentralized-docker-compose.yml
@@ -15,9 +15,10 @@ services:
       - "8160:8160"
     depends_on:
       - discovery
-      - worker
       - lms
       - mysql
+      - redis
+      - worker
     # Allows attachment to this container using 'docker attach <containerID>'.
     stdin_open: true
     tty: true

--- a/decentralized_devstack/provision-mysql-app.sql
+++ b/decentralized_devstack/provision-mysql-app.sql
@@ -3,4 +3,6 @@ FLUSH PRIVILEGES;
 CREATE DATABASE IF NOT EXISTS enterprise_catalog;
 GRANT ALL ON enterprise_catalog.* TO 'entcatalog001'@'%' IDENTIFIED BY 'password';
 
+GRANT ALL ON test_enterprise_catalog.* TO 'entcatalog001'@'%' IDENTIFIED BY 'password';
+
 FLUSH PRIVILEGES;


### PR DESCRIPTION
Without this, make test would fail all tests with following error:
`Got an error creating the test database: (1044, "Access denied for user 'entcatalog001'@'%' to database 'test_enterprise_catalog'")`

There is probably a better ways to fix this error, so if you know of an alternative, please comment below.

I also added redis as dependecy of app and reordered alphabetically
