### PR TITLE
Install django-celery-results.  Set DB isolation level to read committed

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -21,6 +21,10 @@ catalog.HistoricalEnterpriseCatalog:
   ".. no_pii": "This model has no PII"
 contenttypes.ContentType:
   ".. no_pii:": "This model has no PII"
+django_celery_results.ChordCounter:
+  ".. no_pii:": "This model has no PII"
+django_celery_results.TaskResult:
+  ".. no_pii:": "This model has no PII"
 sessions.Session:
   ".. no_pii:": "This model has no PII"
 social_django.Association:

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
 THIRD_PARTY_APPS = (
     'corsheaders',
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
+    'django_celery_results',  # Enables a Django model as the celery result backend
     'rest_framework',
     'rest_framework_swagger',
     'social_django',
@@ -100,6 +101,12 @@ DATABASES = {
         'HOST': 'localhost',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
         'PORT': '',  # Set to empty string for default.
         'ATOMIC_REQUESTS': False,
+        # The default isolation level for MySQL is REPEATABLE READ, which is a little too aggressive
+        # for our needs, particularly around reading celery task state via django-celery-results.
+        # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html#isolevel_read-committed
+        'OPTIONS': {
+            'isolation_level': 'read committed',
+        },
     }
 }
 
@@ -302,7 +309,7 @@ CELERY_BROKER_URL = '{}://{}:{}@{}/{}'.format(
 )
 
 # Results configuration
-CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_RESULT_BACKEND = 'django-db'
 CELERY_TASK_IGNORE_RESULT = False
 CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
 

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -45,6 +45,12 @@ DATABASES = {
         'PORT': os.environ.get('DB_PORT', 3306),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,
+        # The default isolation level for MySQL is REPEATABLE READ, which is a little too aggressive
+        # for our needs, particularly around reading celery task state via django-celery-results.
+        # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html#isolevel_read-committed
+        'OPTIONS': {
+            'isolation_level': 'read committed',
+        },
     }
 }
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,7 @@
 -r github.in              # Forks and other dependencies not yet on PyPI
 
 Django>=2.2,<2.3          # Web application framework
+django-celery-results
 django-cors-headers
 django-crum
 django-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,73 +4,226 @@
 #
 #    make upgrade
 #
-algoliasearch==2.4.0      # via -r requirements/base.in
-amqp==2.6.1               # via kombu
-billiard==3.6.3.0         # via celery
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
-certifi==2020.12.5        # via requests
-cffi==1.14.5              # via cryptography
-chardet==4.0.0            # via requests
-coreapi==2.3.3            # via django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via coreapi
-cryptography==3.4.6       # via pyjwt, social-auth-core
-defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.7.0  # via -r requirements/base.in
-django-crum==0.7.9        # via -r requirements/base.in, edx-django-utils, edx-rbac
-django-extensions==3.1.1  # via -r requirements/base.in
-django-model-utils==4.1.1  # via -r requirements/base.in, edx-celeryutils, edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.in
-django-simple-history==2.12.0  # via -r requirements/base.in
-django-waffle==2.1.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.18            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==2.0.0  # via -r requirements/base.in
-djangorestframework==3.12.2  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.3           # via edx-drf-extensions
-edx-auth-backends==3.3.3  # via -r requirements/base.in
-edx-celeryutils==1.0.0    # via -r requirements/base.in
-edx-django-release-util==1.0.0  # via -r requirements/base.in
-edx-django-utils==3.13.0  # via edx-drf-extensions
-edx-drf-extensions==6.5.0  # via -r requirements/base.in, edx-rbac
-edx-opaque-keys==2.2.0    # via edx-drf-extensions
-edx-rbac==1.4.1           # via -r requirements/base.in
-edx-rest-api-client==1.9.2  # via -r requirements/base.in
-future==0.18.2            # via edx-celeryutils, pyjwkest
-idna==2.10                # via requests
-itypes==1.2.0             # via coreapi
-jinja2==2.11.3            # via coreschema
-jsonfield2==3.0.3         # via -r requirements/base.in, edx-celeryutils
-kombu==4.6.11             # via celery
-langcodes==3.0.0          # via -r requirements/base.in
-markupsafe==1.1.1         # via jinja2
-mysqlclient==2.0.3        # via -r requirements/base.in
-newrelic==6.0.1.155       # via edx-django-utils
-oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via django-rest-swagger
-pbr==5.5.1                # via stevedore
-psutil==5.8.0             # via edx-django-utils
-pycparser==2.20           # via cffi
-pycryptodomex==3.10.1     # via pyjwkest
-pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.3           # via edx-opaque-keys
-python-dateutil==2.8.1    # via edx-drf-extensions
-python3-openid==3.2.0     # via social-auth-core
-pytz==2021.1              # via -r requirements/base.in, celery, django
-pyyaml==5.4.1             # via edx-django-release-util
-redis==3.5.3              # via -r requirements/base.in
-requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.25.1          # via algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via edx-drf-extensions
-rules==2.2                # via -r requirements/base.in
-semantic-version==2.8.5   # via edx-drf-extensions
-simplejson==3.17.2        # via django-rest-swagger
-six==1.15.0               # via django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
-slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via django
-stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
-uritemplate==3.0.1        # via coreapi
-urllib3==1.26.3           # via requests
-vine==1.3.0               # via amqp, celery
-zipp==1.2.0               # via -r requirements/base.in
+algoliasearch==2.4.0
+    # via -r requirements/base.in
+amqp==2.6.1
+    # via kombu
+billiard==3.6.3.0
+    # via celery
+celery==4.4.7
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   django-celery-results
+    #   edx-celeryutils
+certifi==2020.12.5
+    # via requests
+cffi==1.14.5
+    # via cryptography
+chardet==4.0.0
+    # via requests
+coreapi==2.3.3
+    # via
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via coreapi
+cryptography==3.4.6
+    # via
+    #   pyjwt
+    #   social-auth-core
+defusedxml==0.6.0
+    # via
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+django-celery-results==2.0.1
+    # via -r requirements/base.in
+django-cors-headers==3.7.0
+    # via -r requirements/base.in
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.in
+    #   edx-django-utils
+    #   edx-rbac
+django-extensions==3.1.1
+    # via -r requirements/base.in
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/base.in
+    #   edx-celeryutils
+    #   edx-rbac
+django-rest-swagger==2.2.0
+    # via -r requirements/base.in
+django-simple-history==2.12.0
+    # via -r requirements/base.in
+django-waffle==2.1.0
+    # via
+    #   -r requirements/base.in
+    #   edx-django-utils
+    #   edx-drf-extensions
+django==2.2.18
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/base.in
+    #   django-cors-headers
+    #   django-crum
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-celeryutils
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-rbac
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-xml==2.0.0
+    # via -r requirements/base.in
+djangorestframework==3.12.2
+    # via
+    #   -r requirements/base.in
+    #   django-rest-swagger
+    #   drf-jwt
+    #   edx-drf-extensions
+    #   rest-condition
+drf-jwt==1.17.3
+    # via edx-drf-extensions
+edx-auth-backends==3.3.3
+    # via -r requirements/base.in
+edx-celeryutils==1.0.0
+    # via -r requirements/base.in
+edx-django-release-util==1.0.0
+    # via -r requirements/base.in
+edx-django-utils==3.13.0
+    # via edx-drf-extensions
+edx-drf-extensions==6.5.0
+    # via
+    #   -r requirements/base.in
+    #   edx-rbac
+edx-opaque-keys==2.2.0
+    # via edx-drf-extensions
+edx-rbac==1.4.1
+    # via -r requirements/base.in
+edx-rest-api-client==1.9.2
+    # via -r requirements/base.in
+future==0.18.2
+    # via
+    #   edx-celeryutils
+    #   pyjwkest
+idna==2.10
+    # via requests
+itypes==1.2.0
+    # via coreapi
+jinja2==2.11.3
+    # via coreschema
+jsonfield2==3.0.3
+    # via
+    #   -r requirements/base.in
+    #   edx-celeryutils
+kombu==4.6.11
+    # via celery
+langcodes==3.0.0
+    # via -r requirements/base.in
+markupsafe==1.1.1
+    # via jinja2
+mysqlclient==2.0.3
+    # via -r requirements/base.in
+newrelic==6.0.1.155
+    # via edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+openapi-codec==1.3.2
+    # via django-rest-swagger
+pbr==5.5.1
+    # via stevedore
+psutil==5.8.0
+    # via edx-django-utils
+pycparser==2.20
+    # via cffi
+pycryptodomex==3.10.1
+    # via pyjwkest
+pyjwkest==1.4.2
+    # via edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-rest-api-client
+    #   social-auth-core
+pymongo==3.11.3
+    # via edx-opaque-keys
+python-dateutil==2.8.1
+    # via edx-drf-extensions
+python3-openid==3.2.0
+    # via social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/base.in
+    #   celery
+    #   django
+pyyaml==5.4.1
+    # via edx-django-release-util
+redis==3.5.3
+    # via -r requirements/base.in
+requests-oauthlib==1.3.0
+    # via social-auth-core
+requests==2.25.1
+    # via
+    #   algoliasearch
+    #   coreapi
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
+rest-condition==1.0.3
+    # via edx-drf-extensions
+rules==2.2
+    # via -r requirements/base.in
+semantic-version==2.8.5
+    # via edx-drf-extensions
+simplejson==3.17.2
+    # via django-rest-swagger
+six==1.15.0
+    # via
+    #   django-simple-history
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-drf-extensions
+    #   edx-rbac
+    #   pyjwkest
+    #   python-dateutil
+    #   social-auth-app-django
+    #   social-auth-core
+slumber==0.7.1
+    # via edx-rest-api-client
+social-auth-app-django==4.0.0
+    # via
+    #   -r requirements/base.in
+    #   edx-auth-backends
+social-auth-core==4.0.2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sqlparse==0.4.1
+    # via django
+stevedore==3.3.0
+    # via
+    #   edx-django-utils
+    #   edx-opaque-keys
+uritemplate==3.0.1
+    # via coreapi
+urllib3==1.26.3
+    # via requests
+vine==1.3.0
+    # via
+    #   amqp
+    #   celery
+zipp==1.2.0
+    # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,140 +4,651 @@
 #
 #    make upgrade
 #
