### PR TITLE
ENT-4121 | utils.batch() now checks if the iterable is None. 

### DIFF
--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -101,6 +101,6 @@ def batch(iterable, batch_size=1):
     Returns:
         generator: iterates through each batch of an iterable
     """
-    iterable_len = len(iterable)
+    iterable_len = len(iterable) if iterable is not None else 0
     for index in range(0, iterable_len, batch_size):
         yield iterable[index:min(index + batch_size, iterable_len)]


### PR DESCRIPTION
Also fixes a unit test to be less flaky.

## Ticket Link

[Ticket about associated NoneType error](https://openedx.atlassian.net/browse/ENT-4121)

## Post-review

Squash commits into discrete sets of changes
