### PR TITLE
Invoke update_catalog_metadata_task with args instead of kwargs to av…

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             ' to update content_metadata for catalog query %s.'
         )
         logger.info(message, catalog_query)
-        return update_catalog_metadata_task.s(catalog_query_id=catalog_query.id)
+        return update_catalog_metadata_task.s(catalog_query.id)
 
     def _run_update_full_content_metadata_task(self, *args, **kwargs):
         """


### PR DESCRIPTION
…oid ValueError.

We get a ```ValueError: invalid literal for int() with base 10: 'catalog_query_id'non-zero return code``` if the catalog query id is given as a kwarg.
