### PR TITLE
Prefetch related objects in reindex-algolia task

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -19,7 +19,6 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     ContentMetadata,
-    EnterpriseCatalog,
     content_metadata_with_type_course,
     update_contentmetadata_from_discovery,
 )

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from celery import shared_task
 from celery_utils.logged_task import LoggedTask
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 
 from enterprise_catalog.apps.api.v1.utils import (
     create_algolia_objects_from_courses,
@@ -17,7 +17,9 @@ from enterprise_catalog.apps.catalog.constants import (
     COURSE,
 )
 from enterprise_catalog.apps.catalog.models import (
+    CatalogQuery,
     ContentMetadata,
+    EnterpriseCatalog,
     content_metadata_with_type_course,
     update_contentmetadata_from_discovery,
 )
@@ -127,7 +129,13 @@ def index_enterprise_catalog_courses_in_algolia_task(
     # retrieve ContentMetadata records that match the specified content_keys in the
     # content_key or parent_content_key. returns both courses and course runs.
     query = Q(content_key__in=content_keys) | Q(parent_content_key__in=content_keys)
-    content_metadata = ContentMetadata.objects.filter(query)
+
+    catalog_queries = CatalogQuery.objects.prefetch_related(
+        'enterprise_catalogs',
+    )
+    content_metadata = ContentMetadata.objects.filter(query).prefetch_related(
+        Prefetch('catalog_queries', queryset=catalog_queries),
+    )
 
     # iterate through ContentMetadata records, retrieving the enterprise_catalog_uuids
     # and enterprise_customer_uuids associated with each ContentMetadata record (either
@@ -138,16 +146,14 @@ def index_enterprise_catalog_courses_in_algolia_task(
     for metadata in content_metadata:
         is_course_content_type = metadata.content_type == COURSE
         course_content_key = metadata.content_key if is_course_content_type else metadata.parent_content_key
-        associated_queries = metadata.catalog_queries.all().prefetch_related(
-            'enterprise_catalogs',
-        )
+        associated_queries = metadata.catalog_queries.all()
         enterprise_catalog_uuids = set()
         enterprise_customer_uuids = set()
         for query in associated_queries:
-            associated_catalogs = query.enterprise_catalogs.values('uuid', 'enterprise_uuid')
+            associated_catalogs = query.enterprise_catalogs.all()
             for catalog in associated_catalogs:
-                enterprise_catalog_uuids.add(str(catalog['uuid']))
-                enterprise_customer_uuids.add(str(catalog['enterprise_uuid']))
+                enterprise_catalog_uuids.add(str(catalog.uuid))
+                enterprise_customer_uuids.add(str(catalog.enterprise_uuid))
 
         # add to any existing enterprise catalog uuids or enterprise customer uuids
         catalog_uuids_by_course_key[course_content_key].update(enterprise_catalog_uuids)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -93,18 +93,6 @@ class CatalogQuery(models.Model):
             )
         )
 
-    @property
-    def enterprise_catalogs(self):
-        """
-        Helper to retrieve the enterprise catalogs associated with the catalog query.
-
-        Returns:
-            Queryset: The queryset of associated enterprise catalogs
-        """
-        if not self.enterprise_catalogs:
-            return EnterpriseCatalog.objects.none()
-        return self.enterprise_catalogs.all()
-
 
 class EnterpriseCatalog(TimeStampedModel):
     """


### PR DESCRIPTION
Prefetches the associated catalog queries and their associated
enterprise catalogs to avoid the duplicate queries from ManyToMany and
ReverseForeignKey lookups from ContentMetadata --> CatalogQuery -->
EnterpriseCatalog.
This also drops the `enterprise_catalogs` property as that seemed to
circumvent some of Django's prefetching.
Additionally, this drops the `.values` call as that was clearing the
prefetched objects cache due to being a different query.
