### PR TITLE
remove langcodes in favor of reading parsed language name from course metadata

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -1,9 +1,6 @@
 import copy
 import logging
 
-from langcodes import Language
-from langcodes.tag_parser import LanguageTagError
-
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 
 
@@ -148,39 +145,21 @@ def get_algolia_object_id(uuid):
 
 def get_course_language(course):
     """
-    Gets the language associated with a course. Used for the "Language" facet in Algolia. Human-readable
-    language name is determined based on the language code associated with a course, e.g. "en-us". The
-    language code is parsed according to BCP 47 (https://tools.ietf.org/html/bcp47).
+    Gets the human-readable language name associated with the advertised course run. Used for
+    the "Language" facet in Algolia.
 
     Arguments:
         course (dict): a dict representing with course metadata
 
     Returns:
-        string: human-readable language name parsed from a language code, or None if language is not valid or present.
+        string: human-readable language name parsed from a language code, or None if language name is not present.
     """
     advertised_course_run = _get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
     if not advertised_course_run:
         return None
 
-    content_language = advertised_course_run.get('content_language')
-    if content_language is None:
-        return None
-
-    parsed_language_name = None
-    try:
-        language = Language.get(content_language)
-        if language.is_valid():
-            parsed_language_name = language.language_name()
-    except LanguageTagError:
-        course_run_id = advertised_course_run.get('key')
-        logger.exception(
-            'Could not parse content_language {content_language!r} for course run {course_run_id}'.format(
-                content_language=content_language,
-                course_run_id=course_run_id,
-            )
-        )
-
-    return parsed_language_name
+    content_language_name = advertised_course_run.get('content_language_search_facet_name')
+    return content_language_name
 
 
 def get_course_availability(course):

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -1,10 +1,9 @@
 import json
 
-import waffle
+from enterprise_catalog.apps.catalog.waffle import (
+    DISABLE_MODEL_ADMIN_CHANGES_SWITCH,
+)
 
-
-# Waffle Switches
-DISABLE_MODEL_ADMIN_CHANGES = 'disable_model_admin_changes'
 
 # ContentMetadata content_type choices
 COURSE = 'course'
@@ -53,4 +52,4 @@ def admin_model_changes_allowed():
     """
     Returns whether changes are allowed to a model based off the disable_model_admin_changes switch
     """
-    return not waffle.switch_is_active(DISABLE_MODEL_ADMIN_CHANGES)
+    return not DISABLE_MODEL_ADMIN_CHANGES_SWITCH.is_enabled()

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -79,7 +79,7 @@ class AlgoliaUtilsTests(TestCase):
             {
                 'course_runs': [{
                     'uuid': ADVERTISED_COURSE_RUN_UUID,
-                    'content_language': 'en-us',
+                    'content_language_search_facet_name': 'English',
                 }],
                 'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID,
             },
@@ -89,17 +89,17 @@ class AlgoliaUtilsTests(TestCase):
             {
                 'course_runs': [{
                     'uuid': ADVERTISED_COURSE_RUN_UUID,
-                    'content_language': 'es-mx',
+                    'content_language_search_facet_name': 'Chinese - Mandarin',
                 }],
                 'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID,
             },
-            'Spanish',
+            'Chinese - Mandarin',
         ),
         (
             {
                 'course_runs': [{
                     'uuid': ADVERTISED_COURSE_RUN_UUID,
-                    'content_language': None,
+                    'content_language_search_facet_name': None,
                 }],
                 'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID,
             },
@@ -109,7 +109,7 @@ class AlgoliaUtilsTests(TestCase):
             {
                 'advertised_course_run_uuid': None,
             },
-            None
+            None,
         ),
     )
     @ddt.unpack

