### PR TITLE
Increase task timeout and back-looking time window for algolia task

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -145,7 +145,7 @@ def expiring_task_semaphore(time_delta=None):
     def decorator(task):
         @functools.wraps(task)
         def wrapped_task(self, *args, **kwargs):
-            delta = time_delta or timedelta(hours=1)
+            delta = time_delta or ONE_HOUR
             if task_recently_run(self, time_delta=delta):
                 msg_args = (self.name, self.request.id, self.request.args, self.request.kwargs)
                 message = (
@@ -199,14 +199,14 @@ def update_full_content_metadata_task(self):
     ``CELERY_TASK_TIME_LIMIT`` since the task traverses large portions of course-discovery's /courses/ endpoint, which
     was exceeding the previous default limits, causing a SoftTimeLimitExceeded exception.
     """
-    if unready_tasks(update_catalog_metadata_task, timedelta(hours=1)).exists():
+    if unready_tasks(update_catalog_metadata_task, ONE_HOUR).exists():
         raise self.retry(
             exc=RequiredTaskUnreadyError(),
         )
 
     content_keys = [
         metadata.content_key for metadata in
-        ContentMetadata.recently_modified_records(timedelta(hours=1)).filter(content_type=COURSE)
+        ContentMetadata.recently_modified_records(ONE_HOUR).filter(content_type=COURSE)
     ]
     _update_full_content_metadata(content_keys)
 
@@ -307,7 +307,7 @@ def index_enterprise_catalog_courses_in_algolia_task(self):
         )
 
     content_keys = ContentMetadata.recently_modified_records(
-        ONE_HOUR
+        ONE_HOUR * 2
     ).filter(
         content_type=COURSE
     ).values_list(

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -39,7 +39,7 @@ DISCOVERY_COURSE_KEY_BATCH_SIZE = 50
 
 # Async task constants
 TASK_BATCH_SIZE = 250
-TASK_TIMEOUT = 45 * 60  # Gives tasks 45 minutes to return, otherwise times out
+TASK_TIMEOUT = 60 * 60  # Gives tasks 60 minutes to return, otherwise times out
 
 
 def json_serialized_course_modes():

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -108,10 +108,7 @@ class Command(BaseCommand):
                 timeout=TASK_TIMEOUT,
                 propagate=True,
             )
-            logger.info('Finished doing full update of {} metadata records: {}'.format(
-                len(full_update_result),
-                full_update_result
-            ))
+            logger.info('Finished doing full update of metadata records.')
         except Exception as exc:
             # See comment above about celery exception prefixes.
             if type(exc).__name__ != 'TaskRecentlyRunError':


### PR DESCRIPTION
* Fix a NoneType error
* Increase the task timeout (used for groups of tasks) to one hour.  
* Modify the algolia indexing task to look for records modified in the last two hours (up from one hour).

## Ticket Link

https://openedx.atlassian.net/browse/ENT-4081

## Post-review

Squash commits into discrete sets of changes
