### PR TITLE
Put a semaphore on the update_catalog_metadata_task, so we stop doing…

### DIFF
--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -3,6 +3,7 @@ Utility functions for catalog app.
 """
 import hashlib
 import json
+from datetime import datetime
 from logging import getLogger
 
 from edx_rbac.utils import feature_roles_from_jwt
@@ -11,6 +12,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import (
 )
 from edx_rest_framework_extensions.auth.jwt.cookies import \
     get_decoded_jwt as get_decoded_jwt_from_cookie
+from pytz import UTC
 
 from enterprise_catalog.apps.catalog.constants import COURSE_RUN
 
@@ -104,3 +106,8 @@ def batch(iterable, batch_size=1):
     iterable_len = len(iterable) if iterable is not None else 0
     for index in range(0, iterable_len, batch_size):
         yield iterable[index:min(index + batch_size, iterable_len)]
+
+
+def localized_utcnow():
+    """Helper function to return localized utcnow()."""
+    return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
… duplicate work. ENT-4081

## Description

Makes it so that `update_catalog_metadata_task()` can successfully run on a given catalog query id at most once per hour.

## Ticket Link

[Ticket about improving catalog task situation](https://openedx.atlassian.net/browse/ENT-4081)

## Post-review

Squash commits into discrete sets of changes
