### PR TITLE
Standardized task signatures

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -375,3 +375,60 @@ def update_catalog_metadata_task(self, catalog_query_id):  # pylint: disable=unu
 
     associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
     return associated_content_keys
+
+
+def update_catalog_metadata_task_signature(catalog_query_id):
+    """
+    The preferred interface to invocations of the `update_catalog_metadata_task`,
+    so that our `TaskResult` fields related to this task are consistent.
+
+    Args:
+      catalog_query_id: The id of a CatalogQuery to invoke the task upon.
+    """
+    return update_catalog_metadata_task.s(catalog_query_id)
+
+
+def update_full_content_metadata_task_signature(content_keys=None, immutable=True):
+    """
+    The preferred interface to invocations of the `update_full_content_metadata_task`,
+    so that our `TaskResult` fields related to this task are consistent.
+
+    For the difference between s() and si(), see the celery docs on task signatures:
+    https://docs.celeryproject.org/en/v5.0.5/userguide/canvas.html#signatures
+
+    Args:
+      content_keys: A list of content keys to update full metadata of.
+      immutable: Boolean indicating if the task is immutable.  If False, expects
+        that content_keys will be provided from the result of a parent task in a chain or chord.
+    """
+    if immutable:
+        if not content_keys:
+            raise Exception('content_keys are required if immutable is True')
+        return update_full_content_metadata_task.si(content_keys)
+
+    return update_catalog_metadata_task.s()
+
+
+def index_enterprise_catalog_courses_in_algolia_task_signature(algolia_fields, content_keys=None, immutable=True):
+    """
+    The preferred interface to invocations of the `index_enterprise_catalog_courses_in_algolia_task`,
+    so that our `TaskResult` fields related to this task are consistent.
+
+    For the difference between s() and si(), see the celery docs on task signatures:
+    https://docs.celeryproject.org/en/v5.0.5/userguide/canvas.html#signatures
+
+    Args:
+      algolia_fields: A list of algolia fields to update.
+      content_keys: A list of content keys to update full metadata of.
+      immutable: Boolean indicating if the task is immutable.  If False, expects
+        that content_keys will be provided from the result of a parent task in a chain or chord.
+    """
+    if immutable:
+        if not content_keys:
+            raise Exception('content_keys are required if immutable is True')
+        return index_enterprise_catalog_courses_in_algolia_task.si(
+            content_keys,
+            algolia_fields,
+        )
+
+    return index_enterprise_catalog_courses_in_algolia_task.s(algolia_fields),

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import (
-    index_enterprise_catalog_courses_in_algolia_task,
+    index_enterprise_catalog_courses_in_algolia_task_signature,
 )
 from enterprise_catalog.apps.catalog.algolia_utils import (
     ALGOLIA_FIELDS,
@@ -38,10 +38,10 @@ class Command(BaseCommand):
         indexable_course_keys = get_indexable_course_keys(all_course_content_metadata)
 
         for content_keys_batch in batch(indexable_course_keys, batch_size=TASK_BATCH_SIZE):
-            result = index_enterprise_catalog_courses_in_algolia_task.run(
+            result = index_enterprise_catalog_courses_in_algolia_task_signature(
                 content_keys=content_keys_batch,
                 algolia_fields=ALGOLIA_FIELDS,
-            )
+            ).run()
             message = (
                 'index_enterprise_catalog_courses_in_algolia_task from command reindex_algolia finished'
                 ' successfully with result %s.'

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             ' to update content_metadata for catalog query %s.'
         )
         logger.info(message, catalog_query)
-        return update_catalog_metadata_task.s(catalog_query_id=catalog_query.id)
+        return update_catalog_metadata_task_signature(catalog_query.id)
 
     def _run_update_full_content_metadata_task(self, *args, **kwargs):
         """
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         # task.si() is used as a shortcut for an immutable signature to avoid calling this with the results from the
         # previously run `update_catalog_metadata_task`.
         # https://docs.celeryproject.org/en/master/userguide/canvas.html#immutability
-        return update_full_content_metadata_task.si(all_content_keys)
+        return update_full_content_metadata_task_signature(content_keys)
 
     def add_arguments(self, parser):
         # Argument to specify catalogs to update

--- a/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from enterprise_catalog.apps.api.tasks import update_full_content_metadata_task
+from enterprise_catalog.apps.api.tasks import update_full_content_metadata_task_signature
 from enterprise_catalog.apps.catalog.management.utils import (
     get_all_content_keys,
 )
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         all_content_keys = get_all_content_keys()
-        result = update_full_content_metadata_task.run(all_content_keys)
+        result = update_full_content_metadata_task_signature(all_content_keys).run()
         message = (
             'update_full_content_metadata task from update_full_content_metadata command finished'
             ' successfully with result %s'


### PR DESCRIPTION
## Description

Provide a common interface for creating celery task signatures before they are applied/run/chained/etc.  This will make the data stored in `TaskResult` more consistent, and thus, more likely to avoid false negatives when asking "has a task with this (name, args, kwargs) been run recently?".
## Ticket Link

[Better catalog tasks](https://openedx.atlassian.net/browse/ENT-4081)

## Post-review

Squash commits into discrete sets of changes
