### PR TITLE
adjust celery time limits for the `update_full_content_metadata_task` task

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -28,12 +28,19 @@ from enterprise_catalog.apps.catalog.utils import batch
 logger = logging.getLogger(__name__)
 
 
-@shared_task(base=LoggedTask)
+# soft_time_limit: 6 minutes (raised from 4)
+# time_limit: 7 minutes (raised from 5)
+@shared_task(base=LoggedTask, soft_time_limit=360, time_limit=420)
 def update_full_content_metadata_task(*args, **kwargs):  # pylint: disable=unused-argument
     """
     Traverse discovery's /api/v1/courses endpoint to fetch the full course metadata of all ContentMetadata
     records with a content type of "course". The course metadata is merged with the existing contents of
     the json_metadata field for each ContentMetadata record.
+
+    Note: This task increases the maximum ``soft_time_limit`` and ``time_limit`` options since the task
+    requires traversing the full pagination of course-discovery's /courses/ endpoint, which was previously
+    exceeding the default ``CELERY_TASK_SOFT_TIME_LIMIT`` and ``CELERY_TASK_TIME_LIMIT``, causing a
+    SoftTimeLimitExceeded exception.
     """
     discovery_client = DiscoveryApiClient()
 

--- a/enterprise_catalog/apps/api_client/constants.py
+++ b/enterprise_catalog/apps/api_client/constants.py
@@ -9,7 +9,7 @@ from django.conf import settings
 # Discovery API Client Constants
 DISCOVERY_SEARCH_ALL_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'search/all/')
 DISCOVERY_COURSES_ENDPOINT = urljoin(settings.DISCOVERY_SERVICE_API_URL, 'courses/')
-DISCOVERY_OFFSET_SIZE = 100
+DISCOVERY_OFFSET_SIZE = 200
 
 # Enterprise API Client Constants
 ENTERPRISE_API_URL = urljoin(settings.LMS_BASE_URL, '/enterprise/api/v1/')

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -70,7 +70,7 @@ class TestDiscoveryApiClient(TestCase):
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_courses_with_error(self, mock_oauth_client):
         """
-        get_courses should return empty list when a call to discovery endpoint fails.
+        get_courses should return any courses that may have already been retrieved when the error occurs.
         """
         mock_oauth_client.return_value.get.side_effect = JSONDecodeError('error', '{}', 0)
 


### PR DESCRIPTION
## Description

* Increase `DISCOVERY_OFFSET_SIZE` to 200 (slightly less total number of network requests to traverse all courses, which should help speed up the traversal).
* Increase `soft_time_limit` and `time_limit` for `update_full_content_metadata_task` to 6 and 7 minutes from the defaults of 4 and 5 minutes, respectively.
* Catch the `SoftTimeLimitExceeded` exception in `DiscoveryApiClient.get_courses`, and return any courses we might have already so we can at least partially update some of the courses.

## Ticket Link

Link to the associated ticket
[ENT-3539](https://openedx.atlassian.net/browse/ENT-3539)

## Post-review

Squash commits into discrete sets of changes