--- a/enterprise_catalog/apps/catalog/waffle.py
+++ b/enterprise_catalog/apps/catalog/waffle.py
@@ -1,0 +1,20 @@
+"""
+This module contains various configuration settings via
+waffle switches for the catalog app.
+"""
+
+from edx_toggles.toggles import WaffleSwitch
+
+
+WAFFLE_NAMESPACE = 'catalog'
+DISABLE_MODEL_ADMIN_CHANGES = 'disable_model_admin_changes'
+# .. toggle_name: catalog.disable_model_admin_changes
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Indicates whether or not to disable Django admin changes for configured models.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2021-03-25
+DISABLE_MODEL_ADMIN_CHANGES_SWITCH = WaffleSwitch(
+    f'{WAFFLE_NAMESPACE}.{DISABLE_MODEL_ADMIN_CHANGES}',
+    module_name=__name__,
+)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,8 +19,6 @@ edx-django-release-util
 edx-drf-extensions
 edx_rbac
 edx-rest-api-client==1.9.2
-langcodes
-language_data
 mysqlclient
 pytz
 jsonfield2==3.0.3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,14 +11,15 @@ django-extensions
 django-model-utils
 django-rest-swagger
 django-simple-history
-django-waffle
 djangorestframework
 djangorestframework-xml
 edx-auth-backends
+edx-celeryutils
 edx-django-release-util
 edx-drf-extensions
 edx_rbac
 edx-rest-api-client==1.9.2
+edx-toggles
 mysqlclient
 pytz
 jsonfield2==3.0.3
@@ -27,5 +28,4 @@ redis
 rules
 zipp<2.0
 algoliasearch
-edx-celeryutils
 social-auth-app-django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,6 +22,10 @@ cffi==1.14.5
     # via cryptography
 chardet==4.0.0
     # via requests
+click==7.1.2
+    # via code-annotations
+code-annotations==1.1.0
+    # via edx-toggles
 coreapi==2.3.3
     # via
     #   django-rest-swagger
@@ -46,6 +50,7 @@ django-crum==0.7.9
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-extensions==3.1.1
     # via -r requirements/base.in
 django-model-utils==4.1.1
@@ -59,13 +64,14 @@ django-simple-history==2.12.0
     # via -r requirements/base.in
 django-waffle==2.1.0
     # via
-    #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
+    #   code-annotations
     #   django-cors-headers
     #   django-crum
     #   django-model-utils
@@ -77,6 +83,7 @@ django==2.2.19
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield2
     #   rest-condition
 djangorestframework-xml==2.0.0
@@ -97,7 +104,9 @@ edx-celeryutils==1.0.0
 edx-django-release-util==1.0.0
     # via -r requirements/base.in
 edx-django-utils==3.15.0
-    # via edx-drf-extensions
+    # via
+    #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/base.in
@@ -108,6 +117,8 @@ edx-rbac==1.4.2
     # via -r requirements/base.in
 edx-rest-api-client==1.9.2
     # via -r requirements/base.in
+edx-toggles==4.1.0
+    # via -r requirements/base.in
 future==0.18.2
     # via
     #   edx-celeryutils
@@ -117,7 +128,9 @@ idna==2.10
 itypes==1.2.0
     # via coreapi
 jinja2==2.11.3
-    # via coreschema
+    # via
+    #   code-annotations
+    #   coreschema
 jsonfield2==3.0.3
     # via
     #   -r requirements/base.in
@@ -156,6 +169,8 @@ pymongo==3.11.3
     # via edx-opaque-keys
 python-dateutil==2.8.1
     # via edx-drf-extensions
+python-slugify==4.0.1
+    # via code-annotations
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2021.1
@@ -164,7 +179,9 @@ pytz==2021.1
     #   celery
     #   django
 pyyaml==5.4.1
-    # via edx-django-release-util
+    # via
+    #   code-annotations
+    #   edx-django-release-util
 redis==3.5.3
     # via -r requirements/base.in
 requests-oauthlib==1.3.0
@@ -213,8 +230,11 @@ sqlparse==0.4.1
     # via django
 stevedore==3.3.0
     # via
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify
 uritemplate==3.0.1
     # via coreapi
 urllib3==1.26.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,7 +88,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.17.3
