### PR TITLE
BOM-2190 : Unpin social-auth-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['py38']
-        django-version: ['django22', 'django30']
+        django-version: ['django22']
+        status: ['']
+        include:
+          - python-version: 'py38'
+            django-version: 'django30'
+            status: 'ignored'
 
     steps:
     - uses: actions/checkout@v2
@@ -28,5 +33,6 @@ jobs:
     - name: Install test dependencies and run validation
       run: |
         docker exec -e TOXENV=${{ matrix.python-version }}-${{ matrix.django-version }} -u root enterprise.catalog.app /edx/app/enterprise_catalog/enterprise_catalog/validate.sh
+      continue-on-error: ${{ matrix.status == 'ignored' }}
     - name: Code Coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['py38']
-        django-version: ['django22']
-        status: ['']
-        include:
-          - python-version: 'py38'
-            django-version: 'django30'
-            status: 'ignored'
+        django-version: ['django22', 'django30']
 
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +28,5 @@ jobs:
     - name: Install test dependencies and run validation
       run: |
         docker exec -e TOXENV=${{ matrix.python-version }}-${{ matrix.django-version }} -u root enterprise.catalog.app /edx/app/enterprise_catalog/enterprise_catalog/validate.sh
-      continue-on-error: ${{ matrix.status == 'ignored' }}
     - name: Code Coverage
       uses: codecov/codecov-action@v1

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -9,7 +9,7 @@ from enterprise_catalog.apps.api.v1 import views
 
 app_name = 'v1'
 
-router = DefaultRouter()  # pylint: disable=invalid-name
+router = DefaultRouter()
 router.register(r'enterprise-catalogs', views.EnterpriseCatalogCRUDViewSet, basename='enterprise-catalog')
 router.register(r'enterprise-catalogs', views.EnterpriseCatalogContainsContentItems, basename='enterprise-catalog')
 router.register(r'enterprise-catalogs', views.EnterpriseCatalogGetContentMetadata, basename='enterprise-catalog')

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -145,7 +145,7 @@ class EnterpriseCatalogContainsContentItems(BaseViewSet, viewsets.ModelViewSet):
 
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
     @action(detail=True)
-    def contains_content_items(self, request, uuid, course_run_ids, program_uuids, **kwargs):
+    def contains_content_items(self, request, uuid, course_run_ids, program_uuids, **kwargs):  # pylint: disable=unused-argument
         """
         Returns whether or not the EnterpriseCatalog contains the specified content.
 
@@ -211,7 +211,7 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         return response
 
     @action(detail=True)
-    def get_content_metadata(self, request, uuid, **kwargs):
+    def get_content_metadata(self, request, uuid, **kwargs):  # pylint: disable=unused-argument
         """
         Returns all the content metadata associated with the enterprise catalog.
 
@@ -305,7 +305,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
 
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
     @action(detail=True)
-    def contains_content_items(self, request, enterprise_uuid, course_run_ids, program_uuids, **kwargs):
+    def contains_content_items(self, request, enterprise_uuid, course_run_ids, program_uuids, **kwargs):  # pylint: disable=unused-argument
         """
         Returns whether or not the specified content is available for the given enterprise.
         ---

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -26,7 +26,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         Makes a request to discovery's /search/all/ endpoint with the specified
         content_filter, page, and request_params
         """
