### PR TITLE
feat: add language name to Algolia index course records

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -243,20 +243,10 @@ class UpdateFullContentMetadataTaskTests(TestCase):
 
         # add aggregation_key and uuid to course objects since they should now exist
         # after merging the original json_metadata with the course metadata
-        course_data_1.update({
-            'uuid': metadata_1.json_metadata.get('uuid'),
-            'aggregation_key': 'course:fakeX',
-            'marketing_url': metadata_1.json_metadata.get('marketing_url'),
-            'image_url': metadata_1.json_metadata.get('image_url'),
-            'owners': metadata_1.json_metadata.get('owners'),
-        })
-        course_data_2.update({
-            'uuid': metadata_2.json_metadata.get('uuid'),
-            'aggregation_key': 'course:testX',
-            'marketing_url': metadata_2.json_metadata.get('marketing_url'),
-            'image_url': metadata_2.json_metadata.get('image_url'),
-            'owners': metadata_2.json_metadata.get('owners'),
-        })
+        course_data_1.update(metadata_1.json_metadata)
+        course_data_2.update(metadata_2.json_metadata)
+        course_data_1.update({'aggregation_key': 'course:fakeX'})
+        course_data_2.update({'aggregation_key': 'course:testX'})
 
         assert metadata_1.json_metadata == course_data_1
         assert metadata_2.json_metadata == course_data_2
@@ -359,7 +349,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
     def test_index_algolia_with_batched_uuids(self, mock_search_client, mock_was_recently_indexed):
         """
         Assert that the correct data is sent to Algolia index, with the expected enterprise
-        catalog and enterprise customer associations.
+        catalog, enterprise customer, and catalog query associations.
         """
         algolia_data = self._set_up_factory_data_for_algolia()
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -195,12 +195,12 @@ def get_course_availability(course):
         'upcoming': 'Upcoming',
     }
     course_runs = course.get('course_runs') or []
-    active_course_runs = filter(_is_course_run_active, course_runs)
+    active_course_runs = [run for run in course_runs if _is_course_run_active(run)]
     availability = set()
     for course_run in active_course_runs:
-        run_availability = course_run.get('availability', '').lower()
+        run_availability = course_run.get('availability') or ''
         availability.add(
-            COURSE_AVAILABILITY_MESSAGES.get(run_availability, DEFAULT_COURSE_AVAILABILITY)
+            COURSE_AVAILABILITY_MESSAGES.get(run_availability.lower(), DEFAULT_COURSE_AVAILABILITY)
         )
     return list(availability)
 
@@ -343,7 +343,8 @@ def _is_course_run_active(course_run):
     Returns:
         bool: Whether the specified course run is "active" (i.e., published, enrollable, marketable)
     """
-    is_published = course_run.get('status', '').lower() == 'published'
+    course_run_status = course_run.get('status') or ''
+    is_published = course_run_status.lower() == 'published'
     is_enrollable = course_run.get('is_enrollable', False)
     is_marketable = course_run.get('is_marketable', False)
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -1,7 +1,13 @@
 import copy
+import logging
+
+from langcodes import Language
+from langcodes.tag_parser import LanguageTagError
 
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 
+
+logger = logging.getLogger(__name__)
 
 ALGOLIA_UUID_BATCH_SIZE = 100
 
@@ -16,6 +22,7 @@ ALGOLIA_FIELDS = [
     'enterprise_customer_uuids',
     'full_description',
     'key',  # for links to Course about pages from the Learner Portal search page
+    'language',
     'level_type',
     'objectID',  # required by Algolia, e.g. "course-{uuid}"
     'partners',
@@ -45,6 +52,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'enterprise_catalog_uuids',
         'enterprise_catalog_query_uuids',
         'enterprise_customer_uuids',
+        'language',
         'level_type',
         'partners.name',
         'programs',
@@ -91,7 +99,7 @@ def _should_index_course(course_metadata):
     if advertised_course_run is None:
         return False
 
-    owners = course_json_metadata.get('owners', [])
+    owners = course_json_metadata.get('owners') or []
     return (len(owners) > 0
             and bool(course_json_metadata.get('url_slug'))
             and not advertised_course_run.get('hidden'))
@@ -105,8 +113,11 @@ def get_indexable_course_keys(courses_content_metadata):
         courses_content_metadata (list of ContentMetadata): A list of ContentMetadata objects representing courses that
             should be filtered down.
     """