-algoliasearch==2.4.0      # via -r requirements/quality.txt, -r requirements/test.txt
-amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
-appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-astroid==2.4.2            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
-attrs==20.3.0             # via -r requirements/test.txt, jsonschema, pytest
-bcrypt==3.2.0             # via paramiko
-billiard==3.6.3.0         # via -r requirements/quality.txt, -r requirements/test.txt, celery
-cached-property==1.5.2    # via docker-compose
-celery==4.4.7             # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/test.txt, requests
-cffi==1.14.5              # via -r requirements/quality.txt, -r requirements/test.txt, bcrypt, cryptography, pynacl
-chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/test.txt, diff-cover, requests
-click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==1.1.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.4             # via -r requirements/test.txt, pytest-cov
-cryptography==3.4.6       # via -r requirements/quality.txt, -r requirements/test.txt, paramiko, pyjwt, social-auth-core
-ddt==1.4.1                # via -r requirements/dev.in, -r requirements/test.txt
-defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
-diff-cover==4.2.1         # via -r requirements/dev.in
-distlib==0.3.1            # via -r requirements/test.txt, virtualenv
-distro==1.5.0             # via docker-compose
-django-cors-headers==3.7.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-crum==0.7.9        # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-rbac
-django-debug-toolbar==3.2  # via -r requirements/dev.in
-django-dynamic-fixture==3.1.1  # via -r requirements/test.txt
-django-extensions==3.1.1  # via -r requirements/quality.txt, -r requirements/test.txt
-django-model-utils==4.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-simple-history==2.12.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-waffle==2.1.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.18            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
-djangorestframework==3.12.2  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-docker-compose==1.28.2    # via -r requirements/dev.in
-docker[ssh]==4.4.2        # via docker-compose
-dockerpty==0.4.1          # via docker-compose
-docopt==0.6.2             # via docker-compose
-drf-jwt==1.17.3           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.3.3  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-celeryutils==1.0.0    # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-release-util==1.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.13.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.5.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
-edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==4.0.1           # via -r requirements/quality.txt, -r requirements/test.txt
-edx-opaque-keys==2.2.0    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
-edx-rest-api-client==1.9.2  # via -r requirements/quality.txt, -r requirements/test.txt
-factory-boy==3.2.0        # via -r requirements/test.txt
-faker==6.1.1              # via -r requirements/test.txt, factory-boy
-filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, pyjwkest
-gunicorn==20.0.4          # via -r requirements/dev.in
-idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==3.4.0  # via inflect
-inflect==3.0.2            # via -r requirements/dev.in, jinja2-pluralize
-iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==5.7.0              # via -r requirements/quality.txt, -r requirements/test.txt, pylint
-itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.3            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
-jsonfield2==3.0.3         # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-jsonschema==3.2.0         # via docker-compose
-kombu==4.6.11             # via -r requirements/quality.txt, -r requirements/test.txt, celery
-langcodes==3.0.0          # via -r requirements/quality.txt, -r requirements/test.txt
-lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
-markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
-mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
-mysqlclient==2.0.3        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==6.0.1.155       # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
-oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-packaging==20.9           # via -r requirements/test.txt, pytest, tox
-paramiko==2.7.2           # via docker
-path.py==12.5.0           # via edx-i18n-tools
-path==15.1.0              # via path.py
-pbr==5.5.1                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
-pip-tools==5.5.0          # via -r requirements/pip-tools.txt
-pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
-polib==1.1.0              # via edx-i18n-tools
-psutil==5.8.0             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
-py==1.10.0                # via -r requirements/test.txt, pytest, tox
-pycodestyle==2.6.0        # via -r requirements/quality.txt
-pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
-pycryptodomex==3.10.1     # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
-pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.8.0           # via diff-cover
-pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-pylint-django==2.4.2      # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.6.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.3           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
-pynacl==1.4.0             # via paramiko
-pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pyrsistent==0.17.3        # via jsonschema
-pytest-cov==2.11.1        # via -r requirements/test.txt
-pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.2.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
-python-dotenv==0.15.0     # via docker-compose
-python-slugify==4.0.1     # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations
-python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-pytz==2021.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django
-pyyaml==5.4.1             # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, docker-compose, edx-django-release-util, edx-i18n-tools
-redis==3.5.3              # via -r requirements/quality.txt, -r requirements/test.txt
-requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-requests==2.25.1          # via -r requirements/quality.txt, -r requirements/test.txt, algoliasearch, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
-semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, bcrypt, django-dynamic-fixture, django-simple-history, docker, dockerpty, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-rbac, jsonschema, pyjwkest, pynacl, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv, websocket-client
-slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
-snowballstemmer==2.1.0    # via -r requirements/quality.txt, pydocstyle
-social-auth-app-django==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
-social-auth-core==4.0.2   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/quality.txt, -r requirements/test.txt, django, django-debug-toolbar
-stevedore==3.3.0          # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via -r requirements/quality.txt, -r requirements/test.txt, faker, python-slugify
-texttable==1.6.3          # via docker-compose
-toml==0.10.2              # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pytest, tox
-tox==3.22.0               # via -r requirements/test.txt
-uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-urllib3==1.26.3           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp, celery
-virtualenv==20.4.2        # via -r requirements/test.txt, tox
-websocket-client==0.57.0  # via docker, docker-compose
-wrapt==1.12.1             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
-zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata
+algoliasearch==2.4.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+amqp==2.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   kombu
+appdirs==1.4.4
+    # via
+    #   -r requirements/test.txt
+    #   virtualenv
+astroid==2.4.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pylint
+    #   pylint-celery
+attrs==20.3.0
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   pytest
+bcrypt==3.2.0
+    # via paramiko
+billiard==3.6.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   celery
+cached-property==1.5.2
+    # via docker-compose
+celery==4.4.7
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-celery-results
+    #   edx-celeryutils
+certifi==2020.12.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+chardet==4.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   diff-cover
+    #   requests
+click-log==0.3.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-lint
+click==7.1.2
+    # via
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   click-log
+    #   code-annotations
+    #   edx-lint
+    #   pip-tools
+code-annotations==1.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-lint
+coreapi==2.3.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   coreapi
+coverage==5.4
+    # via
+    #   -r requirements/test.txt
+    #   pytest-cov
+cryptography==3.4.6
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   paramiko
+    #   pyjwt
+    #   social-auth-core
+ddt==1.4.1
+    # via
+    #   -r requirements/dev.in
+    #   -r requirements/test.txt
+defusedxml==0.6.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+diff-cover==4.2.1
+    # via -r requirements/dev.in
+distlib==0.3.1
+    # via
+    #   -r requirements/test.txt
+    #   virtualenv
+distro==1.5.0
+    # via docker-compose
+django-celery-results==2.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-cors-headers==3.7.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-crum==0.7.9
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-rbac
+django-debug-toolbar==3.2
+    # via -r requirements/dev.in
+django-dynamic-fixture==3.1.1
+    # via -r requirements/test.txt
+django-extensions==3.1.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-celeryutils
+    #   edx-rbac
+django-rest-swagger==2.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-simple-history==2.12.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-waffle==2.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django==2.2.18
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   django-cors-headers
+    #   django-crum
+    #   django-debug-toolbar
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-celeryutils
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-i18n-tools
+    #   edx-lint
+    #   edx-rbac
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-xml==2.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+djangorestframework==3.12.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+    #   drf-jwt
+    #   edx-drf-extensions
+    #   rest-condition
+docker-compose==1.28.2
+    # via -r requirements/dev.in
+docker[ssh]==4.4.2
+    # via docker-compose
+dockerpty==0.4.1
+    # via docker-compose
+docopt==0.6.2
+    # via docker-compose
+drf-jwt==1.17.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-auth-backends==3.3.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-celeryutils==1.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-django-release-util==1.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-django-utils==3.13.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-drf-extensions==6.5.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-rbac
+edx-i18n-tools==0.5.3
+    # via -r requirements/dev.in
+edx-lint==4.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-opaque-keys==2.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-rbac==1.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-rest-api-client==1.9.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+factory-boy==3.2.0
+    # via -r requirements/test.txt
+faker==6.1.1
+    # via
+    #   -r requirements/test.txt
+    #   factory-boy
+filelock==3.0.12
+    # via
+    #   -r requirements/test.txt
+    #   tox
+    #   virtualenv
+future==0.18.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-celeryutils
+    #   pyjwkest
+gunicorn==20.0.4
+    # via -r requirements/dev.in
+idna==2.10
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requests
+importlib-metadata==3.4.0
+    # via inflect
+inflect==3.0.2
+    # via
+    #   -r requirements/dev.in
+    #   jinja2-pluralize
+iniconfig==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+isort==5.7.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pylint
+itypes==1.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   coreapi
+jinja2-pluralize==0.3.0
+    # via diff-cover
+jinja2==2.11.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   coreschema
+    #   diff-cover
+    #   jinja2-pluralize
+jsonfield2==3.0.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-celeryutils
+jsonschema==3.2.0
+    # via docker-compose
+kombu==4.6.11
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   celery
+langcodes==3.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+lazy-object-proxy==1.4.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jinja2
+mccabe==0.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pylint
+mysqlclient==2.0.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+newrelic==6.0.1.155
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requests-oauthlib
+    #   social-auth-core
+openapi-codec==1.3.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+packaging==20.9
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+    #   tox
+paramiko==2.7.2
+    # via docker
+path.py==12.5.0
+    # via edx-i18n-tools
+path==15.1.0
+    # via path.py
+pbr==5.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   stevedore
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.txt
+pluggy==0.13.1
+    # via
+    #   -r requirements/test.txt
+    #   diff-cover
+    #   pytest
+    #   tox
+polib==1.1.0
+    # via edx-i18n-tools
+psutil==5.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+py==1.10.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+    #   tox
+pycodestyle==2.6.0
+    # via -r requirements/quality.txt
+pycparser==2.20
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   cffi
+pycryptodomex==3.10.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
+pydocstyle==5.1.1
+    # via -r requirements/quality.txt
+pygments==2.8.0
+    # via diff-cover
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-rest-api-client
+    #   social-auth-core
+pylint-celery==0.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-lint
+pylint-django==2.4.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-lint
+pylint-plugin-utils==0.6
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-lint
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+pymongo==3.11.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+pynacl==1.4.0
+    # via paramiko
+pyparsing==2.4.7
+    # via
+    #   -r requirements/test.txt
+    #   packaging
+pyrsistent==0.17.3
+    # via jsonschema
+pytest-cov==2.11.1
+    # via -r requirements/test.txt
+pytest-django==4.1.0
+    # via -r requirements/test.txt
+pytest==6.2.2
+    # via
+    #   -r requirements/test.txt
+    #   pytest-cov
+    #   pytest-django
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+    #   faker
+python-dotenv==0.15.0
+    # via docker-compose
+python-slugify==4.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+python3-openid==3.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   celery
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   docker-compose
+    #   edx-django-release-util
+    #   edx-i18n-tools
+redis==3.5.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   algoliasearch
+    #   coreapi
+    #   docker
+    #   docker-compose
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
+rest-condition==1.0.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+rules==2.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+semantic-version==2.8.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+simplejson==3.17.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+six==1.15.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   astroid
+    #   bcrypt
+    #   django-dynamic-fixture
+    #   django-simple-history
+    #   docker
+    #   dockerpty
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-drf-extensions
+    #   edx-i18n-tools
+    #   edx-lint
+    #   edx-rbac
+    #   jsonschema
+    #   pyjwkest
+    #   pynacl
+    #   python-dateutil
+    #   social-auth-app-django
+    #   social-auth-core
+    #   tox
+    #   virtualenv
+    #   websocket-client
+slumber==0.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-rest-api-client
+snowballstemmer==2.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   pydocstyle
+social-auth-app-django==4.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+social-auth-core==4.0.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sqlparse==0.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django
+    #   django-debug-toolbar
+stevedore==3.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
+text-unidecode==1.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   faker
+    #   python-slugify
+texttable==1.6.3
+    # via docker-compose
+toml==0.10.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pylint
+    #   pytest
+    #   tox
+tox==3.22.0
+    # via -r requirements/test.txt
+uritemplate==3.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   coreapi
+urllib3==1.26.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requests
+vine==1.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   amqp
+    #   celery
+virtualenv==20.4.2
+    # via
+    #   -r requirements/test.txt
+    #   tox
+websocket-client==0.57.0
+    # via
+    #   docker
+    #   docker-compose
+wrapt==1.12.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   astroid
+zipp==1.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.18            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.18

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,130 +4,513 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
-algoliasearch==2.4.0      # via -r requirements/test.txt
-amqp==2.6.1               # via -r requirements/test.txt, kombu
-appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==20.3.0             # via -r requirements/test.txt, pytest
-babel==2.9.0              # via sphinx
-billiard==3.6.3.0         # via -r requirements/test.txt, celery
-bleach==3.3.0             # via readme-renderer
-celery==4.4.7             # via -r requirements/test.txt, edx-celeryutils
-certifi==2020.12.5        # via -r requirements/test.txt, requests
-cffi==1.14.5              # via -r requirements/test.txt, cryptography
-chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
-click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==1.1.0   # via -r requirements/test.txt, edx-lint
-coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.4             # via -r requirements/test.txt, pytest-cov
-cryptography==3.4.6       # via -r requirements/test.txt, pyjwt, social-auth-core
-ddt==1.4.1                # via -r requirements/test.txt
-defusedxml==0.6.0         # via -r requirements/test.txt, djangorestframework-xml, python3-openid, social-auth-core
-distlib==0.3.1            # via -r requirements/test.txt, virtualenv
-django-cors-headers==3.7.0  # via -r requirements/test.txt
-django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils, edx-rbac
-django-dynamic-fixture==3.1.1  # via -r requirements/test.txt
-django-extensions==3.1.1  # via -r requirements/test.txt
-django-model-utils==4.1.1  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-simple-history==2.12.0  # via -r requirements/test.txt
-django-waffle==2.1.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.18            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-lint, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==2.0.0  # via -r requirements/test.txt
-djangorestframework==3.12.2  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-doc8==0.8.1               # via -r requirements/doc.in
-docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.3.3  # via -r requirements/test.txt
-edx-celeryutils==1.0.0    # via -r requirements/test.txt
-edx-django-release-util==1.0.0  # via -r requirements/test.txt
-edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.5.0  # via -r requirements/test.txt, edx-rbac
-edx-lint==4.0.1           # via -r requirements/test.txt
-edx-opaque-keys==2.2.0    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.4.1           # via -r requirements/test.txt
-edx-rest-api-client==1.9.2  # via -r requirements/test.txt
-edx-sphinx-theme==2.0.0   # via -r requirements/doc.in
-factory-boy==3.2.0        # via -r requirements/test.txt
-faker==6.1.1              # via -r requirements/test.txt, factory-boy
-filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-future==0.18.2            # via -r requirements/test.txt, edx-celeryutils, pyjwkest
-idna==2.10                # via -r requirements/test.txt, requests
-imagesize==1.2.0          # via sphinx
-iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==5.7.0              # via -r requirements/test.txt, pylint
-itypes==1.2.0             # via -r requirements/test.txt, coreapi
-jinja2==2.11.3            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
-jsonfield2==3.0.3         # via -r requirements/test.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/test.txt, celery
-langcodes==3.0.0          # via -r requirements/test.txt
-lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
-markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
-mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mysqlclient==2.0.3        # via -r requirements/test.txt
-newrelic==6.0.1.155       # via -r requirements/test.txt, edx-django-utils
-oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
-packaging==20.9           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
-pbr==5.5.1                # via -r requirements/test.txt, stevedore
-pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
-py==1.10.0                # via -r requirements/test.txt, pytest, tox
-pycparser==2.20           # via -r requirements/test.txt, cffi
-pycryptodomex==3.10.1     # via -r requirements/test.txt, pyjwkest
-pygments==2.8.0           # via doc8, readme-renderer, sphinx
-pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.4.2      # via -r requirements/test.txt, edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.6.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.3           # via -r requirements/test.txt, edx-opaque-keys
-pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.11.1        # via -r requirements/test.txt
-pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.2.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
-python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
-python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2021.1              # via -r requirements/test.txt, babel, celery, django
-pyyaml==5.4.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
-readme-renderer==28.0     # via -r requirements/doc.in
-redis==3.5.3              # via -r requirements/test.txt
-requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.25.1          # via -r requirements/test.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
-rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
-restructuredtext-lint==1.3.2  # via doc8
-rules==2.2                # via -r requirements/test.txt
-semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
-simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-rbac, edx-sphinx-theme, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, tox, virtualenv
-slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
-snowballstemmer==2.1.0    # via sphinx
-social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==4.0.2   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.5.1             # via -r requirements/doc.in, edx-sphinx-theme
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-sqlparse==0.4.1           # via -r requirements/test.txt, django
-stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, tox
-tox==3.22.0               # via -r requirements/test.txt
-uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.26.3           # via -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp, celery
-virtualenv==20.4.2        # via -r requirements/test.txt, tox
-webencodings==0.5.1       # via bleach
-wrapt==1.12.1             # via -r requirements/test.txt, astroid
-zipp==1.2.0               # via -r requirements/test.txt
+alabaster==0.7.12
+    # via sphinx
+algoliasearch==2.4.0
+    # via -r requirements/test.txt
+amqp==2.6.1
+    # via
+    #   -r requirements/test.txt
+    #   kombu
+appdirs==1.4.4
+    # via
+    #   -r requirements/test.txt
+    #   virtualenv
+astroid==2.4.2
+    # via
+    #   -r requirements/test.txt
+    #   pylint
+    #   pylint-celery
+attrs==20.3.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+babel==2.9.0
+    # via sphinx
+billiard==3.6.3.0
+    # via
+    #   -r requirements/test.txt
+    #   celery
+bleach==3.3.0
+    # via readme-renderer
+celery==4.4.7
+    # via
+    #   -r requirements/test.txt
+    #   django-celery-results
+    #   edx-celeryutils
+certifi==2020.12.5
+    # via
+    #   -r requirements/test.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/test.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/test.txt
+    #   doc8
+    #   requests
+click-log==0.3.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+click==7.1.2
+    # via
+    #   -r requirements/test.txt
+    #   click-log
+    #   code-annotations
+    #   edx-lint
+code-annotations==1.1.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+coreapi==2.3.3
+    # via
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via
+    #   -r requirements/test.txt
+    #   coreapi
+coverage==5.4
+    # via
+    #   -r requirements/test.txt
+    #   pytest-cov
+cryptography==3.4.6
+    # via
+    #   -r requirements/test.txt
+    #   pyjwt
+    #   social-auth-core
+ddt==1.4.1
+    # via -r requirements/test.txt
+defusedxml==0.6.0
+    # via
+    #   -r requirements/test.txt
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+distlib==0.3.1
+    # via
+    #   -r requirements/test.txt
+    #   virtualenv
+django-celery-results==2.0.1
+    # via -r requirements/test.txt
+django-cors-headers==3.7.0
+    # via -r requirements/test.txt
+django-crum==0.7.9
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-rbac
+django-dynamic-fixture==3.1.1
+    # via -r requirements/test.txt
+django-extensions==3.1.1
+    # via -r requirements/test.txt
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/test.txt
+    #   edx-celeryutils
+    #   edx-rbac
+django-rest-swagger==2.2.0
+    # via -r requirements/test.txt
+django-simple-history==2.12.0
+    # via -r requirements/test.txt
+django-waffle==2.1.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django==2.2.18
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   django-cors-headers
+    #   django-crum
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-celeryutils
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-lint
+    #   edx-rbac
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-xml==2.0.0
+    # via -r requirements/test.txt
+djangorestframework==3.12.2
+    # via
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+    #   drf-jwt
+    #   edx-drf-extensions
+    #   rest-condition
+doc8==0.8.1
+    # via -r requirements/doc.in
+docutils==0.16
+    # via
+    #   doc8
+    #   readme-renderer
+    #   restructuredtext-lint
+    #   sphinx
+drf-jwt==1.17.3
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-auth-backends==3.3.3
+    # via -r requirements/test.txt
+edx-celeryutils==1.0.0
+    # via -r requirements/test.txt
+edx-django-release-util==1.0.0
+    # via -r requirements/test.txt
+edx-django-utils==3.13.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-drf-extensions==6.5.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-rbac
+edx-lint==4.0.1
+    # via -r requirements/test.txt
+edx-opaque-keys==2.2.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-rbac==1.4.1
+    # via -r requirements/test.txt
+edx-rest-api-client==1.9.2
+    # via -r requirements/test.txt
+edx-sphinx-theme==2.0.0
+    # via -r requirements/doc.in
+factory-boy==3.2.0
+    # via -r requirements/test.txt
+faker==6.1.1
+    # via
+    #   -r requirements/test.txt
+    #   factory-boy
+filelock==3.0.12
+    # via
+    #   -r requirements/test.txt
+    #   tox
+    #   virtualenv
+future==0.18.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-celeryutils
+    #   pyjwkest
+idna==2.10
+    # via
+    #   -r requirements/test.txt
+    #   requests
+imagesize==1.2.0
+    # via sphinx
+iniconfig==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+isort==5.7.0
+    # via
+    #   -r requirements/test.txt
+    #   pylint
+itypes==1.2.0
+    # via
+    #   -r requirements/test.txt
+    #   coreapi
+jinja2==2.11.3
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   coreschema
+    #   sphinx
+jsonfield2==3.0.3
+    # via
+    #   -r requirements/test.txt
+    #   edx-celeryutils
+kombu==4.6.11
+    # via
+    #   -r requirements/test.txt
+    #   celery
+langcodes==3.0.0
+    # via -r requirements/test.txt
+lazy-object-proxy==1.4.3
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   jinja2
+mccabe==0.6.1
+    # via
+    #   -r requirements/test.txt
+    #   pylint
+mysqlclient==2.0.3
+    # via -r requirements/test.txt
+newrelic==6.0.1.155
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   -r requirements/test.txt
+    #   requests-oauthlib
+    #   social-auth-core
+openapi-codec==1.3.2
+    # via
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+packaging==20.9
+    # via
+    #   -r requirements/test.txt
+    #   bleach
+    #   pytest
+    #   sphinx
+    #   tox
+pbr==5.5.1
+    # via
+    #   -r requirements/test.txt
+    #   stevedore
+pluggy==0.13.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+    #   tox
+psutil==5.8.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+py==1.10.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+    #   tox
+pycparser==2.20
+    # via
+    #   -r requirements/test.txt
+    #   cffi
+pycryptodomex==3.10.1
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
+pygments==2.8.0
+    # via
+    #   doc8
+    #   readme-renderer
+    #   sphinx
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   -r requirements/test.txt
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-rest-api-client
+    #   social-auth-core
+pylint-celery==0.3
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+pylint-django==2.4.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+pylint-plugin-utils==0.6
+    # via
+    #   -r requirements/test.txt
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+pymongo==3.11.3
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+pyparsing==2.4.7
+    # via
+    #   -r requirements/test.txt
+    #   packaging
+pytest-cov==2.11.1
+    # via -r requirements/test.txt
+pytest-django==4.1.0
+    # via -r requirements/test.txt
+pytest==6.2.2
+    # via
+    #   -r requirements/test.txt
+    #   pytest-cov
+    #   pytest-django
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+    #   faker
+python-slugify==4.0.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+python3-openid==3.2.0
+    # via
+    #   -r requirements/test.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/test.txt
+    #   babel
+    #   celery
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   edx-django-release-util
+readme-renderer==28.0
+    # via -r requirements/doc.in
+redis==3.5.3
+    # via -r requirements/test.txt
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements/test.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/test.txt
+    #   algoliasearch
+    #   coreapi
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
+    #   sphinx
+rest-condition==1.0.3
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+restructuredtext-lint==1.3.2
+    # via doc8
+rules==2.2
+    # via -r requirements/test.txt
+semantic-version==2.8.5
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+simplejson==3.17.2
+    # via
+    #   -r requirements/test.txt
+    #   django-rest-swagger
+six==1.15.0
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+    #   bleach
+    #   django-dynamic-fixture
+    #   django-simple-history
+    #   doc8
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-drf-extensions
+    #   edx-lint
+    #   edx-rbac
+    #   edx-sphinx-theme
+    #   pyjwkest
+    #   python-dateutil
+    #   readme-renderer
+    #   social-auth-app-django
+    #   social-auth-core
+    #   tox
+    #   virtualenv
+slumber==0.7.1
+    # via
+    #   -r requirements/test.txt
+    #   edx-rest-api-client
+snowballstemmer==2.1.0
+    # via sphinx
+social-auth-app-django==4.0.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+social-auth-core==4.0.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sphinx==3.5.1
+    # via
+    #   -r requirements/doc.in
+    #   edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==1.0.3
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinx
+sqlparse==0.4.1
+    # via
+    #   -r requirements/test.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   doc8
+    #   edx-django-utils
+    #   edx-opaque-keys
+text-unidecode==1.3
+    # via
+    #   -r requirements/test.txt
+    #   faker
+    #   python-slugify
+toml==0.10.2
+    # via
+    #   -r requirements/test.txt
+    #   pylint
+    #   pytest
+    #   tox
+tox==3.22.0
+    # via -r requirements/test.txt
+uritemplate==3.0.1
+    # via
+    #   -r requirements/test.txt
+    #   coreapi
+urllib3==1.26.3
+    # via
+    #   -r requirements/test.txt
+    #   requests
+vine==1.3.0
+    # via
+    #   -r requirements/test.txt
+    #   amqp
+    #   celery
+virtualenv==20.4.2
+    # via
+    #   -r requirements/test.txt
+    #   tox
+webencodings==0.5.1
+    # via bleach
+wrapt==1.12.1
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+zipp==1.2.0
+    # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip-tools.in
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,82 +4,317 @@
 #
 #    make upgrade
 #
