### PR TITLE
Add set -e to validate.sh

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+
+set -e  # exit immediately on error
+
 export DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.test
 
-source /edx/app/enterprise_catalog/enterprise_catalog/venv/bin/activate
 cd /edx/app/enterprise_catalog/enterprise_catalog
 
 make requirements


### PR DESCRIPTION
## Description

This will cause `validate.sh` to exit immediately on failure.

This also removes the activation of a non-existent python virtual environment.

## Post-review

Squash commits into discrete sets of changes