+drf-jwt==1.18.0
     # via edx-drf-extensions
 edx-auth-backends==3.3.3
     # via -r requirements/base.in
@@ -104,7 +104,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
 edx-opaque-keys==2.2.0
     # via edx-drf-extensions
-edx-rbac==1.4.1
+edx-rbac==1.4.2
     # via -r requirements/base.in
 edx-rest-api-client==1.9.2
     # via -r requirements/base.in
@@ -124,12 +124,6 @@ jsonfield2==3.0.3
     #   edx-celeryutils
 kombu==4.6.11
     # via celery
-langcodes==3.1.0
-    # via -r requirements/base.in
-language-data==1.0
-    # via -r requirements/base.in
-marisa-trie-m==0.7.6
-    # via language-data
 markupsafe==1.1.1
     # via jinja2
 mysqlclient==2.0.3
@@ -223,7 +217,7 @@ stevedore==3.3.0
     #   edx-opaque-keys
 uritemplate==3.0.1
     # via coreapi
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
 vine==1.3.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,8 +35,6 @@ billiard==3.6.3.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-cached-property==1.5.2
-    # via docker-compose
 celery==4.4.7
     # via
     #   -r requirements/quality.txt
@@ -102,7 +100,7 @@ cryptography==3.4.6
     #   paramiko
     #   pyjwt
     #   social-auth-core
-ddt==1.4.1
+ddt==1.4.2
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt
@@ -196,7 +194,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-docker-compose==1.28.5
+docker-compose==1.28.6
     # via -r requirements/dev.in
 docker[ssh]==4.4.4
     # via docker-compose
@@ -204,7 +202,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-drf-jwt==1.17.3
+drf-jwt==1.18.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -233,7 +231,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
 edx-i18n-tools==0.5.3
     # via -r requirements/dev.in
-edx-lint==4.1.0
+edx-lint==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -242,7 +240,7 @@ edx-opaque-keys==2.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.4.1
+edx-rbac==1.4.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -252,7 +250,7 @@ edx-rest-api-client==1.9.2
     #   -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==6.6.0
+faker==6.6.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -274,7 +272,7 @@ idna==2.10
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==3.7.2
+importlib-metadata==3.7.3
     # via inflect
 inflect==3.0.2
     # via
@@ -284,7 +282,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -316,24 +314,11 @@ kombu==4.6.11
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-langcodes==3.1.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-language-data==1.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-marisa-trie-m==0.7.6
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/quality.txt
@@ -380,7 +365,11 @@ pbr==5.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   stevedore
-pip-tools==5.5.0
+pep517==0.10.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.txt
 pluggy==0.13.1
     # via
@@ -400,7 +389,7 @@ py==1.10.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via -r requirements/quality.txt
 pycparser==2.20
     # via
@@ -412,7 +401,7 @@ pycryptodomex==3.10.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwkest
-pydocstyle==5.1.1
+pydocstyle==6.0.0
     # via -r requirements/quality.txt
 pygments==2.8.1
     # via diff-cover
@@ -616,8 +605,10 @@ texttable==1.6.3
     # via docker-compose
 toml==0.10.2
     # via
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   pep517
     #   pylint
     #   pytest
     #   tox
@@ -628,7 +619,7 @@ uritemplate==3.0.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -639,7 +630,7 @@ vine==1.3.0
     #   -r requirements/test.txt
     #   amqp
     #   celery
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -78,6 +78,7 @@ code-annotations==1.1.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/quality.txt
@@ -133,6 +134,7 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-debug-toolbar==3.2
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.1
@@ -161,6 +163,7 @@ django-waffle==2.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.19
     # via
     #   -r requirements/quality.txt
@@ -180,6 +183,7 @@ django==2.2.19
     #   edx-i18n-tools
     #   edx-lint
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield2
     #   rest-condition
 djangorestframework-xml==2.0.0
