### PR TITLE
Exclude the task's own id from the task_recently_run() check. ENT-4018

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -76,10 +76,6 @@ def _fetch_courses_by_keys(course_keys):
             continue
         if timezone.now() - content_metadata[0].modified > timedelta(seconds=timeout_seconds):
             courses.append(content_metadata[0].json_metadata)
-            logger.info(
-                'ContentMetadata with key %s has recently been updated and will not be requested from Discovery API',
-                key,
-            )
         else:
             course_keys_to_fetch.append(key)
 
@@ -110,7 +106,11 @@ def task_recently_run(task_object, time_delta):
         task_args=str(task_object.request.args),
         task_kwargs=str(task_object.request.kwargs),
         date_created__gte=localized_utcnow() - time_delta,
-    ).exclude(status=states.FAILURE).exists()
+    ).exclude(
+        status=states.FAILURE,
+    ).exclude(
+        task_id=str(task_object.request.id),
+    ).exists()
 
 
 def expiring_task_semaphore(time_delta=None, early_return_value=None):


### PR DESCRIPTION
## Description

A `TaskResult` object is written as soon as a task is received (with a status of `RECEIVED`) - which means when we check if a task with the same name/args already exists, we'll find that one does - it's the current task.  This change updates that check to exclude records with the same `task_id` as the current task.

## Ticket Link

[ENT-4081](https://openedx.atlassian.net/browse/ENT-4081)

## Post-review

Squash commits into discrete sets of changes