-algoliasearch==2.4.0      # via -r requirements/base.txt
-amqp==2.6.1               # via -r requirements/base.txt, kombu
-billiard==3.6.3.0         # via -r requirements/base.txt, celery
-celery==4.4.7             # via -r requirements/base.txt, edx-celeryutils
-certifi==2020.12.5        # via -r requirements/base.txt, requests
-cffi==1.14.5              # via -r requirements/base.txt, cryptography
-chardet==4.0.0            # via -r requirements/base.txt, requests
-coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.4.6       # via -r requirements/base.txt, pyjwt, social-auth-core
-defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.7.0  # via -r requirements/base.txt
-django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
-django-extensions==3.1.1  # via -r requirements/base.txt
-django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.12.0  # via -r requirements/base.txt
-django-waffle==2.1.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.18            # via -r requirements/base.txt, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.3.3  # via -r requirements/base.txt
-edx-celeryutils==1.0.0    # via -r requirements/base.txt
-edx-django-release-util==1.0.0  # via -r requirements/base.txt
-edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.5.0  # via -r requirements/base.txt, edx-rbac
-edx-opaque-keys==2.2.0    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.4.1           # via -r requirements/base.txt
-edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
-gevent==21.1.2            # via -r requirements/production.in
-greenlet==1.0.0           # via gevent
-gunicorn==20.0.4          # via -r requirements/production.in
-idna==2.10                # via -r requirements/base.txt, requests
-itypes==1.2.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.3            # via -r requirements/base.txt, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/base.txt, celery
-langcodes==3.0.0          # via -r requirements/base.txt
-markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==2.0.3        # via -r requirements/base.txt
-newrelic==6.0.1.155       # via -r requirements/base.txt, edx-django-utils
-oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
-psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.10.1     # via -r requirements/base.txt, pyjwkest
-pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
-python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-memcached==1.59    # via -r requirements/production.in
-python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2021.1              # via -r requirements/base.txt, celery, django
-pyyaml==5.4.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
-redis==3.5.3              # via -r requirements/base.txt
-requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.25.1          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-rules==2.2                # via -r requirements/base.txt
-semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
-slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.26.3           # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-zipp==1.2.0               # via -r requirements/base.txt
-zope.event==4.5.0         # via gevent
-zope.interface==5.2.0     # via gevent
+algoliasearch==2.4.0
+    # via -r requirements/base.txt
+amqp==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+billiard==3.6.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==4.4.7
+    # via
+    #   -r requirements/base.txt
+    #   django-celery-results
+    #   edx-celeryutils
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+coreapi==2.3.3
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+cryptography==3.4.6
+    # via
+    #   -r requirements/base.txt
+    #   pyjwt
+    #   social-auth-core
+defusedxml==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+django-celery-results==2.0.1
+    # via -r requirements/base.txt
+django-cors-headers==3.7.0
+    # via -r requirements/base.txt
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-rbac
+django-extensions==3.1.1
+    # via -r requirements/base.txt
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+    #   edx-rbac
+django-rest-swagger==2.2.0
+    # via -r requirements/base.txt
+django-simple-history==2.12.0
+    # via -r requirements/base.txt
+django-waffle==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django==2.2.18
+    # via
+    #   -r requirements/base.txt
+    #   django-cors-headers
+    #   django-crum
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-celeryutils
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-rbac
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-xml==2.0.0
+    # via -r requirements/base.txt
+djangorestframework==3.12.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+    #   drf-jwt
+    #   edx-drf-extensions
+    #   rest-condition
+drf-jwt==1.17.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-auth-backends==3.3.3
+    # via -r requirements/base.txt
+edx-celeryutils==1.0.0
+    # via -r requirements/base.txt
+edx-django-release-util==1.0.0
+    # via -r requirements/base.txt
+edx-django-utils==3.13.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-drf-extensions==6.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-rbac
+edx-opaque-keys==2.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-rbac==1.4.1
+    # via -r requirements/base.txt
+edx-rest-api-client==1.9.2
+    # via -r requirements/base.txt
+future==0.18.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+    #   pyjwkest
+gevent==21.1.2
+    # via -r requirements/production.in
+greenlet==1.0.0
+    # via gevent
+gunicorn==20.0.4
+    # via -r requirements/production.in
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+itypes==1.2.0
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+jinja2==2.11.3
+    # via
+    #   -r requirements/base.txt
+    #   coreschema
+jsonfield2==3.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+kombu==4.6.11
+    # via
+    #   -r requirements/base.txt
+    #   celery
+langcodes==3.0.0
+    # via -r requirements/base.txt
+markupsafe==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
+mysqlclient==2.0.3
+    # via -r requirements/base.txt
+newrelic==6.0.1.155
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
+openapi-codec==1.3.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+pbr==5.5.1
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+psutil==5.8.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pycryptodomex==3.10.1
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-rest-api-client
+    #   social-auth-core
+pymongo==3.11.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+python-memcached==1.59
+    # via -r requirements/production.in
+python3-openid==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/production.in
+    #   edx-django-release-util
+redis==3.5.3
+    # via -r requirements/base.txt
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
+    #   coreapi
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
+rest-condition==1.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+rules==2.2
+    # via -r requirements/base.txt
+semantic-version==2.8.5
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+simplejson==3.17.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   django-simple-history
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-drf-extensions
+    #   edx-rbac
+    #   pyjwkest
+    #   python-dateutil
+    #   python-memcached
+    #   social-auth-app-django
+    #   social-auth-core
+slumber==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-rest-api-client
+social-auth-app-django==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==4.0.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-opaque-keys
+uritemplate==3.0.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+vine==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   amqp
+    #   celery
+zipp==1.2.0
+    # via -r requirements/base.txt
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.2.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,92 +4,358 @@
 #
 #    make upgrade
 #