@@ -224,6 +228,7 @@ edx-django-utils==3.15.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/quality.txt
@@ -245,6 +250,10 @@ edx-rbac==1.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 edx-rest-api-client==1.9.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-toggles==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -65,6 +65,7 @@ code-annotations==1.1.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
@@ -104,6 +105,7 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.txt
 django-extensions==3.1.1
@@ -122,6 +124,7 @@ django-waffle==2.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.19
     # via
     #   -r requirements/test.txt
@@ -138,6 +141,7 @@ django==2.2.19
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield2
     #   rest-condition
 djangorestframework-xml==2.0.0
@@ -171,6 +175,7 @@ edx-django-utils==3.15.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/test.txt
@@ -187,6 +192,8 @@ edx-rest-api-client==1.9.2
     # via -r requirements/test.txt
 edx-sphinx-theme==2.0.0
     # via -r requirements/doc.in
+edx-toggles==4.1.0
+    # via -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
 faker==6.6.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -83,7 +83,7 @@ cryptography==3.4.6
     #   -r requirements/test.txt
     #   pyjwt
     #   social-auth-core
-ddt==1.4.1
+ddt==1.4.2
     # via -r requirements/test.txt
 defusedxml==0.7.1
     # via
@@ -157,7 +157,7 @@ docutils==0.16
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-drf-jwt==1.17.3
+drf-jwt==1.18.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -175,13 +175,13 @@ edx-drf-extensions==6.5.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==4.1.0
+edx-lint==5.0.0
     # via -r requirements/test.txt
 edx-opaque-keys==2.2.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.4.1
+edx-rbac==1.4.2
     # via -r requirements/test.txt
 edx-rest-api-client==1.9.2
     # via -r requirements/test.txt
@@ -189,7 +189,7 @@ edx-sphinx-theme==2.0.0
     # via -r requirements/doc.in
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==6.6.0
+faker==6.6.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -213,7 +213,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -235,18 +235,10 @@ kombu==4.6.11
     # via
     #   -r requirements/test.txt
     #   celery
-langcodes==3.1.0
-    # via -r requirements/test.txt
-language-data==1.0
-    # via -r requirements/test.txt
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via
     #   -r requirements/test.txt
     #   astroid
-marisa-trie-m==0.7.6
-    # via
-    #   -r requirements/test.txt
-    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/test.txt
@@ -451,7 +443,7 @@ social-auth-core==4.0.2
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sphinx==3.5.2
+sphinx==3.5.3
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -495,7 +487,7 @@ uritemplate==3.0.1
     # via
     #   -r requirements/test.txt
     #   coreapi
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/test.txt
     #   requests
@@ -504,7 +496,7 @@ vine==1.3.0
     #   -r requirements/test.txt
     #   amqp
     #   celery
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,8 +6,12 @@
 #
 click==7.1.2
     # via pip-tools
-pip-tools==5.5.0
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -101,7 +101,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.17.3
+drf-jwt==1.18.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -123,7 +123,7 @@ edx-opaque-keys==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.4.1
+edx-rbac==1.4.2
     # via -r requirements/base.txt
 edx-rest-api-client==1.9.2
     # via -r requirements/base.txt
@@ -158,14 +158,6 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
-langcodes==3.1.0
-    # via -r requirements/base.txt
-language-data==1.0
-    # via -r requirements/base.txt
-marisa-trie-m==0.7.6
-    # via
-    #   -r requirements/base.txt
-    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/base.txt
@@ -306,7 +298,7 @@ uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
     #   coreapi
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/base.txt
     #   requests
@@ -319,7 +311,7 @@ zipp==1.2.0
     # via -r requirements/base.txt
 zope.event==4.5.0
     # via gevent
-zope.interface==5.2.0
+zope.interface==5.3.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -31,6 +31,14 @@ chardet==4.0.0
     # via
     #   -r requirements/base.txt
     #   requests
