### PR TITLE
Map system ent. admin role to catalog learner

### DIFF
--- a/enterprise_catalog/apps/catalog/tests/test_rules.py
+++ b/enterprise_catalog/apps/catalog/tests/test_rules.py
@@ -57,6 +57,7 @@ class TestCatalogAdminRBACPermissions(APITestMixin):
     @ddt.data(
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE),
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE),
+        ('catalog.has_admin_access', SYSTEM_ENTERPRISE_ADMIN_ROLE),
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_LEARNER_ROLE),
     )
     @ddt.unpack
@@ -68,6 +69,7 @@ class TestCatalogAdminRBACPermissions(APITestMixin):
     @ddt.data(
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE),
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE),
+        ('catalog.has_admin_access', SYSTEM_ENTERPRISE_ADMIN_ROLE),
         ('catalog.has_admin_access', SYSTEM_ENTERPRISE_LEARNER_ROLE),
     )
     @ddt.unpack
@@ -100,10 +102,12 @@ class TestCatalogLearnerRBACPermissions(APITestMixin):
     @ddt.data(
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE, TEST_ENTERPRISE_UUID),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE, TEST_ENTERPRISE_UUID),
+        ('catalog.has_learner_access', SYSTEM_ENTERPRISE_ADMIN_ROLE, TEST_ENTERPRISE_UUID),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_LEARNER_ROLE, TEST_ENTERPRISE_UUID),
         ('catalog.has_learner_access', ENTERPRISE_CATALOG_ADMIN_ROLE, TEST_ENTERPRISE_UUID),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE, ALL_ACCESS_CONTEXT),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE, ALL_ACCESS_CONTEXT),
+        ('catalog.has_learner_access', SYSTEM_ENTERPRISE_ADMIN_ROLE, ALL_ACCESS_CONTEXT),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_LEARNER_ROLE, ALL_ACCESS_CONTEXT),
         ('catalog.has_learner_access', ENTERPRISE_CATALOG_ADMIN_ROLE, ALL_ACCESS_CONTEXT),
     )
@@ -116,6 +120,7 @@ class TestCatalogLearnerRBACPermissions(APITestMixin):
     @ddt.data(
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE),
+        ('catalog.has_learner_access', SYSTEM_ENTERPRISE_ADMIN_ROLE),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_LEARNER_ROLE),
         ('catalog.has_learner_access', ENTERPRISE_CATALOG_ADMIN_ROLE),
     )
@@ -128,6 +133,7 @@ class TestCatalogLearnerRBACPermissions(APITestMixin):
     @ddt.data(
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_OPERATOR_ROLE),
+        ('catalog.has_learner_access', SYSTEM_ENTERPRISE_ADMIN_ROLE),
         ('catalog.has_learner_access', SYSTEM_ENTERPRISE_LEARNER_ROLE),
         ('catalog.has_learner_access', ENTERPRISE_CATALOG_ADMIN_ROLE),
     )

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -8,6 +8,7 @@ from corsheaders.defaults import default_headers as corsheaders_default_headers
 from enterprise_catalog.apps.catalog.constants import (
     ENTERPRISE_CATALOG_ADMIN_ROLE,
     ENTERPRISE_CATALOG_LEARNER_ROLE,
+    SYSTEM_ENTERPRISE_ADMIN_ROLE,
     SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
     SYSTEM_ENTERPRISE_OPERATOR_ROLE,
     SYSTEM_ENTERPRISE_LEARNER_ROLE,
@@ -347,7 +348,10 @@ ALGOLIA = {
 
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
+    # The enterprise catalog admin role is for users who need to perform state altering requests on catalogs
     SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE: [ENTERPRISE_CATALOG_ADMIN_ROLE],
     SYSTEM_ENTERPRISE_OPERATOR_ROLE: [ENTERPRISE_CATALOG_ADMIN_ROLE],
+    # Admins and learners should both be able to access catalog metadata and call the contains content endpoints
     SYSTEM_ENTERPRISE_LEARNER_ROLE: [ENTERPRISE_CATALOG_LEARNER_ROLE],
+    SYSTEM_ENTERPRISE_ADMIN_ROLE: [ENTERPRISE_CATALOG_LEARNER_ROLE],
 }


### PR DESCRIPTION
This is to ensure that enterprise admins with the system enterprise
admin role are properly mapped to a feature role in enterprise-catalog.
This mapping allows admins to have the same catalog access as their
learners, granting access to the `get_content_metadata` and
`contains_content_items` endpoints used in the learner portal.

ENT-3672