-algoliasearch==2.4.0      # via -r requirements/base.txt
-amqp==2.6.1               # via -r requirements/base.txt, kombu
-astroid==2.4.2            # via pylint, pylint-celery
-billiard==3.6.3.0         # via -r requirements/base.txt, celery
-celery==4.4.7             # via -r requirements/base.txt, edx-celeryutils
-certifi==2020.12.5        # via -r requirements/base.txt, requests
-cffi==1.14.5              # via -r requirements/base.txt, cryptography
-chardet==4.0.0            # via -r requirements/base.txt, requests
-click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==1.1.0   # via edx-lint
-coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.4.6       # via -r requirements/base.txt, pyjwt, social-auth-core
-defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-django-cors-headers==3.7.0  # via -r requirements/base.txt
-django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
-django-extensions==3.1.1  # via -r requirements/base.txt
-django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.12.0  # via -r requirements/base.txt
-django-waffle==2.1.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.18            # via -r requirements/base.txt, code-annotations, django-cors-headers, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-celeryutils, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-lint, edx-rbac, jsonfield2, rest-condition
-djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.3.3  # via -r requirements/base.txt
-edx-celeryutils==1.0.0    # via -r requirements/base.txt
-edx-django-release-util==1.0.0  # via -r requirements/base.txt
-edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.5.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==4.0.1           # via -r requirements/quality.in
-edx-opaque-keys==2.2.0    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.4.1           # via -r requirements/base.txt
-edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
-idna==2.10                # via -r requirements/base.txt, requests
-isort==5.7.0              # via -r requirements/quality.in, pylint
-itypes==1.2.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.3            # via -r requirements/base.txt, code-annotations, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/base.txt, celery
-langcodes==3.0.0          # via -r requirements/base.txt
-lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mccabe==0.6.1             # via pylint
-mysqlclient==2.0.3        # via -r requirements/base.txt
-newrelic==6.0.1.155       # via -r requirements/base.txt, edx-django-utils
-oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
-psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
-pycodestyle==2.6.0        # via -r requirements/quality.in
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.10.1     # via -r requirements/base.txt, pyjwkest
-pydocstyle==5.1.1         # via -r requirements/quality.in
-pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==2.4.2      # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.6.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
-python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-slugify==4.0.1     # via code-annotations
-python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2021.1              # via -r requirements/base.txt, celery, django
-pyyaml==5.4.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
-redis==3.5.3              # via -r requirements/base.txt
-requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.25.1          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-rules==2.2                # via -r requirements/base.txt
-semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
-slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-snowballstemmer==2.1.0    # via pydocstyle
-social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via python-slugify
-toml==0.10.2              # via pylint
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.26.3           # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-wrapt==1.12.1             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt
+algoliasearch==2.4.0
+    # via -r requirements/base.txt
+amqp==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+astroid==2.4.2
+    # via
+    #   pylint
+    #   pylint-celery
+billiard==3.6.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==4.4.7
+    # via
+    #   -r requirements/base.txt
+    #   django-celery-results
+    #   edx-celeryutils
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+click-log==0.3.2
+    # via edx-lint
+click==7.1.2
+    # via
+    #   click-log
+    #   code-annotations
+    #   edx-lint
+code-annotations==1.1.0
+    # via edx-lint
+coreapi==2.3.3
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+cryptography==3.4.6
+    # via
+    #   -r requirements/base.txt
+    #   pyjwt
+    #   social-auth-core
+defusedxml==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+django-celery-results==2.0.1
+    # via -r requirements/base.txt
+django-cors-headers==3.7.0
+    # via -r requirements/base.txt
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-rbac
+django-extensions==3.1.1
+    # via -r requirements/base.txt
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+    #   edx-rbac
+django-rest-swagger==2.2.0
+    # via -r requirements/base.txt
+django-simple-history==2.12.0
+    # via -r requirements/base.txt
+django-waffle==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django==2.2.18
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   django-cors-headers
+    #   django-crum
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-celeryutils
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-lint
+    #   edx-rbac
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-xml==2.0.0
+    # via -r requirements/base.txt
+djangorestframework==3.12.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+    #   drf-jwt
+    #   edx-drf-extensions
+    #   rest-condition
+drf-jwt==1.17.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-auth-backends==3.3.3
+    # via -r requirements/base.txt
+edx-celeryutils==1.0.0
+    # via -r requirements/base.txt
+edx-django-release-util==1.0.0
+    # via -r requirements/base.txt
+edx-django-utils==3.13.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-drf-extensions==6.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-rbac
+edx-lint==4.0.1
+    # via -r requirements/quality.in
+edx-opaque-keys==2.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-rbac==1.4.1
+    # via -r requirements/base.txt
+edx-rest-api-client==1.9.2
+    # via -r requirements/base.txt
+future==0.18.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+    #   pyjwkest
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+isort==5.7.0
+    # via
+    #   -r requirements/quality.in
+    #   pylint
+itypes==1.2.0
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+jinja2==2.11.3
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   coreschema
+jsonfield2==3.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+kombu==4.6.11
+    # via
+    #   -r requirements/base.txt
+    #   celery
+langcodes==3.0.0
+    # via -r requirements/base.txt
+lazy-object-proxy==1.4.3
+    # via astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
+mccabe==0.6.1
+    # via pylint
+mysqlclient==2.0.3
+    # via -r requirements/base.txt
+newrelic==6.0.1.155
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
+openapi-codec==1.3.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+pbr==5.5.1
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+psutil==5.8.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pycodestyle==2.6.0
+    # via -r requirements/quality.in
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pycryptodomex==3.10.1
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+pydocstyle==5.1.1
+    # via -r requirements/quality.in
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-rest-api-client
+    #   social-auth-core
+pylint-celery==0.3
+    # via edx-lint
+pylint-django==2.4.2
+    # via edx-lint
+pylint-plugin-utils==0.6
+    # via
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.2
+    # via
+    #   edx-lint
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+pymongo==3.11.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+python-slugify==4.0.1
+    # via code-annotations
+python3-openid==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-release-util
+redis==3.5.3
+    # via -r requirements/base.txt
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
+    #   coreapi
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
+rest-condition==1.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+rules==2.2
+    # via -r requirements/base.txt
+semantic-version==2.8.5
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+simplejson==3.17.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   django-simple-history
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-drf-extensions
+    #   edx-lint
+    #   edx-rbac
+    #   pyjwkest
+    #   python-dateutil
+    #   social-auth-app-django
+    #   social-auth-core
+slumber==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-rest-api-client
+snowballstemmer==2.1.0
+    # via pydocstyle
+social-auth-app-django==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==4.0.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify
+toml==0.10.2
+    # via pylint
+uritemplate==3.0.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+vine==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   amqp
+    #   celery
+wrapt==1.12.1
+    # via astroid
+zipp==1.2.0
+    # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,107 +4,413 @@
 #
 #    make upgrade
 #
