### PR TITLE
fix: use image_url for algolia course indexing

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -173,14 +173,14 @@ class UpdateFullContentMetadataTaskTests(TestCase):
             'uuid': metadata_1.json_metadata.get('uuid'),
             'aggregation_key': 'course:fakeX',
             'marketing_url': metadata_1.json_metadata.get('marketing_url'),
-            'original_image': metadata_1.json_metadata.get('original_image'),
+            'image_url': metadata_1.json_metadata.get('image_url'),
             'owners': metadata_1.json_metadata.get('owners'),
         })
         course_data_2.update({
             'uuid': metadata_2.json_metadata.get('uuid'),
             'aggregation_key': 'course:testX',
             'marketing_url': metadata_2.json_metadata.get('marketing_url'),
-            'original_image': metadata_2.json_metadata.get('original_image'),
+            'image_url': metadata_2.json_metadata.get('image_url'),
             'owners': metadata_2.json_metadata.get('owners'),
         })
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -276,10 +276,8 @@ def get_course_card_image_url(course):
     Returns:
         str: the url for the course card image
     """
-    original_image = course.get('original_image')
-    if original_image:
-        return original_image.get('src')
-    return None
+    image_url = course.get('image_url')
+    return image_url
 
 
 def get_course_skill_names(course):

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -73,7 +73,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
             }]
             json_metadata.update({
                 'marketing_url': f'https://marketing.url/{self.content_key}',
-                'original_image': {'src': FAKE_IMAGE_URL},
+                'image_url': FAKE_IMAGE_URL,
                 'owners': owners,
             })
         return json_metadata

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -71,15 +71,11 @@ class AlgoliaUtilsTests(TestCase):
 
     @ddt.data(
         (
-            {'original_image': {'src': 'https://fake.image'}},
+            {'image_url': 'https://fake.image'},
             'https://fake.image',
         ),
         (
-            {'original_image': None},
-            None,
-        ),
-        (
-            {'original_image': {}},
+            {'image_url': None},
             None,
         ),
     )


### PR DESCRIPTION
## Description

Use `image_url` field in course content metadata during Algolia indexing now that this field exists and seems to have stable data (i.e., all course content in enterprise-catalog has an `image_url` field), which IIRC wasn't the case before.

**User impact: better performance when loading course search results due to loading smaller file sizes.**

The learner portal currently uses whatever image url is indexed in Algolia.

_Example:_
In this example, we can see a ~67.8% decrease in image file size by using the smaller image: 12.65 kB vs. 39.1 kB. Multiply these savings over 24 course cards visible at a time, and there's the potential for reducing the image payload for **each** page in the search results by over half a mB (634.8 kB). Note this is solely based on the example file sizes for the images shown below.

```
{
  "image_url": "https://prod-discovery.edx-cdn.org/media/course/image/5236b816-deac-4a69-9586-96ca0f4dad2a-ccead5306d4c.small.jpg",
}
```

vs.

```
"original_image": {
  "src": "https://prod-discovery.edx-cdn.org/media/course/image/e56e7660-bc94-46fd-95c5-ae3f765da60c-3c84e255cf9e.jpg",
  // ...
},
```

## Post-review

Squash commits into discrete sets of changes
