### PR TITLE
Remove isort_check from quality/validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@
 TOX = ''
 .PHONY: help clean piptools requirements dev_requirements \
         doc_requirementsprod_requirements static shell test coverage \
-        isort_check isort style lint quality pii_check validate \
+        style lint quality pii_check validate \
         migrate html_coverage upgrade extract_translation dummy_translations \
         compile_translations fake_translations  pull_translations \
         push_translations start-devstack open-devstack  pkg-devstack \
         detect_changed_source_translations validate_translations \
         dev.provision dev.init dev.makemigrations dev.migrate dev.up \
         dev.up.build dev.down dev.destroy dev.stop docker_build \
-        shellcheck
+        shellcheck mysql-client
 
 
 define BROWSER_PYSCRIPT
@@ -66,19 +66,13 @@ coverage: clean
 	pytest --cov-report html
 	$(BROWSER) htmlcov/index.html
 
-isort_check: ## check that isort has been run
-	isort --check-only --diff -rc enterprise_catalog/
-
-isort: ## run isort to sort imports in all Python files
-	isort --recursive --atomic enterprise_catalog/
-
 style: ## run Python style checker
 	pycodestyle enterprise_catalog *.py
 
 lint: ## run Python code linting
 	pylint --rcfile=pylintrc enterprise_catalog *.py
 
-quality: clean style isort_check lint ## check code style and import sorting, then lint
+quality: clean style lint ## check code style then lint
 
 pii_check: ## check for PII annotations on all Django models
 	DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.test \
@@ -180,6 +174,9 @@ dev.stop: # Stops containers so they can be restarted
 
 %-attach: ## Attach terminal I/O to the specified service container
 	docker attach enterprise.catalog.$*
+
+mysql-client: # Attach and run a mysql client for the enterprise_catalog DB
+	docker-compose exec -u 0 mysql bash -c "mysql enterprise_catalog"
 
 docker_build: ## Builds with the latest enterprise catalog
 	docker build . --target app -t openedx/enterprise-catalog:latest

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -114,10 +114,6 @@ future==0.18.2
     #   pyjwkest
 idna==2.10
     # via requests
-importlib-metadata==3.7.0
-    # via
-    #   kombu
-    #   stevedore
 itypes==1.2.0
     # via coreapi
 jinja2==2.11.3
@@ -132,7 +128,7 @@ markupsafe==1.1.1
     # via jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.in
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via edx-django-utils
 oauthlib==3.1.0
     # via
@@ -219,8 +215,6 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 uritemplate==3.0.1
     # via coreapi
 urllib3==1.26.3
@@ -230,6 +224,4 @@ vine==1.3.0
     #   amqp
     #   celery
 zipp==1.2.0
-    # via
-    #   -r requirements/base.in
-    #   importlib-metadata
+    # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -196,7 +196,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-docker-compose==1.28.4
+docker-compose==1.28.5
     # via -r requirements/dev.in
 docker[ssh]==4.4.4
     # via docker-compose
@@ -275,21 +275,7 @@ idna==2.10
     #   -r requirements/test.txt
     #   requests
 importlib-metadata==3.7.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   inflect
-    #   jsonschema
-    #   kombu
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via
-    #   -r requirements/test.txt
-    #   virtualenv
+    # via inflect
 inflect==3.0.2
     # via
     #   -r requirements/dev.in
@@ -349,7 +335,7 @@ mysqlclient==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -624,16 +610,6 @@ toml==0.10.2
     #   tox
 tox==3.22.0
     # via -r requirements/test.txt
-typed-ast==1.4.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/quality.txt
@@ -668,7 +644,6 @@ zipp==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   importlib-metadata
-    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -209,19 +209,6 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/test.txt
-    #   kombu
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via
-    #   -r requirements/test.txt
-    #   virtualenv
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -262,7 +249,7 @@ mccabe==0.6.1
     #   pylint
 mysqlclient==2.0.3
     # via -r requirements/test.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -496,14 +483,6 @@ toml==0.10.2
     #   tox
 tox==3.22.0
     # via -r requirements/test.txt