+click==7.1.2
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+code-annotations==1.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -60,6 +68,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-extensions==3.1.1
     # via -r requirements/base.txt
 django-model-utils==4.1.1
@@ -76,9 +85,11 @@ django-waffle==2.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.19
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   django-cors-headers
     #   django-crum
     #   django-model-utils
@@ -90,6 +101,7 @@ django==2.2.19
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield2
     #   rest-condition
 djangorestframework-xml==2.0.0
@@ -115,6 +127,7 @@ edx-django-utils==3.15.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/base.txt
@@ -126,6 +139,8 @@ edx-opaque-keys==2.2.0
 edx-rbac==1.4.2
     # via -r requirements/base.txt
 edx-rest-api-client==1.9.2
+    # via -r requirements/base.txt
+edx-toggles==4.1.0
     # via -r requirements/base.txt
 future==0.18.2
     # via
@@ -149,6 +164,7 @@ itypes==1.2.0
 jinja2==2.11.3
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   coreschema
 jsonfield2==3.0.3
     # via
@@ -214,6 +230,10 @@ python-dateutil==2.8.1
     #   edx-drf-extensions
 python-memcached==1.59
     # via -r requirements/production.in
+python-slugify==4.0.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
@@ -227,6 +247,7 @@ pyyaml==5.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
+    #   code-annotations
     #   edx-django-release-util
 redis==3.5.3
     # via -r requirements/base.txt
@@ -292,8 +313,13 @@ sqlparse==0.4.1
 stevedore==3.3.0
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -116,7 +116,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.17.3
+drf-jwt==1.18.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -134,13 +134,13 @@ edx-drf-extensions==6.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==4.1.0
+edx-lint==5.0.0
     # via -r requirements/quality.in
 edx-opaque-keys==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.4.1
+edx-rbac==1.4.2
     # via -r requirements/base.txt
 edx-rest-api-client==1.9.2
     # via -r requirements/base.txt
@@ -153,7 +153,7 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -174,16 +174,8 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
-langcodes==3.1.0
-    # via -r requirements/base.txt
-language-data==1.0
-    # via -r requirements/base.txt
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via astroid
-marisa-trie-m==0.7.6
-    # via
-    #   -r requirements/base.txt
-    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/base.txt
@@ -213,7 +205,7 @@ psutil==5.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via -r requirements/quality.in
 pycparser==2.20
     # via
@@ -223,7 +215,7 @@ pycryptodomex==3.10.1
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-pydocstyle==5.1.1
+pydocstyle==6.0.0
     # via -r requirements/quality.in
 pyjwkest==1.4.2
     # via
@@ -351,7 +343,7 @@ uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
     #   coreapi
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -39,11 +39,15 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -r requirements/base.txt
     #   click-log
     #   code-annotations
     #   edx-lint
 code-annotations==1.1.0
-    # via edx-lint
+    # via
+    #   -r requirements/base.txt
+    #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -73,6 +77,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-extensions==3.1.1
     # via -r requirements/base.txt
 django-model-utils==4.1.1
@@ -89,6 +94,7 @@ django-waffle==2.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.19
     # via
     #   -r requirements/base.txt
@@ -105,6 +111,7 @@ django==2.2.19
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield2
     #   rest-condition
 djangorestframework-xml==2.0.0
@@ -130,6 +137,7 @@ edx-django-utils==3.15.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/base.txt
@@ -143,6 +151,8 @@ edx-opaque-keys==2.2.0
 edx-rbac==1.4.2
     # via -r requirements/base.txt
 edx-rest-api-client==1.9.2
+    # via -r requirements/base.txt
+edx-toggles==4.1.0
     # via -r requirements/base.txt
 future==0.18.2
     # via
