### PR TITLE
Removing lms sql data dump from repository

### DIFF
--- a/.env
+++ b/.env
@@ -5,5 +5,22 @@
 # docker-compose command. Unless the line below is uncommented, legacy
 # devstack should work as normal.
 
-# TODO: Uncomment the following line to use Decentralized Devstack
+# TODO: Uncomment one of the following lines with "COMPOSE_FILE" based on your use case
+
+# UNCOMMENT the following line to use latest Decentralized Devstack, this will pull latest images of each service
 #COMPOSE_FILE=decentralized-docker-compose.yml
+
+# UNCOMMENT the following line if you want to develop in local version of dependencies(services)
+#COMPOSE_FILE=decentralized-docker-compose.yml:decentralized-docker-compose-develop-dependencies.yml
+# the code for dependencies should live in directory set by following variable:
+#DEVSTACK_WORKSPACE=TODO
+
+#  If you don't need the most latest version of either edx-platform or discovery,
+# UNCOMMENT either of the *STABLE_TAG to use stable images
+
+# docker images are tagged as: {git hash}-devstack
+# the following image tags has been vetted to be stable
+# if you find this to be unstable for your team/squad, please update it with a more stable image
+# ideally, this would be somehow in sync with openedx releases
+#EDX_PLATFORM_STABLE_TAG=226bb0c4980432287cc10b8b23fc49e46ca7e0e6
+#DISCOVERY_STABLE_TAG=92d0481ac547fdcb28a1837e67889c0c8972b27b

--- a/.env
+++ b/.env
@@ -5,7 +5,6 @@
 # docker-compose command. Unless the line below is uncommented, legacy
 # devstack should work as normal.
 
-# TODO: Uncomment one of the following lines with "COMPOSE_FILE" based on your use case
 
 # UNCOMMENT the following line to use latest Decentralized Devstack, this will pull latest images of each service
 #COMPOSE_FILE=decentralized-docker-compose.yml

--- a/decentralized-docker-compose-develop-dependencies.yml
+++ b/decentralized-docker-compose-develop-dependencies.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+
+services:
+
+  discovery:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/course-discovery:/edx/app/discovery/discovery:cached
+
+  lms:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+
+

--- a/decentralized-docker-compose.yml
+++ b/decentralized-docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - .:/edx/app/enterprise_catalog/enterprise_catalog
 
   discovery:
-    image: openedx/discovery:latest-devstack
+    image: openedx/discovery:${DISCOVERY_STABLE_TAG:-latest}-devstack
     container_name: edx.devstack.discovery
     hostname: discovery.devstack.edx
     links:
@@ -89,7 +89,7 @@ services:
       - elasticsearch_data:/usr/share/elasticsearch/logs
 
   lms:
-    image: openedx/edx-platform:latest-devstack
+    image: openedx/edx-platform:${EDX_PLATFORM_STABLE_TAG:-latest}-devstack
     container_name: edx.devstack.lms
     hostname: lms.devstack.edx
     depends_on:

--- a/decentralized-docker-compose.yml
+++ b/decentralized-docker-compose.yml
@@ -63,6 +63,8 @@ services:
     image: openedx/discovery:latest-devstack
     container_name: edx.devstack.discovery
     hostname: discovery.devstack.edx
+    links:
+      - "mysql:edx.devstack.mysql57"
     depends_on:
       - mysql
       - elasticsearch

--- a/decentralized_devstack/provision-lms.sh
+++ b/decentralized_devstack/provision-lms.sh
@@ -11,8 +11,9 @@ else
   log_step "lms: Ensuring MySQL databases and users exist..."
   docker-compose exec -T mysql mysql -uroot mysql < decentralized_devstack/provision-mysql-lms.sql
 
-  log_step "lms: Adding default MySQL data from dump..."
-  docker-compose exec -T mysql mysql edxapp < decentralized_devstack/provision-mysql-lms-data.sql
+  touch /tmp/provision-mysql-lms-data.sql
+  curl https://raw.githubusercontent.com/edx/edx-platform/master/edxapp.sql > /tmp/provision-mysql-lms-data.sql
+  docker-compose exec -T mysql mysql edxapp < /tmp/provision-mysql-lms-data.sql
 fi
 
 log_step "lms: Making sure MongoDB is ready..."
@@ -34,13 +35,12 @@ service_exec mongo mongorestore --quiet --gzip /data/dump
 
 log_step "lms: Bringing up LMS..."
 docker-compose up --detach lms
-
 # # TODO: Make sure this handles squashed migrations idempotently 
 # # (e.g. enterprise/migrations/0001_squashed_0092_auto_20200312_1650.py)
-log_step "lms: Running migrations for default database..."
-service_exec_management lms migrate
+# log_step "lms: Running migrations for default database..."
+# service_exec_management lms migrate
 
-log_step "lms: Running migrations for courseware student module history (CSMH) database..."
-service_exec_management lms migrate --database student_module_history
+# log_step "lms: Running migrations for courseware student module history (CSMH) database..."
+# service_exec_management lms migrate --database student_module_history
 
 log_message "Done provisioning LMS."