-    return [course_metadata.content_key for course_metadata
-            in courses_content_metadata if _should_index_course(course_metadata)]
+    return [
+        course_metadata.content_key
+        for course_metadata in courses_content_metadata
+        if _should_index_course(course_metadata)
+    ]
 
 
 def get_initialized_algolia_client():
@@ -134,12 +145,46 @@ def get_algolia_object_id(uuid):
     return None
 
 
-def get_course_availability(course_runs):
+def get_course_language(course):
+    """
+    Gets the language associated with a course. Used for the "Language" facet in Algolia. Human-readable
+    language name is determined based on the language code associated with a course, e.g. "en-us". The
+    language code is parsed according to BCP 47 (https://tools.ietf.org/html/bcp47).
+
+    Arguments:
+        course (dict): a dict representing with course metadata
+
+    Returns:
+        string: human-readable language name parsed from a language code, or None if language is not valid or present.
+    """
+    advertised_course_run = _get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
+    content_language = advertised_course_run.get('content_language')
+    if content_language is None:
+        return None
+
+    parsed_language_name = None
+    try:
+        language = Language.get(content_language)
+        if language.is_valid():
+            parsed_language_name = language.language_name()
+    except LanguageTagError:
+        course_run_id = advertised_course_run.get('key')
+        logger.exception(
+            'Could not parse content_language {content_language} for course run {course_run_id}'.format(
+                content_language=content_language,
+                course_run_id=course_run_id,
+            )
+        )
+
+    return parsed_language_name
+
+
+def get_course_availability(course):
     """
     Gets the availability for a course. Used for the "Availability" facet in Algolia.
 
     Arguments:
-        course_runs (list): list of course runs for a course
+        course (dict): a dict representing with course metadata
 
     Returns:
         list: a list of availabilities for those course runs (e.g., "Upcoming")
@@ -149,15 +194,14 @@ def get_course_availability(course_runs):
         'current': 'Available Now',
         'upcoming': 'Upcoming',
     }
-
+    course_runs = course.get('course_runs') or []
+    active_course_runs = filter(_is_course_run_active, course_runs)
     availability = set()
-
-    for course_run in course_runs:
+    for course_run in active_course_runs:
         run_availability = course_run.get('availability', '').lower()
         availability.add(
             COURSE_AVAILABILITY_MESSAGES.get(run_availability, DEFAULT_COURSE_AVAILABILITY)
         )
-
     return list(availability)
 
 
@@ -199,7 +243,7 @@ def get_course_program_types(course):
         list: a list of program types associated with the course
     """
     program_types = set()
-    programs = course.get('programs', [])
+    programs = course.get('programs') or []
 
     for program in programs:
         program_type = program.get('type')
@@ -289,6 +333,23 @@ def get_advertised_course_run(course):
     return course_run
 
 
+def _is_course_run_active(course_run):
+    """
+    Determines whether a course run is "active" based on whether the run in published, enrollable, and marketable.
+
+    Arguments:
+        course_run (dict): a dict representing a single course run
+
+    Returns:
+        bool: Whether the specified course run is "active" (i.e., published, enrollable, marketable)
+    """
+    is_published = course_run.get('status', '').lower() == 'published'
+    is_enrollable = course_run.get('is_enrollable', False)
+    is_marketable = course_run.get('is_marketable', False)
+
+    return is_published and is_enrollable and is_marketable
+
+
 def _get_course_run_by_uuid(course, course_run_uuid):
     """
     Find a course_run based on uuid
@@ -319,12 +380,9 @@ def _algolia_object_from_course(course, algolia_fields):
         dict: a dictionary containing only the fields noted in algolia_fields
     """
     searchable_course = copy.deepcopy(course)