-        LOGGER.info(f'Retrieving results from course-discovery for page {page}...')
+        LOGGER.info('Retrieving results from course-discovery for page %s...', page)
         response = self.client.post(
             DISCOVERY_SEARCH_ALL_ENDPOINT,
             json=content_filter,
@@ -82,7 +82,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         """
         Makes a request to discovery's /api/v1/courses/ endpoint with the specified offset and request_params
         """
-        LOGGER.info(f'Retrieving courses from course-discovery for offset {offset}...')
+        LOGGER.info('Retrieving courses from course-discovery for offset %s...', offset)
         response = self.client.get(
             DISCOVERY_COURSES_ENDPOINT,
             params=request_params,

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -72,7 +72,7 @@ class CatalogQuery(models.Model):
         verbose_name_plural = _("Catalog Queries")
         app_label = 'catalog'
 
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         self.content_filter_hash = get_content_filter_hash(self.content_filter)
         super().save(*args, **kwargs)
 

--- a/enterprise_catalog/docker_gunicorn_configuration.py
+++ b/enterprise_catalog/docker_gunicorn_configuration.py
@@ -23,7 +23,8 @@ def close_all_caches():
     # We do this in a way that is safe for 1.4 and 1.8 while we still have some
     # 1.4 installations.
     from django.conf import settings  # pylint: disable=import-outside-toplevel
-    from django.core import cache as django_cache  # pylint: disable=import-outside-toplevel
+    from django.core import \
+        cache as django_cache  # pylint: disable=import-outside-toplevel
     if hasattr(django_cache, 'caches'):
         get_cache = django_cache.caches.__getitem__
     else:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,3 +28,4 @@ zipp<2.0
 algoliasearch
 langcodes
 edx-celeryutils
+social-auth-app-django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.in
 djangorestframework==3.12.2  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.3           # via edx-drf-extensions
 edx-auth-backends==3.3.0  # via -r requirements/base.in
-edx-celeryutils==0.5.6    # via -r requirements/base.in
+edx-celeryutils==0.5.7    # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,31 +8,31 @@ algoliasearch==2.4.0      # via -r requirements/base.in
 amqp==2.6.1               # via kombu
 billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
-certifi==2020.6.20        # via requests
-cffi==1.14.3              # via cryptography
-chardet==3.0.4            # via requests
+certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
+chardet==4.0.0            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==3.1.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt, social-auth-core
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.5.0  # via -r requirements/base.in
-django-crum==0.7.7        # via -r requirements/base.in, edx-rbac
-django-extensions==3.0.9  # via -r requirements/base.in
-django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
+django-cors-headers==3.6.0  # via -r requirements/base.in
+django-crum==0.7.9        # via -r requirements/base.in, edx-django-utils, edx-rbac
+django-extensions==3.1.0  # via -r requirements/base.in
+django-model-utils==4.1.1  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
-django-simple-history==2.11.0  # via -r requirements/base.in
+django-simple-history==2.12.0  # via -r requirements/base.in
 django-waffle==2.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==2.2.17            # via -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.in
-djangorestframework==3.12.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.2           # via edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.in
-edx-celeryutils==0.5.2    # via -r requirements/base.in
+djangorestframework==3.12.2  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.3           # via edx-drf-extensions
+edx-auth-backends==3.3.0  # via -r requirements/base.in
+edx-celeryutils==0.5.6    # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.8.0   # via edx-drf-extensions
+edx-django-utils==3.13.0  # via edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
-edx-rbac==1.3.3           # via -r requirements/base.in
+edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils, pyjwkest
 idna==2.10                # via requests
@@ -43,35 +43,35 @@ kombu==4.6.11             # via celery
 langcodes==2.1.0          # via -r requirements/base.in
 marisa-trie==0.7.5        # via langcodes
 markupsafe==1.1.1         # via jinja2
-mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.20.0.149      # via edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.in
+newrelic==5.24.0.153      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
-pbr==5.5.0                # via stevedore
-psutil==5.7.2             # via edx-django-utils
+pbr==5.5.1                # via stevedore
+psutil==5.8.0             # via edx-django-utils
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
+pycryptodomex==3.9.9      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.0           # via edx-opaque-keys
+pymongo==3.11.2           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.1              # via -r requirements/base.in, celery, django
+pytz==2020.5              # via -r requirements/base.in, celery, django
 pyyaml==5.3.1             # via edx-django-release-util
 redis==3.5.3              # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.24.0          # via algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via cryptography, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via django
-stevedore==3.2.2          # via edx-django-utils, edx-opaque-keys
+social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
+social-auth-core==4.0.2   # via edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1           # via django
+stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.10          # via requests
+urllib3==1.26.2           # via requests
 vine==1.3.0               # via amqp, celery
 zipp==1.2.0               # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,4 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# 3.3.0 updates models with data from get_user_details(), which overrides is_superuser
-# https://openedx.atlassian.net/browse/ARCHBOM-1078
-social-auth-core<3.3.0
-
 celery<5.0      # 5.0 has dropped python3.5 support.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 drf-jwt==1.17.3           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.3.0  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-celeryutils==0.5.6    # via -r requirements/quality.txt, -r requirements/test.txt
+edx-celeryutils==0.5.7    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
@@ -56,7 +56,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/tes
 edx-rbac==1.3.4           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==3.2.0        # via -r requirements/test.txt
-faker==5.4.0              # via -r requirements/test.txt, factory-boy
+faker==5.5.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
@@ -94,7 +94,7 @@ pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.3           # via diff-cover
+pygments==2.7.4           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,64 +7,64 @@
 algoliasearch==2.4.0      # via -r requirements/quality.txt, -r requirements/test.txt
 amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/test.txt, jsonschema, pytest
+astroid==2.4.2            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
+attrs==20.3.0             # via -r requirements/test.txt, jsonschema, pytest
 bcrypt==3.2.0             # via paramiko
 billiard==3.6.3.0         # via -r requirements/quality.txt, -r requirements/test.txt, celery
 cached-property==1.5.2    # via docker-compose
 celery==4.4.7             # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
-cffi==1.14.3              # via -r requirements/quality.txt, -r requirements/test.txt, bcrypt, cryptography, pynacl
-chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
+certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/test.txt, requests
+cffi==1.14.4              # via -r requirements/quality.txt, -r requirements/test.txt, bcrypt, cryptography, pynacl
+chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.9.0   # via -r requirements/test.txt
+code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.1.1       # via -r requirements/quality.txt, -r requirements/test.txt, paramiko, pyjwt
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/quality.txt, -r requirements/test.txt, paramiko, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/dev.in, -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
-diff-cover==4.0.1         # via -r requirements/dev.in
+diff-cover==4.1.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 distro==1.5.0             # via docker-compose
-django-cors-headers==3.5.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
-django-debug-toolbar==3.1.1  # via -r requirements/dev.in
-django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.9  # via -r requirements/quality.txt, -r requirements/test.txt
-django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
+django-cors-headers==3.6.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-crum==0.7.9        # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-rbac
+django-debug-toolbar==3.2  # via -r requirements/dev.in
+django-dynamic-fixture==3.1.1  # via -r requirements/test.txt
+django-extensions==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-model-utils==4.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-simple-history==2.12.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.17            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
-djangorestframework==3.12.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.12.2  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 docker-compose==1.27.4    # via -r requirements/dev.in
-docker[ssh]==4.3.1        # via docker-compose
+docker[ssh]==4.4.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
-drf-jwt==1.17.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-celeryutils==0.5.2    # via -r requirements/quality.txt, -r requirements/test.txt
+drf-jwt==1.17.3           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-auth-backends==3.3.0  # via -r requirements/quality.txt, -r requirements/test.txt
+edx-celeryutils==0.5.6    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.8.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.13.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.5.2           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-lint==1.6             # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.3.3           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-rbac==1.3.4           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
-factory-boy==3.0.1        # via -r requirements/test.txt
-faker==4.1.6              # via -r requirements/test.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.4.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
 idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==2.0.0  # via inflect
+importlib-metadata==3.4.0  # via inflect
 inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
+isort==5.7.0              # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
@@ -76,68 +76,68 @@ lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/tes
 marisa-trie==0.7.5        # via -r requirements/quality.txt, -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
-mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.20.0.149      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/quality.txt, -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-packaging==20.4           # via -r requirements/test.txt, pytest, tox
+packaging==20.8           # via -r requirements/test.txt, pytest, tox
 paramiko==2.7.2           # via docker
 path.py==12.5.0           # via edx-i18n-tools
-path==15.0.0              # via path.py
-pbr==5.5.0                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt
+path==15.0.1              # via path.py
+pbr==5.5.1                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
+pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==5.7.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+psutil==5.8.0             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.1           # via diff-cover
+pygments==2.7.3           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
+pylint==2.6.0             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/test.txt
-pytest==6.1.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.txt
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
-python-dotenv==0.14.0     # via docker-compose
+python-dotenv==0.15.0     # via docker-compose
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
+pytz==2020.5              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, docker-compose, edx-django-release-util, edx-i18n-tools
 redis==3.5.3              # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-requests==2.24.0          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, bcrypt, cryptography, django-dynamic-fixture, django-simple-history, docker, dockerpty, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, jsonschema, packaging, pip-tools, pyjwkest, pynacl, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv, websocket-client
+six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, bcrypt, cryptography, django-dynamic-fixture, django-simple-history, docker, dockerpty, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, jsonschema, pyjwkest, pynacl, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv, websocket-client
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar
-stevedore==3.2.2          # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
+social-auth-app-django==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
+social-auth-core==4.0.2   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar
+stevedore==3.3.0          # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
-tox==3.20.0               # via -r requirements/test.txt
+toml==0.10.2              # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pytest, tox
+tox==3.21.0               # via -r requirements/test.txt
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, requests
+urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/test.txt, requests
 vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp, celery
-virtualenv==20.0.32       # via -r requirements/test.txt, tox
+virtualenv==20.3.0        # via -r requirements/test.txt, tox
 websocket-client==0.57.0  # via docker, docker-compose
-wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
+wrapt==1.12.1             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -42,7 +42,7 @@ doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.3.0  # via -r requirements/test.txt
-edx-celeryutils==0.5.6    # via -r requirements/test.txt
+edx-celeryutils==0.5.7    # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt, edx-rbac
@@ -52,7 +52,7 @@ edx-rbac==1.3.4           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
 edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 factory-boy==3.2.0        # via -r requirements/test.txt
-faker==5.4.0              # via -r requirements/test.txt, factory-boy
+faker==5.5.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
@@ -79,7 +79,7 @@ psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
-pygments==2.7.3           # via doc8, readme-renderer, sphinx
+pygments==2.7.4           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,57 +8,57 @@ alabaster==0.7.12         # via sphinx
 algoliasearch==2.4.0      # via -r requirements/test.txt
 amqp==2.6.1               # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/test.txt, pytest
-babel==2.8.0              # via sphinx
+astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
+attrs==20.3.0             # via -r requirements/test.txt, pytest
+babel==2.9.0              # via sphinx
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
 bleach==3.2.1             # via readme-renderer
 celery==4.4.7             # via -r requirements/test.txt, edx-celeryutils
-certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.3              # via -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
+certifi==2020.12.5        # via -r requirements/test.txt, requests
+cffi==1.14.4              # via -r requirements/test.txt, cryptography
+chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.9.0   # via -r requirements/test.txt
+code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.1.1       # via -r requirements/test.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/test.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
-django-cors-headers==3.5.0  # via -r requirements/test.txt
-django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
-django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.9  # via -r requirements/test.txt
-django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
+django-cors-headers==3.6.0  # via -r requirements/test.txt
+django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils, edx-rbac
+django-dynamic-fixture==3.1.1  # via -r requirements/test.txt
+django-extensions==3.1.0  # via -r requirements/test.txt
+django-model-utils==4.1.1  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-simple-history==2.11.0  # via -r requirements/test.txt
+django-simple-history==2.12.0  # via -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.17            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/test.txt
-djangorestframework==3.12.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.12.2  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/test.txt
-edx-celeryutils==0.5.2    # via -r requirements/test.txt
+drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
+edx-auth-backends==3.3.0  # via -r requirements/test.txt
+edx-celeryutils==0.5.6    # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt, edx-rbac
-edx-lint==1.5.2           # via -r requirements/test.txt
+edx-lint==1.6             # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.3.3           # via -r requirements/test.txt
+edx-rbac==1.3.4           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/test.txt
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-factory-boy==3.0.1        # via -r requirements/test.txt
-faker==4.1.6              # via -r requirements/test.txt, factory-boy
+edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.4.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/test.txt, pylint
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
+isort==5.7.0              # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jsonfield2==3.0.3         # via -r requirements/test.txt, edx-celeryutils
@@ -68,66 +68,66 @@ lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 marisa-trie==0.7.5        # via -r requirements/test.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.20.0.149      # via -r requirements/test.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
-packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
-pbr==5.5.0                # via -r requirements/test.txt, stevedore
+packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycparser==2.20           # via -r requirements/test.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
-pygments==2.7.1           # via doc8, readme-renderer, sphinx
+pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
+pygments==2.7.3           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
+pylint==2.6.0             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/test.txt
-pytest==6.1.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.txt
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/test.txt, babel, celery, django
+pytz==2020.5              # via -r requirements/test.txt, babel, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
-readme-renderer==26.0     # via -r requirements/doc.in
+readme-renderer==28.0     # via -r requirements/doc.in
 redis==3.5.3              # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.24.0          # via -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
+requests==2.25.1          # via -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
-restructuredtext-lint==1.3.1  # via doc8
+restructuredtext-lint==1.3.2  # via doc8
 rules==2.2                # via -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.2.1             # via -r requirements/doc.in, edx-sphinx-theme
+social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
+social-auth-core==4.0.2   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sphinx==3.4.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-sqlparse==0.3.1           # via -r requirements/test.txt, django
-stevedore==3.2.2          # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
+sqlparse==0.4.1           # via -r requirements/test.txt, django
+stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
-tox==3.20.0               # via -r requirements/test.txt
+toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, tox
+tox==3.21.0               # via -r requirements/test.txt
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/test.txt, requests
+urllib3==1.26.2           # via -r requirements/test.txt, requests
 vine==1.3.0               # via -r requirements/test.txt, amqp, celery
-virtualenv==20.0.32       # via -r requirements/test.txt, tox
+virtualenv==20.3.0        # via -r requirements/test.txt, tox
 webencodings==0.5.1       # via bleach
-wrapt==1.11.2             # via -r requirements/test.txt, astroid
+wrapt==1.12.1             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,5 +1,1 @@
 #Forks and other dependencies not yet on PyPI
-
-# Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
-# This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,34 +8,34 @@ algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -r requirements/base.txt, edx-celeryutils
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+certifi==2020.12.5        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography
+chardet==4.0.0            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.5.0  # via -r requirements/base.txt
-django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.9  # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
+django-cors-headers==3.6.0  # via -r requirements/base.txt
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
+django-extensions==3.1.0  # via -r requirements/base.txt
+django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.11.0  # via -r requirements/base.txt
+django-simple-history==2.12.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.17            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.2    # via -r requirements/base.txt
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
+edx-auth-backends==3.3.0  # via -r requirements/base.txt
+edx-celeryutils==0.5.6    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.3.3           # via -r requirements/base.txt
+edx-rbac==1.3.4           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
-gevent==20.9.0            # via -r requirements/production.in
+gevent==20.12.1           # via -r requirements/production.in
 greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
@@ -46,41 +46,41 @@ kombu==4.6.11             # via -r requirements/base.txt, celery
 langcodes==2.1.0          # via -r requirements/base.txt
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
-psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, celery, django
+pytz==2020.5              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, cryptography, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==3.2.2          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+urllib3==1.26.2           # via -r requirements/base.txt, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 zipp==1.2.0               # via -r requirements/base.txt
 zope.event==4.5.0         # via gevent
-zope.interface==5.1.2     # via gevent
+zope.interface==5.2.0     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -27,7 +27,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.3.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.6    # via -r requirements/base.txt
+edx-celeryutils==0.5.7    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,41 +6,41 @@
 #
 algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==2.6.1               # via -r requirements/base.txt, kombu
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==2.4.2            # via pylint, pylint-celery
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -r requirements/base.txt, edx-celeryutils
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+certifi==2020.12.5        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography
+chardet==4.0.0            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.5.0  # via -r requirements/base.txt
-django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.9  # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
+django-cors-headers==3.6.0  # via -r requirements/base.txt
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
+django-extensions==3.1.0  # via -r requirements/base.txt
+django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.11.0  # via -r requirements/base.txt
+django-simple-history==2.12.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.17            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.2    # via -r requirements/base.txt
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
+edx-auth-backends==3.3.0  # via -r requirements/base.txt
+edx-celeryutils==0.5.6    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.5.2           # via -r requirements/quality.in
+edx-lint==1.6             # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.3.3           # via -r requirements/base.txt
+edx-rbac==1.3.4           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
-isort==4.3.21             # via -r requirements/quality.in, pylint
+isort==5.7.0              # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
@@ -50,30 +50,30 @@ lazy-object-proxy==1.4.3  # via astroid
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
-psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, celery, django
+pytz==2020.5              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
@@ -81,12 +81,13 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==3.2.2          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
+toml==0.10.2              # via pylint
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+urllib3==1.26.2           # via -r requirements/base.txt, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-wrapt==1.11.2             # via astroid
+wrapt==1.12.1             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -30,7 +30,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.3.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.6    # via -r requirements/base.txt
+edx-celeryutils==0.5.7    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,50 +7,50 @@
 algoliasearch==2.4.0      # via -r requirements/base.txt
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 appdirs==1.4.4            # via virtualenv
-astroid==2.3.3            # via pylint, pylint-celery
-attrs==20.2.0             # via pytest
+astroid==2.4.2            # via pylint, pylint-celery
+attrs==20.3.0             # via pytest
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+certifi==2020.12.5        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography
+chardet==4.0.0            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.9.0   # via -r requirements/test.in
+code-annotations==0.10.2  # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.3             # via -r requirements/test.in, pytest-cov
-cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.in, pytest-cov
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
 distlib==0.3.1            # via virtualenv
-django-cors-headers==3.5.0  # via -r requirements/base.txt
-django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.9  # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
+django-cors-headers==3.6.0  # via -r requirements/base.txt
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
+django-dynamic-fixture==3.1.1  # via -r requirements/test.in
+django-extensions==3.1.0  # via -r requirements/base.txt
+django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.11.0  # via -r requirements/base.txt
+django-simple-history==2.12.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.2    # via -r requirements/base.txt
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
+edx-auth-backends==3.3.0  # via -r requirements/base.txt
+edx-celeryutils==0.5.6    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.5.2           # via -r requirements/test.in
+edx-lint==1.6             # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.3.3           # via -r requirements/base.txt
+edx-rbac==1.3.4           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-factory-boy==3.0.1        # via -r requirements/test.in
-faker==4.1.6              # via factory-boy
+factory-boy==3.2.0        # via -r requirements/test.in
+faker==5.4.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
-iniconfig==1.0.1          # via pytest
-isort==4.3.21             # via pylint
+iniconfig==1.1.1          # via pytest
+isort==5.7.0              # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
@@ -60,52 +60,52 @@ lazy-object-proxy==1.4.3  # via astroid
 marisa-trie==0.7.5        # via -r requirements/base.txt, langcodes
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-packaging==20.4           # via pytest, tox
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
+packaging==20.8           # via pytest, tox
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest, tox
-psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
-py==1.9.0                 # via pytest, tox
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
+py==1.10.0                # via pytest, tox
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==3.10.0     # via -r requirements/test.in
-pytest==6.1.0             # via pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.2.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, celery, django
+pytz==2020.5              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
 redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==3.2.2          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
-toml==0.10.1              # via pytest, tox
-tox==3.20.0               # via -r requirements/test.in
+toml==0.10.2              # via pylint, pytest, tox
+tox==3.21.0               # via -r requirements/test.in
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+urllib3==1.26.2           # via -r requirements/base.txt, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-virtualenv==20.0.32       # via tox
-wrapt==1.11.2             # via astroid
+virtualenv==20.3.0        # via tox
+wrapt==1.12.1             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -36,7 +36,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/base.txt
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.3.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.6    # via -r requirements/base.txt
+edx-celeryutils==0.5.7    # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
@@ -45,7 +45,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 factory-boy==3.2.0        # via -r requirements/test.in
-faker==5.4.0              # via factory-boy
+faker==5.5.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-packaging==20.4           # via tox
+packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
+py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
+six==1.15.0               # via tox, virtualenv
+toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/tox.in
-tox==3.20.0               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.32       # via tox
+tox==3.21.0               # via -r requirements/tox.in, tox-battery
+virtualenv==20.3.0        # via tox


### PR DESCRIPTION
The bug mentioned on [ARCHBOM-1078](https://openedx.atlassian.net/browse/ARCHBOM-1078) is fixed in `social-auth-core==3.3.3`, See [this comment](https://openedx.atlassian.net/browse/BOM-2094?focusedCommentId=514498) for details, now we are unpinning it wherever it was previously pinned due to that bug.
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2190