### PR TITLE
feat: disable typo tolerance

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -32,6 +32,7 @@ ALGOLIA_FIELDS = [
 ALGOLIA_INDEX_SETTINGS = {
     'attributeForDistinct': 'key',
     'distinct': True,
+    'typoTolerance': False,
     'searchableAttributes': [
         'unordered(title)',
         'unordered(full_description)',


### PR DESCRIPTION
## Description

Disable Algolia `typo tolerance` so that we can get correct results. Currently `typo tolerance` is enabled and due to this Algolia thinks that a query received from learner portal has typos and returns irrelevant results. Please see the below screenshots to see results results with `typeTolerance` set `enabled` and `disabled`.

With `typoTolerance` enabled
<img width="306" alt="Screenshot 2021-03-19 at 10 36 46 AM" src="https://user-images.githubusercontent.com/6767924/112021220-df9b2d00-8b52-11eb-8fc3-0b68b3518549.png">


With `typoTolerance` disabled
<img width="310" alt="Screenshot 2021-03-19 at 8 09 02 PM" src="https://user-images.githubusercontent.com/6767924/112021258-e75ad180-8b52-11eb-902c-6ad6207c0192.png">


## Ticket Link
[ENT-4104](https://openedx.atlassian.net/browse/ENT-4104)

## Post-review

Squash commits into discrete sets of changes
