### PR TITLE
feat: ENT-3804 Add pacing_type and start/end dates to indexed fields in algolia

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -286,6 +286,8 @@ def get_advertised_course_run(course):
         dict: containing key, pacing_type, start and end for the course_run, or None
     """
     full_course_run = _get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
+    if full_course_run is None:
+        return None
     course_run = dict(
         key=full_course_run.get('key'),
         pacing_type=full_course_run.get('pacing_type'),
@@ -307,7 +309,7 @@ def _get_course_run_by_uuid(course, course_run_uuid):
         dict: a course_run or None
     """
     try:
-        course_run = [run for run in course.get('course_runs') if run.get('uuid') == course_run_uuid][0]
+        course_run = [run for run in course.get('course_runs', []) if run.get('uuid') == course_run_uuid][0]
     except IndexError:
         return None
     return course_run

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -26,6 +26,7 @@ ALGOLIA_FIELDS = [
     'short_description',
     'subjects',
     'title',
+    'pacing_type',
 ]
 
 # default configuration for the index
@@ -273,6 +274,26 @@ def get_course_card_image_url(course):
     return None
 
 
+def get_pacing_type(course_runs):
+    """
+    Gets pacing types
+
+    Argument:
+        published_course_runs (list)
+
+    Returns:
+        list: A unique list of pacing_types
+    """
+    pacing_types = set()
+
+    for course_run in course_runs:
+        pacing_type = course_run.get('pacing_type')
+        if pacing_type:
+            pacing_types.add(pacing_type)
+
+    return list(pacing_types)
+
+
 def _algolia_object_from_course(course, algolia_fields):
     """
     Transforms a course into an Algolia object.
@@ -296,6 +317,7 @@ def _algolia_object_from_course(course, algolia_fields):
         'programs': get_course_program_types(searchable_course),
         'subjects': get_course_subjects(searchable_course),
         'card_image_url': get_course_card_image_url(searchable_course),
+        'pacing_type': get_pacing_type(published_course_runs),
     })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -288,12 +288,12 @@ def get_advertised_course_run(course):
     full_course_run = _get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
     if full_course_run is None:
         return None
-    course_run = dict(
-        key=full_course_run.get('key'),
-        pacing_type=full_course_run.get('pacing_type'),
-        start=full_course_run.get('start'),
-        end=full_course_run.get('end'),
-    )
+    course_run = {
+        'key': full_course_run.get('key'),
+        'pacing_type': full_course_run.get('pacing_type'),
+        'start': full_course_run.get('start'),
+        'end': full_course_run.get('end'),
+    }
     return course_run
 
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -86,7 +86,8 @@ def _should_index_course(course_metadata):
         advertised_course_run_uuid,
     )
 
-    return False if advertised_course_run_uuid is None
+    if advertised_course_run_uuid is None:
+        return False
 
     owners = course_json_metadata.get('owners', [])
     return (len(owners) > 0

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -86,7 +86,7 @@ def _should_index_course(course_metadata):
         advertised_course_run_uuid,
     )
 
-    if advertised_course_run_uuid is None:
+    if advertised_course_run is None:
         return False
 
     owners = course_json_metadata.get('owners', [])

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -7,16 +7,17 @@ from django.test import TestCase
 from enterprise_catalog.apps.catalog.algolia_utils import (
     ALGOLIA_INDEX_SETTINGS,
     _should_index_course,
+    get_advertised_course_run,
     get_course_card_image_url,
     get_course_partners,
     get_course_subjects,
     get_initialized_algolia_client,
-    get_advertised_course_run,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
 )
+
 
 ADVERTISED_COURSE_RUN_UUID = uuid4()
 

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -18,6 +18,8 @@ from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
 )
 
+ADVERTISED_COURSE_RUN_UUID = uuid4()
+
 
 @ddt.ddt
 class AlgoliaUtilsTests(TestCase):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -11,6 +11,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_course_partners,
     get_course_subjects,
     get_initialized_algolia_client,
+    get_advertised_course_run,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE
 from enterprise_catalog.apps.catalog.tests.factories import (
@@ -162,6 +163,37 @@ class AlgoliaUtilsTests(TestCase):
         """
         course_subjects = get_course_subjects(course_metadata)
         assert sorted(course_subjects) == sorted(expected_subjects)
+
+    @ddt.data(
+        (
+            {
+                'course_runs': [{
+                    'key': 'course-v1:org+course+1T2021',
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z',
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                {
+                    'key': 'course-v1:org+course+1T2021',
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z'
+
+                }
+            }
+        )
+    )
+    @ddt.unpack
+    def test_get_advertised_course_run(self, searchable_course, expected_course_run):
+        """
+        Assert get_advertised_course_runs fetches just enough info about advertised course run
+        """
+        advertised_course_run = get_advertised_course_run(searchable_course)
+        assert advertised_course_run == expected_course_run
 
     @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.AlgoliaSearchClient')
     def test_get_initialized_algolia_client(self, mock_search_client):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -179,13 +179,10 @@ class AlgoliaUtilsTests(TestCase):
                 'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
             },
             {
-                {
-                    'key': 'course-v1:org+course+1T2021',
-                    'pacing_type': 'instructor_paced',
-                    'start': '2013-10-16T14:00:00Z',
-                    'end': '2014-10-16T14:00:00Z'
-
-                }
+                'key': 'course-v1:org+course+1T2021',
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
             }
         )
     )


### PR DESCRIPTION
## Description

Algolia index for enterprise catalog needs some new fields to satisfy requirements of ENT-3518 (pacing_type, start and end dates of the advertised course run)

## Ticket Link

Link to the associated ticket
[ENT-3804](https://openedx.atlassian.net/browse/ENT-3804)

## Post-review

Squash commits into discrete sets of changes