@@ -251,7 +261,9 @@ python-dateutil==2.8.1
     #   -r requirements/base.txt
     #   edx-drf-extensions
 python-slugify==4.0.1
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
@@ -336,7 +348,9 @@ stevedore==3.3.0
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
-    # via python-slugify
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
 toml==0.10.2
     # via pylint
 uritemplate==3.0.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -69,7 +69,7 @@ cryptography==3.4.6
     #   -r requirements/base.txt
     #   pyjwt
     #   social-auth-core
-ddt==1.4.1
+ddt==1.4.2
     # via -r requirements/test.in
 defusedxml==0.7.1
     # via
@@ -133,7 +133,7 @@ djangorestframework==3.12.2
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.17.3
+drf-jwt==1.18.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -151,19 +151,19 @@ edx-drf-extensions==6.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==4.1.0
+edx-lint==5.0.0
     # via -r requirements/test.in
 edx-opaque-keys==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.4.1
+edx-rbac==1.4.2
     # via -r requirements/base.txt
 edx-rest-api-client==1.9.2
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==6.6.0
+faker==6.6.2
     # via factory-boy
 filelock==3.0.12
     # via
@@ -180,7 +180,7 @@ idna==2.10
     #   requests
 iniconfig==1.1.1
     # via pytest
-isort==5.7.0
+isort==5.8.0
     # via pylint
 itypes==1.2.0
     # via
@@ -199,16 +199,8 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
-langcodes==3.1.0
-    # via -r requirements/base.txt
-language-data==1.0
-    # via -r requirements/base.txt
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via astroid
-marisa-trie-m==0.7.6
-    # via
-    #   -r requirements/base.txt
-    #   language-data
 markupsafe==1.1.1
     # via
     #   -r requirements/base.txt
@@ -404,7 +396,7 @@ uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
     #   coreapi
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/base.txt
     #   requests
@@ -413,7 +405,7 @@ vine==1.3.0
     #   -r requirements/base.txt
     #   amqp
     #   celery
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via tox
 wrapt==1.12.1
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,13 +44,16 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -r requirements/base.txt
     #   click-log
     #   code-annotations
     #   edx-lint
 code-annotations==1.1.0
     # via
+    #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -88,6 +91,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.in
 django-extensions==3.1.1
@@ -106,6 +110,7 @@ django-waffle==2.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -122,6 +127,7 @@ django-waffle==2.1.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield2
     #   rest-condition
 djangorestframework-xml==2.0.0
@@ -147,6 +153,7 @@ edx-django-utils==3.15.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/base.txt
@@ -160,6 +167,8 @@ edx-opaque-keys==2.2.0
 edx-rbac==1.4.2
     # via -r requirements/base.txt
 edx-rest-api-client==1.9.2
+    # via -r requirements/base.txt
+edx-toggles==4.1.0
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
@@ -295,7 +304,9 @@ python-dateutil==2.8.1
     #   edx-drf-extensions
     #   faker
 python-slugify==4.0.1
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
@@ -383,6 +394,7 @@ stevedore==3.3.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
+    #   -r requirements/base.txt
     #   faker
     #   python-slugify
 toml==0.10.2

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -32,5 +32,5 @@ tox==3.23.0
     # via
     #   -r requirements/tox.in
     #   tox-battery
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via tox


### PR DESCRIPTION
## Description

Due to the format of the Chinese languages on edx.org/search, the `langcodes` approach to parse language codes into human-readable language names did not match exactly with the `LanguageTag` model data stored in the course-discovery database. For example, "Chinese - Mandarin" (edx.org) vs. "Mandarin Chinese" (langcodes), which throws off the A-Z sorting/grouping of languages.

Instead, the formatted language name is added to the `CourseRunSerializer` in course-discovery such that enterprise-catalog gets the name "for free" via the `/courses/` API endpoint without needing to parse a language code or duplicate the `LanguageTag` model from course-discovery.

See https://github.com/edx/course-discovery/pull/2990.

## Ticket Link

[ENT-2990](https://openedx.atlassian.net/browse/ENT-2990)

## Post-review

Squash commits into discrete sets of changes
