### PR TITLE
Allow updating a specified subset of catalogs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.8
 env:
   matrix:

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -16,6 +16,14 @@ from enterprise_catalog.apps.catalog.tests.factories import (
 class UpdateContentMetadataCommandTests(TestCase):
     command_name = 'update_content_metadata'
 
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.catalog_query_a = CatalogQueryFactory()
+        cls.catalog_query_b = CatalogQueryFactory()
+        cls.enterprise_catalog_a = EnterpriseCatalogFactory(catalog_query=cls.catalog_query_a)
+        cls.enterprise_catalog_b = EnterpriseCatalogFactory(catalog_query=cls.catalog_query_b)
+
     def tearDown(self):
         super(UpdateContentMetadataCommandTests, self).tearDown()
         # clean up any stale test objects
@@ -29,18 +37,11 @@ class UpdateContentMetadataCommandTests(TestCase):
         """
         Verify that the job creates an update task for every catalog query
         """
-        [catalog_query_a, catalog_query_b, catalog_query_c] = CatalogQueryFactory.create_batch(3)
-
-        enterprise_catalog_a = EnterpriseCatalogFactory(catalog_query=catalog_query_a)
-        enterprise_catalog_b = EnterpriseCatalogFactory(catalog_query=catalog_query_b)
-        enterprise_catalog_c = EnterpriseCatalogFactory(catalog_query=catalog_query_c)
-
         call_command(self.command_name)
 
         mock_chord.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=catalog_query_a),
-            mock_catalog_task.s(catalog_query_id=catalog_query_b),
-            mock_catalog_task.s(catalog_query_id=catalog_query_c),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b),
         ])
         mock_full_metadata_task.s.assert_called_once()
 
@@ -52,15 +53,27 @@ class UpdateContentMetadataCommandTests(TestCase):
         Verify that the job creates an update task for every catalog query that is used by
         at least one enterprise catalog.
         """
-        [catalog_query_a, catalog_query_b, catalog_query_c] = CatalogQueryFactory.create_batch(3)
-
-        enterprise_catalog_a = EnterpriseCatalogFactory(catalog_query=catalog_query_a)
-        enterprise_catalog_b = EnterpriseCatalogFactory(catalog_query=catalog_query_b)
+        # Create another catalog query that isn't used by any catalog, so shouldn't be updated
+        CatalogQueryFactory()
 
         call_command(self.command_name)
 
         mock_chord.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=catalog_query_a),
-            mock_catalog_task.s(catalog_query_id=catalog_query_b),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b),
+        ])
+        mock_full_metadata_task.s.assert_called_once()
+
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.chord')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
+    def test_update_content_metadata_with_args(self, mock_full_metadata_task, mock_catalog_task, mock_chord):
+        """
+        Verify that the job only updates the catalog query associated with the provided catalog_uuid if given.
+        """
+        call_command(self.command_name, catalog_uuids=[self.enterprise_catalog_a.uuid])
+
+        mock_chord.assert_called_once_with([
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a),
         ])
         mock_full_metadata_task.s.assert_called_once()

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -1,7 +1,7 @@
 import logging
+from uuid import UUID
 
 from celery import chord
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import (
@@ -9,7 +9,7 @@ from enterprise_catalog.apps.api.tasks import (
     update_full_content_metadata_task,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE
-from enterprise_catalog.apps.catalog.models import CatalogQuery
+from enterprise_catalog.apps.catalog.models import CatalogQuery, EnterpriseCatalog
 
 
 logger = logging.getLogger(__name__)
@@ -17,8 +17,25 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = (
-        'Update Content Metadata, along with the associations of Catalog Queries and Content Metadata',
+        'Updates Content Metadata, along with the associations of Catalog Queries and Content Metadata. '
+        'Example usage with --catalog_uuids: '
+        './manage.py update_content_metadata --catalog_uuids {catalog_uuid_a} {catalog_uuid_b} ...'
     )
+
+    def add_arguments(self, parser):
+        """
+        Add required arguments to the parser.
+        """
+        parser.add_argument(
+            '--catalog_uuids',
+            dest='catalog_uuids',
+            required=False,
+            nargs='+',
+            type=UUID,
+            metavar='ENTERPRISE_CATALOG_UUID',
+            help='If provided, only updates content metadata for the specified catalog',
+        )
+        super(Command, self).add_arguments(parser)
 
     def _run_update_catalog_metadata_task(self, catalog_query):
         message = (
@@ -40,6 +57,19 @@ class Command(BaseCommand):
         # find all CatalogQuery records used by at least one EnterpriseCatalog to avoid
         # calling /search/all/ for a CatalogQuery that is not currently used by any catalogs.
         catalog_queries = CatalogQuery.objects.filter(enterprise_catalogs__isnull=False).distinct()
+
+        catalog_uuids = options.get('catalog_uuids')
+        if catalog_uuids:
+            enterprise_catalogs = EnterpriseCatalog.objects.filter(uuid__in=catalog_uuids)
+            catalog_queries = catalog_queries.filter(
+                enterprise_catalogs__isnull=False,
+                enterprise_catalogs__in=enterprise_catalogs,
+            ).distinct()
+            message = (
+                'Updating {} unique CatalogQuery(s) for EnterpriseCatalog(s) with uuid(s): {}'
+            ).format(catalog_queries.count(), catalog_uuids)
+            logger.info(message)
+
 
         # create a group of celery tasks that run in parallel to create/update ContentMetadata records
         # and associate those with the appropriate CatalogQuery(s). once all those tasks succeed, run a

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -9,7 +9,10 @@ from enterprise_catalog.apps.api.tasks import (
     update_full_content_metadata_task,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE
-from enterprise_catalog.apps.catalog.models import CatalogQuery, EnterpriseCatalog
+from enterprise_catalog.apps.catalog.models import (
+    CatalogQuery,
+    EnterpriseCatalog,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -61,15 +64,11 @@ class Command(BaseCommand):
         catalog_uuids = options.get('catalog_uuids')
         if catalog_uuids:
             enterprise_catalogs = EnterpriseCatalog.objects.filter(uuid__in=catalog_uuids)
-            catalog_queries = catalog_queries.filter(
-                enterprise_catalogs__isnull=False,
-                enterprise_catalogs__in=enterprise_catalogs,
-            ).distinct()
+            catalog_queries = catalog_queries.filter(enterprise_catalogs__in=enterprise_catalogs).distinct()
             message = (
                 'Updating {} unique CatalogQuery(s) for EnterpriseCatalog(s) with uuid(s): {}'
             ).format(catalog_queries.count(), catalog_uuids)
             logger.info(message)
-
 
         # create a group of celery tasks that run in parallel to create/update ContentMetadata records
         # and associate those with the appropriate CatalogQuery(s). once all those tasks succeed, run a


### PR DESCRIPTION
Adds an optional kwarg `catalog_uuids` to the update_content_metadata
command which allows users to only update the ContentMetadata for the
catalogs that are associated with the catalog query of the provided
catalog.
Note that this does not change the update_full_content_metadata task to
only do that process for the subset of content associated with the
catalog queries of the enterprise catalogs that are given here. That is
being split out to try and make the refactoring cleaner.