### PR TITLE
Avoid algolia task doomspiral

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -5,8 +5,7 @@ from collections import defaultdict
 from datetime import timedelta
 
 from celery import shared_task, states
-from celery.exceptions import Ignore, SoftTimeLimitExceeded
-from celery.exceptions import TimeoutError as CeleryTimeoutError
+from celery.exceptions import Ignore
 from celery_utils.logged_task import LoggedTask
 from django.db import IntegrityError
 from django.db.models import Prefetch, Q
@@ -175,8 +174,6 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     """
     autoretry_for = (
         IntegrityError,
-        SoftTimeLimitExceeded,
-        CeleryTimeoutError,
         OperationalError,
     )
     retry_kwargs = {'max_retries': 5}

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -314,9 +314,10 @@ CELERY_TASK_IGNORE_RESULT = False
 CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
 
 # Celery task time limits.
-# Tasks will be asked to quit after 8 minutes, and un-gracefully killed after 9.
-CELERY_TASK_SOFT_TIME_LIMIT = 480
-CELERY_TASK_TIME_LIMIT = 540
+# Tasks will be asked to quit after 15 minutes...
+CELERY_TASK_SOFT_TIME_LIMIT = 60 * 15
+# ...and un-gracefully killed after 20.
+CELERY_TASK_TIME_LIMIT = 60 * 20
 
 # Propagate exceptions from eagerly applied tasks
 CELERY_EAGER_PROPAGATES = True


### PR DESCRIPTION
Do not auto-retry tasks that failed due to timeout, especially for ones that failed due to a soft timeout.  This can lead to a doom-loop of costly, repetitive work.

Background:
I noticed in the logs that the same algolia reindex task was retried 5 times earlier this afternoon, and it did the same set of work each time.  What happens is something like this:
* Task instance 1 does a lot of hard work.  It does it for 8 minutes, which triggers a soft timeout error.  We retry automatically on soft timeout errors.  task instance 1 keeps running, but a retry is queued up.
* 1 minute has passed, instance 1 is done by now.
* task instance 2 starts, it does a lot of hard work.  It does it for 8 minutes, which triggers a soft timeout error.  We retry automatically on soft timeout errors.  task instance 2 keeps running, but a retry is queued up.
* (...you get the idea...)
* We've hit our max number of retries (5) and stop queueing up more work.
