### PR TITLE
Support accurate build statuses for jobs

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -37,7 +37,9 @@ ACCESS_TO_ALL_ENTERPRISES_TOKEN = '*'
 
 DISCOVERY_COURSE_KEY_BATCH_SIZE = 50
 
+# Async task constants
 TASK_BATCH_SIZE = 250
+TASK_TIMEOUT = 30 * 60  # Gives tasks 30 minutes to return, otherwise times out
 
 
 def json_serialized_course_modes():

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -10,6 +10,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_indexable_course_keys,
     get_initialized_algolia_client,
 )
+from enterprise_catalog.apps.catalog.constants import TASK_TIMEOUT
 from enterprise_catalog.apps.catalog.models import (
     content_metadata_with_type_course,
 )
@@ -44,3 +45,13 @@ class Command(BaseCommand):
             ' the reindex_algolia command to reindex %d courses in Algolia.'
         )
         logger.info(message, async_task.task_id, len(indexable_course_keys))
+
+        # See https://docs.celeryproject.org/en/stable/reference/celery.result.html#celery.result.AsyncResult.get
+        # for documentation
+        async_task.get(timeout=TASK_TIMEOUT, propagate=True)
+        if async_task.successful():
+            message = (
+                'index_enterprise_catalog_courses_in_algolia_task (%s) from command reindex_algolia finished'
+                ' successfully.'
+            )
+            logger.info(message, async_task.task_id)

--- a/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
@@ -3,6 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import update_full_content_metadata_task
+from enterprise_catalog.apps.catalog.constants import TASK_TIMEOUT
 from enterprise_catalog.apps.catalog.management.utils import (
     get_all_content_keys,
 )
@@ -19,9 +20,21 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         all_content_keys = get_all_content_keys()
         async_task = update_full_content_metadata_task.delay(all_content_keys)
-
         message = (
             'Spinning off update_full_content_metadata_task (%s) from update_full_content_metadata command'
             ' to replace minimal json_metadata from /search/all/ with full json_metadata from /courses/.'
         )
         logger.info(message, async_task.task_id)
+
+        # See https://docs.celeryproject.org/en/stable/reference/celery.result.html#celery.result.AsyncResult.get
+        # for documentation
+        async_result = async_task.get(
+            timeout=TASK_TIMEOUT,
+            propagate=True,
+        )
+        if async_task.successful():
+            message = (
+                'update_full_content_metadata task (%s) from update_full_content_metadata command finished'
+                ' successfully with result %s'
+            )
+            logger.info(message, async_task.task_id, async_result)


### PR DESCRIPTION
Updates management commands to collect the results of asynchronous
tasks in order to report if they were successful, or propagate any
exception that might have been raised.

ENT-3544