### PR TITLE
Don't update catalog metadata records if we don't get any course/cour…

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -29,6 +29,7 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     ContentMetadata,
+    NoMetadataOfTypeCourseException,
     update_contentmetadata_from_discovery,
 )
 from enterprise_catalog.apps.catalog.utils import batch
@@ -320,5 +321,10 @@ def update_catalog_metadata_task(catalog_query_id):
         logger.error('Could not find a CatalogQuery with id %s', catalog_query_id)
         return []
 
-    associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+    try:
+        associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+    except NoMetadataOfTypeCourseException exc:
+        logger.error('Did not receive any course or course_run types of metadata from discovery')
+        raise
+
     return associated_content_keys


### PR DESCRIPTION
…se run content from discovery.

## Description

Before doing any content metadata association with CatalogQueries, `update_contentmetadata_from_discovery` now checks if we received any course/course run content from the discovery service.  If we didn't, raise an exception, which is in turn raised by the `update_catalog_metadata_task`.  This helps us deal with a sporadic bug in the discovery service's `search/all` endpoint that causes only metadata of type `program` to be returned.


## Post-review

Squash commits into discrete sets of changes
