### PR TITLE
feat: adds more useful info to the distinct-catalog-queries endpoint …

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1039,8 +1039,8 @@ class DistinctCatalogQueriesViewTests(APITestMixin):
         ).json()
 
         if use_different_query:
-            assert response['count'] == 2
-            assert str(catalog_query_two.id) in response['catalog_query_ids']
+            assert response['num_distinct_query_ids'] == 2
+            assert str(catalog_query_two.id) in response['catalog_uuids_by_catalog_query_id']
         else:
-            assert response['count'] == 1
-        assert str(self.catalog_query_one.id) in response['catalog_query_ids']
+            assert response['num_distinct_query_ids'] == 1
+        assert str(self.catalog_query_one.id) in response['catalog_uuids_by_catalog_query_id']

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1040,7 +1040,7 @@ class DistinctCatalogQueriesViewTests(APITestMixin):
 
         if use_different_query:
             assert response['count'] == 2
-            assert catalog_query_two.id in response['catalog_query_ids']
+            assert str(catalog_query_two.id) in response['catalog_query_ids']
         else:
             assert response['count'] == 1
-        assert self.catalog_query_one.id in response['catalog_query_ids']
+        assert str(self.catalog_query_one.id) in response['catalog_query_ids']

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import crum
 from celery import chain
@@ -340,44 +340,41 @@ class DistinctCatalogQueriesView(APIView):
     View that, given a list of EnterpriseCustomerCatalog UUIDs, returns the
     number of distinct EnterpriseCatalogQueries used by the given set of catalogs.
 
-    Request Data:
-        - enterprise_catalog_uuids (list[UUID4]): List of EnterpriseCustomerCatalog
-        UUIDs to be used in a search for the number of distinct EnterpriseCatalogQuery
-        objects used by the identified catalogs.
-
-    Response Data:
-        - count (int): number of distinct catalog queries used by given catalogs
-        - catalog_query_ids (list[int]): IDs of the distinct catalog queries
+    Also returns a mapping of each EnterpriseCatalogQuery to the UUIDs of
+    EnterpriseCustomerCatalogs which use it to help ECS remediate any issues.
     """
     authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAdminUser]
 
     def post(self, request):
         """
-        Method to handle POST requests to this endpoint
+        Given a list of EnterpriseCustomerCatalog UUIDs, return the number of distinct
+        EnterpriseCatalogQueries used by the given set of catalogs.
+
+        Also return data mapping each EnterpriseCatalogQuery to a list of the given
+        EnterpriseCustomerCatalog UUIDs which use it. This data can be used by ECS to
+        determine which catalogs map to incorrect queries.
+
+        Request Data:
+            - enterprise_catalog_uuids (list[str(UUID4)]): List of EnterpriseCustomerCatalog
+            UUIDs to be used in a search for the number of distinct EnterpriseCatalogQuery
+            objects used by the identified catalogs.
+
+        Response Data:
+            - count (int): number of distinct catalog queries used by given catalogs
+            - catalog_uuids_by_catalog_query_id (dict{ int : list[str(UUID4)] }): dictionary
+            with CatalogQuery ID as the key and the list of UUIDs for EnterpriseCustomerCatalogs
+            that use the given ID as the value.
         """
-        # Find all catalogs that match the UUIDs sent in the request data
         enterprise_catalog_uuids = request.data.get('enterprise_catalog_uuids', [])
         enterprise_catalogs = EnterpriseCatalog.objects.filter(uuid__in=enterprise_catalog_uuids)
 
-        # Iterate through catalogs and populate to the catalog query map
-        # Format:
-        #   key: CatalogQuery ID (int)
-        #   value: EnterpriseCustomerCatalog UUID(s) (list[str])
-        catalog_query_map = {}
+        catalog_query_map = defaultdict(list)
         for catalog in enterprise_catalogs:
-            query_id = catalog.catalog_query_id
-            if query_id in catalog_query_map:
-                catalog_query_map[query_id].append(str(catalog.uuid))
-            else:
-                catalog_query_map[query_id] = [str(catalog.uuid)]
+            catalog_query_map[catalog.catalog_query_id].append(str(catalog.uuid))
 
-        # Return catalog_query_map in the response.
-        # In the case that the catalog query check fails,
-        # the map can be used to determine which catalogs
-        # map to incorrect queries.
         response_data = {
-            'count': len(catalog_query_map.keys()),
-            'catalog_query_ids': catalog_query_map,
+            'num_distinct_query_ids': len(catalog_query_map.keys()),
+            'catalog_uuids_by_catalog_query_id': catalog_query_map,
         }
         return Response(response_data, status=HTTP_200_OK)


### PR DESCRIPTION
…response

## Description

* Returns a list of EnterpriseCustomerCatalog UUIDs in a dictionary, keying on associated CatalogQuery ID
* Adds commenting

## Ticket Link

[ENT-4039](https://openedx.atlassian.net/browse/ENT-4039)

## Post-review

Squash commits into discrete sets of changes
