### PR TITLE
feat: adds config to restart celery worker after 100 tasks

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -319,6 +319,9 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
     'fanout_prefix': True,
 }
 
+# Only allow each worker to run 100 tasks before restarting
+CELERY_WORKER_MAX_TASKS_PER_CHILD = 100
+
 """############################# END CELERY ##################################"""
 
 MEDIA_STORAGE_BACKEND = {


### PR DESCRIPTION
## Description

A memory leak has been discovered in our celery workers. This PR adds config to restart each celery worker after it processes 100 tasks. Background and reasoning for the number 100 can be found [in this article](https://adamj.eu/tech/2019/09/19/working-around-memory-leaks-in-your-django-app/).

## Ticket Link

[ENT-4061](https://openedx.atlassian.net/browse/ENT-4061)

## Post-review

Squash commits into discrete sets of changes
