### PR TITLE
Management command processing changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,6 @@ docker_build: ## Builds with the latest enterprise catalog
 	docker build . --target devstack -t openedx/enterprise-catalog:latest-devstack
 	docker build . --target newrelic -t openedx/enterprise-catalog:latest-newrelic
 
-clean:
-	find . -name '*.pyc' -delete
-
 docker_tag: docker_build
 	docker tag openedx/enterprise-catalog openedx/enterprise-catalog:$$GITHUB_SHA
 	docker tag openedx/enterprise-catalog:latest-devstack openedx/enterprise-catalog:$$GITHUB_SHA-devstack

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -10,10 +10,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_indexable_course_keys,
     get_initialized_algolia_client,
 )
-from enterprise_catalog.apps.catalog.constants import (
-    TASK_BATCH_SIZE,
-    TASK_TIMEOUT,
-)
+from enterprise_catalog.apps.catalog.constants import TASK_BATCH_SIZE
 from enterprise_catalog.apps.catalog.models import (
     content_metadata_with_type_course,
 )
@@ -41,22 +38,12 @@ class Command(BaseCommand):
         indexable_course_keys = get_indexable_course_keys(all_course_content_metadata)
 
         for content_keys_batch in batch(indexable_course_keys, batch_size=TASK_BATCH_SIZE):
-            async_task = index_enterprise_catalog_courses_in_algolia_task.delay(
+            result = index_enterprise_catalog_courses_in_algolia_task.run(
                 content_keys=content_keys_batch,
                 algolia_fields=ALGOLIA_FIELDS,
             )
             message = (
-                'Spinning off task index_enterprise_catalog_courses_in_algolia_task (%s) from'
-                ' the reindex_algolia command to reindex %d courses in Algolia.'
+                'index_enterprise_catalog_courses_in_algolia_task from command reindex_algolia finished'
+                ' successfully with result %s.'
             )
-            logger.info(message, async_task.task_id, len(content_keys_batch))
-
-            # See https://docs.celeryproject.org/en/stable/reference/celery.result.html#celery.result.AsyncResult.get
-            # for documentation
-            async_task.get(timeout=TASK_TIMEOUT, propagate=True)
-            if async_task.successful():
-                message = (
-                    'index_enterprise_catalog_courses_in_algolia_task (%s) from command reindex_algolia finished'
-                    ' successfully.'
-                )
-                logger.info(message, async_task.task_id)
+            logger.info(message, result)

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -37,9 +37,9 @@ class ReindexAlgoliaCommandTests(TestCase):
         with mock.patch(PATH_PREFIX + 'TASK_BATCH_SIZE', 1):
             call_command(self.command_name)
 
-            assert mock_task.delay.call_count == self.number_of_metadata_items
+            assert mock_task.run.call_count == self.number_of_metadata_items
             expected_calls = [
                 mock.call(content_keys=[content_key], algolia_fields=ALGOLIA_FIELDS)
                 for content_key in self.content_keys
             ]
-            mock_task.delay.assert_has_calls(expected_calls, any_order=True)
+            mock_task.run.assert_has_calls(expected_calls, any_order=True)

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_full_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_full_content_metadata.py
@@ -28,4 +28,4 @@ class UpdateFullContentMetadataCommandTests(TestCase):
         Verify that the job spins off the update_full_content_metadata_task
         """
         call_command(self.command_name)
-        mock_task.delay.assert_called_once_with(self._get_content_keys())
+        mock_task.run.assert_called_once_with(self._get_content_keys())

--- a/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
@@ -3,7 +3,6 @@ import logging
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import update_full_content_metadata_task
-from enterprise_catalog.apps.catalog.constants import TASK_TIMEOUT
 from enterprise_catalog.apps.catalog.management.utils import (
     get_all_content_keys,
 )
@@ -19,22 +18,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         all_content_keys = get_all_content_keys()
-        async_task = update_full_content_metadata_task.delay(all_content_keys)
+        result = update_full_content_metadata_task.run(all_content_keys)
         message = (
-            'Spinning off update_full_content_metadata_task (%s) from update_full_content_metadata command'
-            ' to replace minimal json_metadata from /search/all/ with full json_metadata from /courses/.'
+            'update_full_content_metadata task from update_full_content_metadata command finished'
+            ' successfully with result %s'
         )
-        logger.info(message, async_task.task_id)
-
-        # See https://docs.celeryproject.org/en/stable/reference/celery.result.html#celery.result.AsyncResult.get
-        # for documentation
-        async_result = async_task.get(
-            timeout=TASK_TIMEOUT,
-            propagate=True,
-        )
-        if async_task.successful():
-            message = (
-                'update_full_content_metadata task (%s) from update_full_content_metadata command finished'
-                ' successfully with result %s'
-            )
-            logger.info(message, async_task.task_id, async_result)
+        logger.info(message, result)

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -307,9 +307,12 @@ CELERY_TASK_IGNORE_RESULT = False
 CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
 
 # Celery task time limits.
-# Tasks will be asked to quit after 6 minutes, and un-gracefully killed after 7.
-CELERY_TASK_SOFT_TIME_LIMIT = 360
-CELERY_TASK_TIME_LIMIT = 420
+# Tasks will be asked to quit after 8 minutes, and un-gracefully killed after 9.
+CELERY_TASK_SOFT_TIME_LIMIT = 480
+CELERY_TASK_TIME_LIMIT = 540
+
+# Propagate exceptions from eagerly applied tasks
+CELERY_EAGER_PROPAGATES = True
 
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'fanout_patterns': True,


### PR DESCRIPTION
- Bump all task timeout limits again
- Propagate exceptions from eager task applications to more quickly
  catch errors
- Run `reindex_algolia` and `update_full_content_metadata` management
  commands synchronously. This change is to try and ensure that the
  jobs fail in jenkins if there is an error in any one of the tasks.