### PR TITLE
feat: adding distinct-catalog-queries endpoint

### DIFF
--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -21,6 +21,11 @@ urlpatterns = [
         views.EnterpriseCatalogRefreshDataFromDiscovery.as_view({'post': 'post'}),
         name='update-enterprise-catalog'
     ),
+    url(
+        r'distinct-catalog-queries',
+        views.DistinctCatalogQueriesView.as_view(),
+        name='distinct-catalog-queries',
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -364,14 +364,11 @@ class DistinctCatalogQueriesView(APIView):
         """
         Method to handle POST requests to this endpoint
         """
-        distinct_catalog_query_ids = set()
         enterprise_catalog_uuids = request.data.get('enterprise_catalog_uuids', [])
 
-        enterprise_catalogs = EnterpriseCatalog.objects.filter(
+        distinct_catalog_query_ids = EnterpriseCatalog.objects.filter(
             uuid__in=enterprise_catalog_uuids,
-        )
-        for catalog in enterprise_catalogs:
-            distinct_catalog_query_ids.add(catalog.catalog_query.id)
+        ).distinct().values_list('catalog_query__id', flat=True)
 
         response_data = {
             'count': len(distinct_catalog_query_ids),


### PR DESCRIPTION
## Description

* Adds distinct-catalog-queries endpoint to determine the number of distinct CatalogQueries used by the given set of EnterpriseCatalog UUIDs

## Ticket Link

[ENT-4096](https://openedx.atlassian.net/browse/ENT-4096)

## Testing Instructions

* Use Postman to submit requests using the Authorization header with the JWT of an admin user
* Verify that the list of unique CatalogQuery IDs, as well as the count of unique IDs, is returned in the response

## Post-review

Squash commits into discrete sets of changes
