### PR TITLE
Set TASK_TIMEOUT to 45 minutes.

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -39,7 +39,7 @@ DISCOVERY_COURSE_KEY_BATCH_SIZE = 50
 
 # Async task constants
 TASK_BATCH_SIZE = 250
-TASK_TIMEOUT = 30 * 60  # Gives tasks 30 minutes to return, otherwise times out
+TASK_TIMEOUT = 45 * 60  # Gives tasks 45 minutes to return, otherwise times out
 
 
 def json_serialized_course_modes():


### PR DESCRIPTION
## Description

Our daily job to update content metadata takes about 29 minutes, which is really close to the current TASK_TIMEOUT of 30 minutes.  This change give us a little more breathing room.

## Post-review

Squash commits into discrete sets of changes
