### PR TITLE
Automatically retry tasks on requests.exceptions.ConnectionErrors.

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -12,6 +12,7 @@ from django.db import IntegrityError
 from django.db.models import Prefetch, Q
 from django.db.utils import OperationalError
 from django_celery_results.models import TaskResult
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.algolia_utils import (
@@ -174,6 +175,7 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     more documentation.
     """
     autoretry_for = (
+        RequestsConnectionError,
         IntegrityError,
         OperationalError,
     )

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -582,7 +582,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
                     self.enterprise_slug,
                     course_key,
                     course_run_key_param,
-                    self.enterprise_catalog.enterprise_name
+                    slugify(self.enterprise_catalog.enterprise_name),
                 )
             else:
                 updated_json_metadata['enrollment_url'] = enrollment_url.format(
@@ -591,7 +591,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
                     COURSE,
                     updated_json_metadata['key'],
                     self.enterprise_catalog.uuid,
-                    self.enterprise_catalog.enterprise_name,
+                    slugify(self.enterprise_catalog.enterprise_name),
                 )
             updated_json_metadata['xapi_activity_id'] = xapi_activity_id.format(
                 settings.LMS_BASE_URL,
@@ -607,7 +607,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
                 PROGRAM,
                 updated_json_metadata['key'],
                 self.enterprise_catalog.uuid,
-                self.enterprise_catalog.enterprise_name,
+                slugify(self.enterprise_catalog.enterprise_name),
             )
 
         return updated_json_metadata


### PR DESCRIPTION
## Description

We hit a requests `ConnectionError` during a `update_catalog_metadata_task` this morning.  This type of error is likely to be transitory and we should automatically retry tasks that encounter it.

## Post-review

Squash commits into discrete sets of changes