--- a/decentralized_devstack/provision-lms.sh
+++ b/decentralized_devstack/provision-lms.sh
@@ -12,7 +12,11 @@ else
   docker-compose exec -T mysql mysql -uroot mysql < decentralized_devstack/provision-mysql-lms.sql
 
   touch /tmp/provision-mysql-lms-data.sql
-  curl https://raw.githubusercontent.com/edx/edx-platform/master/edxapp.sql > /tmp/provision-mysql-lms-data.sql
+
+  # read variable out of .env file
+  #TODO: document further
+  EDX_PLATFORM_STABLE_TAG=$(source .env && echo $EDX_PLATFORM_STABLE_TAG)
+  curl https://raw.githubusercontent.com/edx/edx-platform/${EDX_PLATFORM_STABLE_TAG:-master}/edxapp.sql > /tmp/provision-mysql-lms-data.sql
   docker-compose exec -T mysql mysql edxapp < /tmp/provision-mysql-lms-data.sql
 fi
 
@@ -42,5 +46,6 @@ docker-compose up --detach lms
 
 # log_step "lms: Running migrations for courseware student module history (CSMH) database..."
 # service_exec_management lms migrate --database student_module_history
+#log_step "lms: Finished migrations for courseware student module history (CSMH) database..."
 
 log_message "Done provisioning LMS."

--- a/decentralized_devstack/provision-lms.sh
+++ b/decentralized_devstack/provision-lms.sh
@@ -13,8 +13,8 @@ else
 
   touch /tmp/provision-mysql-lms-data.sql
 
-  # read variable out of .env file
-  #TODO: document further
+  # Pull a MySQL dump from edx-platform 
+  # the dump is created via a Github Action in order to speed up the startup time and ensure expected data is available."
   EDX_PLATFORM_STABLE_TAG=$(source .env && echo "$EDX_PLATFORM_STABLE_TAG")
   curl https://raw.githubusercontent.com/edx/edx-platform/"${EDX_PLATFORM_STABLE_TAG:-master}"/edxapp.sql > /tmp/provision-mysql-lms-data.sql
   docker-compose exec -T mysql mysql edxapp < /tmp/provision-mysql-lms-data.sql

--- a/decentralized_devstack/provision-lms.sh
+++ b/decentralized_devstack/provision-lms.sh
@@ -15,8 +15,8 @@ else
 
   # read variable out of .env file
   #TODO: document further
-  EDX_PLATFORM_STABLE_TAG=$(source .env && echo $EDX_PLATFORM_STABLE_TAG)
-  curl https://raw.githubusercontent.com/edx/edx-platform/${EDX_PLATFORM_STABLE_TAG:-master}/edxapp.sql > /tmp/provision-mysql-lms-data.sql
+  EDX_PLATFORM_STABLE_TAG=$(source .env && echo "$EDX_PLATFORM_STABLE_TAG")
+  curl https://raw.githubusercontent.com/edx/edx-platform/"${EDX_PLATFORM_STABLE_TAG:-master}"/edxapp.sql > /tmp/provision-mysql-lms-data.sql
   docker-compose exec -T mysql mysql edxapp < /tmp/provision-mysql-lms-data.sql
 fi
 

--- a/decentralized_devstack/provision.sh
+++ b/decentralized_devstack/provision.sh
@@ -44,6 +44,8 @@ if ! is_mysql_ready; then
 	sleep 5
 fi
 
+log_step "mysql ready"
+
 # Run provisioning scripts for dependencies.
 # We call provision-lms.sh, provision-discovery.sh, etc., and log an error
 # if they fail.

--- a/docs/decentralized_devstack_common_commands.rst
+++ b/docs/decentralized_devstack_common_commands.rst
@@ -4,6 +4,10 @@ Common commands for Decentralized Devstack
 .. role:: bash(code)
    :language: bash
 
+We use docker-compose to define and run all the containers necessary for enterprise-catalog service. For Decentralized Devstack, the service is defined in decentralized-docker-compose.yml file. To learn more see: `Docker-compose cheatsheet`_ and `Official compose documentation`_
+
+To use Decentralized Devstack you will need to first go to the `.env` file and uncomment one of the `COMPOSE_FILE` lines.
+
 Below is a list of common commands used during development in Decentralized Devstack, if you find any commands missing, please add it to the list:
 
 - start DD: :bash:`docker-compose up -d`
@@ -29,8 +33,6 @@ Below is a list of common commands used during development in Decentralized Devs
 
 - destroy current DD: :bash:`docker-compose down -v`
 - provision: :bash:`./decentralized_devstack/provision.sh`
-
-We use docker-compose to define and run all the containers necessary for enterprise-catalog service. For decentralized devstack, the service is defined in decentralized-docker-compose.yml file. To learn more see: `Docker-compose cheatsheet`_ and `Official compose documentation`_
 
 .. _ Docker-compose cheatsheet: https://devhints.io/docker-compose
 .. _ Official compose documentation: https://docs.docker.com/compose/


### PR DESCRIPTION
and linking discovery to right mysql container

edx-platform repo now has the sql dump regularly updated, so using that sql dump instead of the one which was in this repository.
This also has work from this PR: https://github.com/edx/enterprise-catalog/pull/210