### PR TITLE
style: update parameter name for clarity

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -893,7 +893,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key
         self.assert_correct_contains_response(url, True)
 
-    def test_no_catalog_list_given_without_get_catalog_list_query(self):
+    def test_no_catalog_list_given_without_get_catalogs_containing_specified_content_ids_query(self):
         """
         Verify that the contains_content_items endpoint does not return a list of catalogs without a querystring
         """
@@ -909,7 +909,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         response = self.client.get(url)
         assert 'catalog_list' not in response.json().keys()
 
-    def test_contains_catalog_list(self):
+    def test_contains_catalog_list_with_catalog_list_param(self):
         """
         Verify the contains_content_items endpoint returns a list of catalogs the course is in if the correct
         parameter is passed
@@ -922,7 +922,29 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         second_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
         relevant_content = ContentMetadataFactory(content_key=content_key)
         self.add_metadata_to_catalog(second_catalog, [relevant_content])
-        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + '&get_catalog_list=True'
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + \
+            '&get_catalog_list=True'
+        self.assert_correct_contains_response(url, True)
+
+        response = self.client.get(url)
+        catalog_list = response.json()['catalog_list']
+        assert set(catalog_list) == {str(second_catalog.uuid)}
+
+    def test_contains_catalog_list_with_content_ids_param(self):
+        """
+        Verify the contains_content_items endpoint returns a list of catalogs the course is in if the correct
+        parameter is passed
+        """
+        content_metadata = ContentMetadataFactory()
+        self.add_metadata_to_catalog(self.enterprise_catalog, [content_metadata])
+
+        # Create a two catalogs that have the content we're looking for
+        content_key = 'fake-key+101x'
+        second_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+        relevant_content = ContentMetadataFactory(content_key=content_key)
+        self.add_metadata_to_catalog(second_catalog, [relevant_content])
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + \
+            '&get_catalogs_containing_specified_content_ids=True'
         self.assert_correct_contains_response(url, True)
 
         response = self.client.get(url)
@@ -947,7 +969,8 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         relevant_content = ContentMetadataFactory(content_key=content_key_2, parent_content_key=parent_content_key)
         self.add_metadata_to_catalog(third_catalog, [relevant_content])
 
-        url = self._get_contains_content_base_url() + '?course_run_ids=' + parent_content_key + '&get_catalog_list=True'
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + parent_content_key + \
+            '&get_catalogs_containing_specified_content_ids=True'
         response = self.client.get(url).json()
         assert response['contains_content_items'] is True
         catalog_list = response['catalog_list']
@@ -962,7 +985,8 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
 
         content_key = 'fake-key+101x'
 
-        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + '&get_catalog_list=True'
+        url = self._get_contains_content_base_url() + '?course_run_ids=' + content_key + \
+            '&get_catalogs_containing_specified_content_ids=True'
         response = self.client.get(url)
         catalog_list = response.json()['catalog_list']
         assert catalog_list == []

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -317,9 +317,15 @@ class EnterpriseCustomerViewSet(BaseViewSet):
               description: Uuids of the programs to check availability of
               paramType: query
             - name: get_catalog_list
+              description: [Old parameter] Return a list of catalogs in which the course / program is present
+              paramType: query
+            - name: get_catalogs_containing_specified_content_ids
               description: Return a list of catalogs in which the course / program is present
               paramType: query
         """
+        get_catalogs_containing_specified_content_ids = request.GET.get(
+            'get_catalogs_containing_specified_content_ids', False
+        )
         get_catalog_list = request.GET.get('get_catalog_list', False)
         course_run_ids = unquote_course_keys(course_run_ids)
 
@@ -330,7 +336,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             contains_content_items = catalog.contains_content_keys(course_run_ids + program_uuids)
             if contains_content_items:
                 any_catalog_contains_content_items = True
-                if not get_catalog_list:
+                if not (get_catalogs_containing_specified_content_ids or get_catalog_list):
                     # Break as soon as we find a catalog that contains the specified content
                     break
                 catalogs_that_contain_course.append(catalog.uuid)
@@ -338,6 +344,6 @@ class EnterpriseCustomerViewSet(BaseViewSet):
         response_data = {
             'contains_content_items': any_catalog_contains_content_items,
         }
-        if get_catalog_list:
+        if (get_catalogs_containing_specified_content_ids or get_catalog_list):
             response_data['catalog_list'] = catalogs_that_contain_course
         return Response(response_data)


### PR DESCRIPTION
## Description

The `get_catalog_list` parameter name was causing confusion as we thought it was returning _all_ catalogs regardless of matching content_ids. The parameter name has been updated to `get_catalogs_containing_specified_content_ids`

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-3991)

## Post-review

Squash commits into discrete sets of changes