-typed-ast==1.4.2
-    # via
-    #   -r requirements/test.txt
-    #   astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/test.txt
@@ -528,10 +507,7 @@ wrapt==1.12.1
     #   -r requirements/test.txt
     #   astroid
 zipp==1.2.0
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
-    #   importlib-resources
+    # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -142,11 +142,6 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/base.txt
-    #   kombu
-    #   stevedore
 itypes==1.2.0
     # via
     #   -r requirements/base.txt
@@ -169,7 +164,7 @@ markupsafe==1.1.1
     #   jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -299,10 +294,6 @@ stevedore==3.3.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
@@ -317,9 +308,7 @@ vine==1.3.0
     #   amqp
     #   celery
 zipp==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
+    # via -r requirements/base.txt
 zope.event==4.5.0
     # via gevent
 zope.interface==5.2.0

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -3,6 +3,5 @@
 -r base.txt               # Core dependencies for this package
 
 edx-lint                  # edX pylint rules and plugins
-isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -153,15 +153,8 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/base.txt
-    #   kombu
-    #   stevedore
 isort==5.7.0
-    # via
-    #   -r requirements/quality.in
-    #   pylint
+    # via pylint
 itypes==1.2.0
     # via
     #   -r requirements/base.txt
@@ -189,7 +182,7 @@ mccabe==0.6.1
     # via pylint
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -344,12 +337,6 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
-typed-ast==1.4.2
-    # via astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
@@ -366,6 +353,4 @@ vine==1.3.0
 wrapt==1.12.1
     # via astroid
 zipp==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
+    # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -178,17 +178,6 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/base.txt
-    #   kombu
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via virtualenv
 iniconfig==1.1.1
     # via pytest
 isort==5.7.0
@@ -220,7 +209,7 @@ mccabe==0.6.1
     # via pylint
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -403,12 +392,6 @@ toml==0.10.2
     #   tox
 tox==3.22.0
     # via -r requirements/test.in
-typed-ast==1.4.2
-    # via astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
@@ -427,7 +410,4 @@ virtualenv==20.4.2
 wrapt==1.12.1
     # via astroid
 zipp==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
-    #   importlib-resources
+    # via -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,13 +12,6 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-importlib-metadata==3.7.0
-    # via
-    #   pluggy
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via virtualenv
 packaging==20.9
     # via tox
 pluggy==0.13.1
@@ -39,11 +32,5 @@ tox==3.22.0
     # via
     #   -r requirements/tox.in
     #   tox-battery
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 virtualenv==20.4.2
     # via tox
-zipp==3.4.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,16 +3,6 @@ ignore=E501,W503
 max-line-length = 120
 exclude=.git,settings,migrations,enterprise_catalog/static,bower_components,enterprise_catalog/wsgi.py
 
-[tool:isort]
-indent='    '
-line_length=80
-multi_line_output=3
-lines_after_imports=2
-include_trailing_comma=True
-skip=
-    settings
-    migrations
-
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = enterprise_catalog.settings.test
 addopts = --cov enterprise_catalog --cov-report term-missing --cov-report xml


### PR DESCRIPTION
...because its costs outweigh its benefits.

## Description

Having our imports sorted just right provides very minimal value, and has a high cumulative cost in PR/CI churn:

1. `pylint` already catches unused imports.
2. Generally, having imports at the top of the file and grouped according to standard python convention is something most developers get right most of the time.
3. ...and if they don't, there's very little impact.  Generally, a developer inspects import in a file by using the search function of their IDE, not via a manual eyeball scan.
4. Having properly sorted imports provides 0 business value...
5. ...it doesn't eliminate any risk.
6. ...it doesn't improve developer productivity or velocity (I'd argue it harms velocity).
7. ...it has negligible impact on code readability, given point (2) above.
8. I can't think of a single incident/bug/defect that would have been caught, if only we were running `isort` (isort has only been a tool used by edX since 2018 or so).