-algoliasearch==2.4.0      # via -r requirements/base.txt
-amqp==2.6.1               # via -r requirements/base.txt, kombu
-appdirs==1.4.4            # via virtualenv
-astroid==2.4.2            # via pylint, pylint-celery
-attrs==20.3.0             # via pytest
-billiard==3.6.3.0         # via -r requirements/base.txt, celery
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
-certifi==2020.12.5        # via -r requirements/base.txt, requests
-cffi==1.14.5              # via -r requirements/base.txt, cryptography
-chardet==4.0.0            # via -r requirements/base.txt, requests
-click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==1.1.0   # via -r requirements/test.in, edx-lint
-coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.4             # via -r requirements/test.in, pytest-cov
-cryptography==3.4.6       # via -r requirements/base.txt, pyjwt, social-auth-core
-ddt==1.4.1                # via -r requirements/test.in
-defusedxml==0.6.0         # via -r requirements/base.txt, djangorestframework-xml, python3-openid, social-auth-core
-distlib==0.3.1            # via virtualenv
-django-cors-headers==3.7.0  # via -r requirements/base.txt
-django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
-django-dynamic-fixture==3.1.1  # via -r requirements/test.in
-django-extensions==3.1.1  # via -r requirements/base.txt
-django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
-django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-simple-history==2.12.0  # via -r requirements/base.txt
-django-waffle==2.1.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-djangorestframework-xml==2.0.0  # via -r requirements/base.txt
-djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.3.3  # via -r requirements/base.txt
-edx-celeryutils==1.0.0    # via -r requirements/base.txt
-edx-django-release-util==1.0.0  # via -r requirements/base.txt
-edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.5.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==4.0.1           # via -r requirements/test.in
-edx-opaque-keys==2.2.0    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.4.1           # via -r requirements/base.txt
-edx-rest-api-client==1.9.2  # via -r requirements/base.txt
-factory-boy==3.2.0        # via -r requirements/test.in
-faker==6.1.1              # via factory-boy
-filelock==3.0.12          # via tox, virtualenv
-future==0.18.2            # via -r requirements/base.txt, edx-celeryutils, pyjwkest
-idna==2.10                # via -r requirements/base.txt, requests
-iniconfig==1.1.1          # via pytest
-isort==5.7.0              # via pylint
-itypes==1.2.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.3            # via -r requirements/base.txt, code-annotations, coreschema
-jsonfield2==3.0.3         # via -r requirements/base.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/base.txt, celery
-langcodes==3.0.0          # via -r requirements/base.txt
-lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mccabe==0.6.1             # via pylint
-mysqlclient==2.0.3        # via -r requirements/base.txt
-newrelic==6.0.1.155       # via -r requirements/base.txt, edx-django-utils
-oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-packaging==20.9           # via pytest, tox
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pluggy==0.13.1            # via pytest, tox
-psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
-py==1.10.0                # via pytest, tox
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.10.1     # via -r requirements/base.txt, pyjwkest
-pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==2.4.2      # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.6.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
-pyparsing==2.4.7          # via packaging
-pytest-cov==2.11.1        # via -r requirements/test.in
-pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.2.2             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
-python-slugify==4.0.1     # via code-annotations
-python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2021.1              # via -r requirements/base.txt, celery, django
-pyyaml==5.4.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
-redis==3.5.3              # via -r requirements/base.txt
-requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.25.1          # via -r requirements/base.txt, algoliasearch, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
-rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-rules==2.2                # via -r requirements/base.txt
-semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
-slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via faker, python-slugify
-toml==0.10.2              # via pylint, pytest, tox
-tox==3.22.0               # via -r requirements/test.in
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.26.3           # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-virtualenv==20.4.2        # via tox
-wrapt==1.12.1             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt
+algoliasearch==2.4.0
+    # via -r requirements/base.txt
+amqp==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+appdirs==1.4.4
+    # via virtualenv
+astroid==2.4.2
+    # via
+    #   pylint
+    #   pylint-celery
+attrs==20.3.0
+    # via pytest
+billiard==3.6.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==4.4.7
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-celery-results
+    #   edx-celeryutils
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+click-log==0.3.2
+    # via edx-lint
+click==7.1.2
+    # via
+    #   click-log
+    #   code-annotations
+    #   edx-lint
+code-annotations==1.1.0
+    # via
+    #   -r requirements/test.in
+    #   edx-lint
+coreapi==2.3.3
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+coverage==5.4
+    # via
+    #   -r requirements/test.in
+    #   pytest-cov
+cryptography==3.4.6
+    # via
+    #   -r requirements/base.txt
+    #   pyjwt
+    #   social-auth-core
+ddt==1.4.1
+    # via -r requirements/test.in
+defusedxml==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-xml
+    #   python3-openid
+    #   social-auth-core
+distlib==0.3.1
+    # via virtualenv
+django-celery-results==2.0.1
+    # via -r requirements/base.txt
+django-cors-headers==3.7.0
+    # via -r requirements/base.txt
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-rbac
+django-dynamic-fixture==3.1.1
+    # via -r requirements/test.in
+django-extensions==3.1.1
+    # via -r requirements/base.txt
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+    #   edx-rbac
+django-rest-swagger==2.2.0
+    # via -r requirements/base.txt
+django-simple-history==2.12.0
+    # via -r requirements/base.txt
+django-waffle==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   django-cors-headers
+    #   django-crum
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-celeryutils
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-lint
+    #   edx-rbac
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-xml==2.0.0
+    # via -r requirements/base.txt
+djangorestframework==3.12.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+    #   drf-jwt
+    #   edx-drf-extensions
+    #   rest-condition
+drf-jwt==1.17.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-auth-backends==3.3.3
+    # via -r requirements/base.txt
+edx-celeryutils==1.0.0
+    # via -r requirements/base.txt
+edx-django-release-util==1.0.0
+    # via -r requirements/base.txt
+edx-django-utils==3.13.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-drf-extensions==6.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-rbac
+edx-lint==4.0.1
+    # via -r requirements/test.in
+edx-opaque-keys==2.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-rbac==1.4.1
+    # via -r requirements/base.txt
+edx-rest-api-client==1.9.2
+    # via -r requirements/base.txt
+factory-boy==3.2.0
+    # via -r requirements/test.in
+faker==6.1.1
+    # via factory-boy
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+future==0.18.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+    #   pyjwkest
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+iniconfig==1.1.1
+    # via pytest
+isort==5.7.0
+    # via pylint
+itypes==1.2.0
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+jinja2==2.11.3
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   coreschema
+jsonfield2==3.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-celeryutils
+kombu==4.6.11
+    # via
+    #   -r requirements/base.txt
+    #   celery
+langcodes==3.0.0
+    # via -r requirements/base.txt
+lazy-object-proxy==1.4.3
+    # via astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
+mccabe==0.6.1
+    # via pylint
+mysqlclient==2.0.3
+    # via -r requirements/base.txt
+newrelic==6.0.1.155
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
+openapi-codec==1.3.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+packaging==20.9
+    # via
+    #   pytest
+    #   tox
+pbr==5.5.1
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+pluggy==0.13.1
+    # via
+    #   pytest
+    #   tox
+psutil==5.8.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+py==1.10.0
+    # via
+    #   pytest
+    #   tox
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pycryptodomex==3.10.1
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-rest-api-client
+    #   social-auth-core
+pylint-celery==0.3
+    # via edx-lint
+pylint-django==2.4.2
+    # via edx-lint
+pylint-plugin-utils==0.6
+    # via
+    #   pylint-celery
+    #   pylint-django
+pylint==2.6.2
+    # via
+    #   edx-lint
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
+pymongo==3.11.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+pyparsing==2.4.7
+    # via packaging
+pytest-cov==2.11.1
+    # via -r requirements/test.in
+pytest-django==4.1.0
+    # via -r requirements/test.in
+pytest==6.2.2
+    # via
+    #   pytest-cov
+    #   pytest-django
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+    #   faker
+python-slugify==4.0.1
+    # via code-annotations
+python3-openid==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-release-util
+redis==3.5.3
+    # via -r requirements/base.txt
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
+    #   coreapi
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
+rest-condition==1.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+rules==2.2
+    # via -r requirements/base.txt
+semantic-version==2.8.5
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+simplejson==3.17.2
+    # via
+    #   -r requirements/base.txt
+    #   django-rest-swagger
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   django-dynamic-fixture
+    #   django-simple-history
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-drf-extensions
+    #   edx-lint
+    #   edx-rbac
+    #   pyjwkest
+    #   python-dateutil
+    #   social-auth-app-django
+    #   social-auth-core
+    #   tox
+    #   virtualenv
+slumber==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-rest-api-client
+social-auth-app-django==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==4.0.2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==3.3.0
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
+text-unidecode==1.3
+    # via
+    #   faker
+    #   python-slugify
+toml==0.10.2
+    # via
+    #   pylint
+    #   pytest
+    #   tox
+tox==3.22.0
+    # via -r requirements/test.in
+uritemplate==3.0.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+vine==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   amqp
+    #   celery
+virtualenv==20.4.2
+    # via tox
+wrapt==1.12.1
+    # via astroid
+zipp==1.2.0
+    # via -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,15 +4,33 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-packaging==20.9           # via tox
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
-toml==0.10.2              # via tox
-tox-battery==0.6.1        # via -r requirements/tox.in
-tox==3.22.0               # via -r requirements/tox.in, tox-battery
-virtualenv==20.4.2        # via tox
+appdirs==1.4.4
+    # via virtualenv
+distlib==0.3.1
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+packaging==20.9
+    # via tox
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pyparsing==2.4.7
+    # via packaging
+six==1.15.0
+    # via
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via tox
+tox-battery==0.6.1
+    # via -r requirements/tox.in
+tox==3.22.0
+    # via
+    #   -r requirements/tox.in
+    #   tox-battery
+virtualenv==20.4.2
+    # via tox


### PR DESCRIPTION
## Description

* Installs https://github.com/celery/django-celery-results
* Sets this app's DB isolation level to read committed instead of repeatable read, so that transactions in one process can read current state of celery tasks in another process.  See https://docs.djangoproject.com/en/3.1/ref/databases/#mysql-isolation-level
* Runs `make upgrade` which changed the formatting of our `*.txt` requirements files.

## Ticket Link

[Better catalog celery tasks](https://openedx.atlassian.net/browse/ENT-4081)

## Post-review

Testing strategy:
* Merge/ship to staging environment
* Pause prod deploy pipeline
* Smoke test - run all of our management commands/celery tasks against stage, make sure they pass and that our data is in a good place before/after.
* On success, deploy to prod.  Still considering what level of testing is appropriate on prod, since our tasks are still in a somewhat fragile state.