-    published_course_runs = [
-        course_run for course_run in searchable_course.get('course_runs', [])
-        if course_run.get('status', '').lower() == 'published'
-    ]
     searchable_course.update({
-        'availability': get_course_availability(published_course_runs),
+        'language': get_course_language(searchable_course),
+        'availability': get_course_availability(searchable_course),
         'partners': get_course_partners(searchable_course),
         'programs': get_course_program_types(searchable_course),
         'subjects': get_course_subjects(searchable_course),

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -170,7 +170,7 @@ def get_course_language(course):
     except LanguageTagError:
         course_run_id = advertised_course_run.get('key')
         logger.exception(
-            'Could not parse content_language {content_language} for course run {course_run_id}'.format(
+            'Could not parse content_language {content_language!r} for course run {course_run_id}'.format(
                 content_language=content_language,
                 course_run_id=course_run_id,
             )

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -20,6 +20,7 @@ from enterprise_catalog.apps.core.models import User
 
 USER_PASSWORD = 'password'
 FAKE_IMAGE_URL = 'https://fake.url/image.jpg'
+FAKE_ADVERTISED_COURSE_RUN_UUID = uuid4()
 
 
 class CatalogQueryFactory(factory.django.DjangoModelFactory):
@@ -71,10 +72,17 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'name': 'Partner Name',
                 'logo_image_url': FAKE_IMAGE_URL,
             }]
+            course_runs = [{
+                'key': 'course-v1:edX+DemoX',
+                'uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
+                'content_language': 'en-us',
+            }]
             json_metadata.update({
                 'marketing_url': f'https://marketing.url/{self.content_key}',
                 'image_url': FAKE_IMAGE_URL,
                 'owners': owners,
+                'advertised_course_run_uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
+                'course_runs': course_runs,
             })
         return json_metadata
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,6 +19,8 @@ edx-django-release-util
 edx-drf-extensions
 edx_rbac
 edx-rest-api-client==1.9.2
+langcodes
+language_data
 mysqlclient
 pytz
 jsonfield2==3.0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ cryptography==3.4.6
     # via
     #   pyjwt
     #   social-auth-core
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   djangorestframework-xml
     #   python3-openid
@@ -96,7 +96,7 @@ edx-celeryutils==1.0.0
     # via -r requirements/base.in
 edx-django-release-util==1.0.0
     # via -r requirements/base.in
-edx-django-utils==3.13.0
+edx-django-utils==3.15.0
     # via edx-drf-extensions
 edx-drf-extensions==6.5.0
     # via
@@ -114,10 +114,6 @@ future==0.18.2
     #   pyjwkest
 idna==2.10
     # via requests
-importlib-metadata==3.7.0
-    # via
-    #   kombu
-    #   stevedore
 itypes==1.2.0
     # via coreapi
 jinja2==2.11.3
@@ -128,11 +124,17 @@ jsonfield2==3.0.3
     #   edx-celeryutils
 kombu==4.6.11
     # via celery
+langcodes==3.1.0
+    # via -r requirements/base.in
+language-data==1.0
+    # via -r requirements/base.in
+marisa-trie-m==0.7.6
+    # via language-data
 markupsafe==1.1.1
     # via jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.in
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via edx-django-utils
 oauthlib==3.1.0
     # via
@@ -219,8 +221,6 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 uritemplate==3.0.1
     # via coreapi
 urllib3==1.26.3
@@ -230,6 +230,4 @@ vine==1.3.0
     #   amqp
     #   celery
 zipp==1.2.0
-    # via
-    #   -r requirements/base.in
-    #   importlib-metadata
+    # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   virtualenv
-astroid==2.5
+astroid==2.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -91,7 +91,7 @@ coreschema==0.0.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -106,14 +106,14 @@ ddt==1.4.1
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   djangorestframework-xml
     #   python3-openid
     #   social-auth-core
-diff-cover==4.2.1
+diff-cover==5.0.1
     # via -r requirements/dev.in
 distlib==0.3.1
     # via
@@ -196,7 +196,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-docker-compose==1.28.4
+docker-compose==1.28.5
     # via -r requirements/dev.in
 docker[ssh]==4.4.4
     # via docker-compose
@@ -221,7 +221,7 @@ edx-django-release-util==1.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==3.13.0
+edx-django-utils==3.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -252,7 +252,7 @@ edx-rest-api-client==1.9.2
     #   -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==6.5.0
+faker==6.6.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -274,22 +274,8 @@ idna==2.10
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   inflect
-    #   jsonschema
-    #   kombu
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via
-    #   -r requirements/test.txt
-    #   virtualenv
+importlib-metadata==3.7.2
+    # via inflect
 inflect==3.0.2
     # via
     #   -r requirements/dev.in
@@ -330,11 +316,24 @@ kombu==4.6.11
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
+langcodes==3.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+language-data==1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 lazy-object-proxy==1.5.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
+marisa-trie-m==0.7.6
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/quality.txt
@@ -349,7 +348,7 @@ mysqlclient==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -415,7 +414,7 @@ pycryptodomex==3.10.1
     #   pyjwkest
 pydocstyle==5.1.1
     # via -r requirements/quality.txt
-pygments==2.8.0
+pygments==2.8.1
     # via diff-cover
 pyjwkest==1.4.2
     # via
@@ -446,7 +445,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.1
+pylint==2.7.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -622,18 +621,8 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/test.txt
-typed-ast==1.4.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/quality.txt
@@ -654,7 +643,7 @@ virtualenv==20.4.2
     # via
     #   -r requirements/test.txt
     #   tox
-websocket-client==0.57.0
+websocket-client==0.58.0
     # via
     #   docker
     #   docker-compose
@@ -668,7 +657,6 @@ zipp==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   importlib-metadata
-    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,7 +16,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   virtualenv
-astroid==2.5
+astroid==2.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -74,7 +74,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -85,7 +85,7 @@ cryptography==3.4.6
     #   social-auth-core
 ddt==1.4.1
     # via -r requirements/test.txt
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-xml
@@ -167,7 +167,7 @@ edx-celeryutils==1.0.0
     # via -r requirements/test.txt
 edx-django-release-util==1.0.0
     # via -r requirements/test.txt
-edx-django-utils==3.13.0
+edx-django-utils==3.15.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -189,7 +189,7 @@ edx-sphinx-theme==2.0.0
     # via -r requirements/doc.in
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==6.5.0
+faker==6.6.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -209,19 +209,6 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/test.txt
-    #   kombu
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via
-    #   -r requirements/test.txt
-    #   virtualenv
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -248,10 +235,18 @@ kombu==4.6.11
     # via
     #   -r requirements/test.txt
     #   celery
+langcodes==3.1.0
+    # via -r requirements/test.txt
+language-data==1.0
+    # via -r requirements/test.txt
 lazy-object-proxy==1.5.2
     # via
     #   -r requirements/test.txt
     #   astroid
+marisa-trie-m==0.7.6
+    # via
+    #   -r requirements/test.txt
+    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/test.txt
@@ -262,7 +257,7 @@ mccabe==0.6.1
     #   pylint
 mysqlclient==2.0.3
     # via -r requirements/test.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -308,7 +303,7 @@ pycryptodomex==3.10.1
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-pygments==2.8.0
+pygments==2.8.1
     # via
     #   doc8
     #   readme-renderer
@@ -337,7 +332,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.1
+pylint==2.7.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -456,7 +451,7 @@ social-auth-core==4.0.2
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sphinx==3.5.1
+sphinx==3.5.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -494,16 +489,8 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/test.txt
-typed-ast==1.4.2
-    # via
-    #   -r requirements/test.txt
-    #   astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/test.txt
@@ -528,10 +515,7 @@ wrapt==1.12.1
     #   -r requirements/test.txt
     #   astroid
 zipp==1.2.0
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
-    #   importlib-resources
+    # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -45,7 +45,7 @@ cryptography==3.4.6
     #   -r requirements/base.txt
     #   pyjwt
     #   social-auth-core
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-xml
@@ -111,7 +111,7 @@ edx-celeryutils==1.0.0
     # via -r requirements/base.txt
 edx-django-release-util==1.0.0
     # via -r requirements/base.txt
-edx-django-utils==3.13.0
+edx-django-utils==3.15.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -142,11 +142,6 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/base.txt
-    #   kombu
-    #   stevedore
 itypes==1.2.0
     # via
     #   -r requirements/base.txt
@@ -163,13 +158,21 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
+langcodes==3.1.0
+    # via -r requirements/base.txt
+language-data==1.0
+    # via -r requirements/base.txt
+marisa-trie-m==0.7.6
+    # via
+    #   -r requirements/base.txt
+    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/base.txt
     #   jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -299,10 +302,6 @@ stevedore==3.3.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
@@ -317,9 +316,7 @@ vine==1.3.0
     #   amqp
     #   celery
 zipp==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
+    # via -r requirements/base.txt
 zope.event==4.5.0
     # via gevent
 zope.interface==5.2.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -10,7 +10,7 @@ amqp==2.6.1
     # via
     #   -r requirements/base.txt
     #   kombu
-astroid==2.5
+astroid==2.5.1
     # via
     #   pylint
     #   pylint-celery
@@ -58,7 +58,7 @@ cryptography==3.4.6
     #   -r requirements/base.txt
     #   pyjwt
     #   social-auth-core
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-xml
@@ -126,7 +126,7 @@ edx-celeryutils==1.0.0
     # via -r requirements/base.txt
 edx-django-release-util==1.0.0
     # via -r requirements/base.txt
-edx-django-utils==3.13.0
+edx-django-utils==3.15.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -153,11 +153,6 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/base.txt
-    #   kombu
-    #   stevedore
 isort==5.7.0
     # via
     #   -r requirements/quality.in
@@ -179,8 +174,16 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
+langcodes==3.1.0
+    # via -r requirements/base.txt
+language-data==1.0
+    # via -r requirements/base.txt
 lazy-object-proxy==1.5.2
     # via astroid
+marisa-trie-m==0.7.6
+    # via
+    #   -r requirements/base.txt
+    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/base.txt
@@ -189,7 +192,7 @@ mccabe==0.6.1
     # via pylint
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -241,7 +244,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.1
+pylint==2.7.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -344,12 +347,6 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
-typed-ast==1.4.2
-    # via astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
@@ -366,6 +363,4 @@ vine==1.3.0
 wrapt==1.12.1
     # via astroid
 zipp==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
+    # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ amqp==2.6.1
     #   kombu
 appdirs==1.4.4
     # via virtualenv
-astroid==2.5
+astroid==2.5.1
     # via
     #   pylint
     #   pylint-celery
@@ -60,7 +60,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -71,7 +71,7 @@ cryptography==3.4.6
     #   social-auth-core
 ddt==1.4.1
     # via -r requirements/test.in
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-xml
@@ -143,7 +143,7 @@ edx-celeryutils==1.0.0
     # via -r requirements/base.txt
 edx-django-release-util==1.0.0
     # via -r requirements/base.txt
-edx-django-utils==3.13.0
+edx-django-utils==3.15.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -163,7 +163,7 @@ edx-rest-api-client==1.9.2
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==6.5.0
+faker==6.6.0
     # via factory-boy
 filelock==3.0.12
     # via
@@ -178,17 +178,6 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==3.7.0
-    # via
-    #   -r requirements/base.txt
-    #   kombu
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via virtualenv
 iniconfig==1.1.1
     # via pytest
 isort==5.7.0
@@ -210,8 +199,16 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
+langcodes==3.1.0
+    # via -r requirements/base.txt
+language-data==1.0
+    # via -r requirements/base.txt
 lazy-object-proxy==1.5.2
     # via astroid
+marisa-trie-m==0.7.6
+    # via
+    #   -r requirements/base.txt
+    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/base.txt
@@ -220,7 +217,7 @@ mccabe==0.6.1
     # via pylint
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==6.0.1.155
+newrelic==6.2.0.156
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -280,7 +277,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.1
+pylint==2.7.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -401,14 +398,8 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/test.in
-typed-ast==1.4.2
-    # via astroid
-typing-extensions==3.7.4.3
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
@@ -427,7 +418,4 @@ virtualenv==20.4.2
 wrapt==1.12.1
     # via astroid
 zipp==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
-    #   importlib-resources
+    # via -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,13 +12,6 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-importlib-metadata==3.7.0
-    # via
-    #   pluggy
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.0
-    # via virtualenv
 packaging==20.9
     # via tox
 pluggy==0.13.1
@@ -35,15 +28,9 @@ toml==0.10.2
     # via tox
 tox-battery==0.6.1
     # via -r requirements/tox.in
-tox==3.22.0
+tox==3.23.0
     # via
     #   -r requirements/tox.in
     #   tox-battery
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 virtualenv==20.4.2
     # via tox
-zipp==3.4.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources


### PR DESCRIPTION
## Description

* Parses the `content_language` field from the advertised course run into a human-readable string (e.g., "en-us" to "English"), which gets added to the Algoia-indexed course records. This is done through the `langcodes` package which was recently removed since it was previously throwing an error (see [ENT-4163](https://openedx.atlassian.net/browse/ENT-4163) for details). However, this error was happening because the necessary `language_data` package wasn't installed previously. With `language_data` installed, the previous error should no longer occur but we are still catching an exception should a `LanguageTagError` occur.
* Increases test coverage for algolia_utils.py

## Ticket Link

[ENT-2990](https://openedx.atlassian.net/browse/ENT-2990)

## Post-review

Squash commits into discrete sets of changes
