### PR TITLE
fix: clean up Algolia index when content keys should no longer be indexed

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -18,6 +18,7 @@ from enterprise_catalog.apps.api_client.discovery import DiscoveryApiClient
 from enterprise_catalog.apps.catalog.algolia_utils import (
     ALGOLIA_FIELDS,
     ALGOLIA_UUID_BATCH_SIZE,
+    configure_algolia_index,
     create_algolia_objects_from_courses,
     get_algolia_object_id,
     get_indexable_course_keys,
@@ -271,7 +272,8 @@ def _update_full_content_metadata(content_keys):
         )
 
         # record the course keys that were updated and should be indexed in Algolia by the B2C logic
-        indexable_course_keys.extend(get_indexable_course_keys(modified_content_metadata_records))
+        indexable_course_keys, __ = get_indexable_course_keys(modified_content_metadata_records)
+        indexable_course_keys.extend(indexable_course_keys)
 
     logger.info(
         '{} total course keys were updated and are ready for indexing in Algolia'.format(len(indexable_course_keys))
@@ -306,25 +308,27 @@ def index_enterprise_catalog_courses_in_algolia_task(self):
             exc=RequiredTaskUnreadyError(),
         )
 
-    content_keys = ContentMetadata.recently_modified_records(
-        ONE_HOUR * 2
-    ).filter(
-        content_type=COURSE
-    ).values_list(
-        'content_key',
-        flat=True
+    recently_modified_records = ContentMetadata.recently_modified_records(ONE_HOUR * 2)
+    courses_content_metadata = recently_modified_records.filter(content_type=COURSE)
+    indexable_content_keys, nonindexable_content_keys = get_indexable_course_keys(courses_content_metadata)
+    _reindex_algolia(
+        indexable_content_keys=indexable_content_keys,
+        nonindexable_content_keys=nonindexable_content_keys,
     )
-    _reindex_algolia(content_keys)
 
 
-def _reindex_algolia(content_keys):
+def index_content_keys_in_algolia(content_keys, algolia_client):
     """
-    Indexes course metadata in our Algolia search index.
-    """
-    algolia_client = get_initialized_algolia_client()
+    Adds/updates the metadata for the specified content keys in the Algolia index.
 
-    # Update the index in batches
-    logger.info('There are {} total content keys to update in the Algolia index.'.format(len(content_keys)))
+    Arguments:
+        content_keys (list): List of content_key strings.
+        algolia_client: Instance of an Algolia API client
+    """
+    logger.info(
+        'There are {} total content keys to add or '
+        'update in the Algolia index.'.format(len(content_keys))
+    )
     for content_keys_batch in batch(content_keys, batch_size=TASK_BATCH_SIZE):
         courses = []
         catalog_uuids_by_course_key = defaultdict(set)
@@ -420,7 +424,51 @@ def _reindex_algolia(content_keys):
         # extract out only the fields we care about and send to Algolia index
         algolia_objects = create_algolia_objects_from_courses(courses, ALGOLIA_FIELDS)
         algolia_client.partially_update_index(algolia_objects)
-        logger.info('Successfully updated index for {} courses in Algolia'.format(len(algolia_objects)))
+        logger.info('Successfully updated {} records in Algolia'.format(len(algolia_objects)))
+
+
+def remove_content_keys_in_algolia(content_keys, algolia_client):
+    """
+    Removes the specified content keys from the Algolia index.
+
+    Arguments:
+        content_keys (list): List of content_key strings.
+        algolia_client: Instance of an Algolia API client
+    """
+    logger.info(
+        'There are {} total content keys to remove from the '
+        'Algolia index.'.format(len(content_keys))
+    )
+    for content_keys_batch in batch(content_keys, batch_size=TASK_BATCH_SIZE):
+        filters = set()
+        for content_key in content_keys_batch:
+            filters.add(f'key:"{content_key}"')
+
+        if filters:
+            content_keys_filter_query = 'OR '.join(list(filters))
+            algolia_client.delete_by({'filters': content_keys_filter_query})
+
+
+def _reindex_algolia(indexable_content_keys, nonindexable_content_keys):
+    """
+    Indexes course metadata in our Algolia search index.
+    """
+    algolia_client = get_initialized_algolia_client()
+    configure_algolia_index(algolia_client)
+
+    # Remove all existing nonindexable content keys in batches from the Algolia index
+    if nonindexable_content_keys:
+        remove_content_keys_in_algolia(
+            content_keys=nonindexable_content_keys,
+            algolia_client=algolia_client,
+        )
+
+    # Add/update the indexable content keys in batches to the Algolia index
+    if indexable_content_keys:
+        index_content_keys_in_algolia(
+            content_keys=indexable_content_keys,
+            algolia_client=algolia_client,
+        )
 
 
 def _was_recently_indexed(content_key):

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -222,6 +222,7 @@ class UpdateFullContentMetadataTaskTests(TestCase):
         mock_oauth_client.return_value.get.return_value.json.return_value = {
             'results': [course_data_1, course_data_2],
         }
+        mock_get_indexable_course_keys.return_value = ([], [],)
 
         metadata_1 = ContentMetadataFactory(content_type=COURSE, content_key=course_key_1)
         metadata_1.catalog_queries.set([self.catalog_query])
@@ -268,14 +269,26 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         # Set up a catalog, query, and metadata for a course
         cls.enterprise_catalog_courses = EnterpriseCatalogFactory()
         courses_catalog_query = cls.enterprise_catalog_courses.catalog_query
-        cls.course_metadata = ContentMetadataFactory(content_type=COURSE, content_key='fakeX')
-        cls.course_metadata.catalog_queries.set([courses_catalog_query])
+        cls.course_metadata_published = ContentMetadataFactory(content_type=COURSE, content_key='fakeX')
+        cls.course_metadata_published.catalog_queries.set([courses_catalog_query])
+        cls.course_metadata_unpublished = ContentMetadataFactory(content_type=COURSE, content_key='testX')
+        cls.course_metadata_unpublished.json_metadata.get('course_runs')[0].update({
+            'status': 'unpublished',
+        })
+        cls.course_metadata_unpublished.catalog_queries.set([courses_catalog_query])
+        cls.course_metadata_unpublished.save()
 
         # Set up new catalog, query, and metadata for a course run
         cls.enterprise_catalog_course_runs = EnterpriseCatalogFactory()
         course_runs_catalog_query = cls.enterprise_catalog_course_runs.catalog_query
-        course_run_metadata = ContentMetadataFactory(content_type=COURSE_RUN, parent_content_key='fakeX')
-        course_run_metadata.catalog_queries.set([course_runs_catalog_query])
+        course_run_metadata_published = ContentMetadataFactory(content_type=COURSE_RUN, parent_content_key='fakeX')
+        course_run_metadata_published.catalog_queries.set([course_runs_catalog_query])
+        course_run_metadata_unpublished = ContentMetadataFactory(content_type=COURSE_RUN, parent_content_key='testX')
+        course_run_metadata_unpublished.json_metadata.update({
+            'status': 'unpublished',
+        })
+        course_run_metadata_unpublished.catalog_queries.set([course_runs_catalog_query])
+        course_run_metadata_unpublished.save()
 
     def _set_up_factory_data_for_algolia(self):
         expected_catalog_uuids = sorted([
@@ -295,7 +308,8 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'catalog_uuids': expected_catalog_uuids,
             'customer_uuids': expected_customer_uuids,
             'query_uuids': expected_catalog_query_uuids,
-            'course_metadata': self.course_metadata,
+            'course_metadata_published': self.course_metadata_published,
+            'course_metadata_unpublished': self.course_metadata_unpublished,
         }
 
     @mock.patch('enterprise_catalog.apps.api.tasks._was_recently_indexed', side_effect=[False, True])
@@ -312,36 +326,43 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             # call it a second time, make assertions that only one thing happened below
             tasks.index_enterprise_catalog_courses_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
-        # create expected Algolia data
-        expected_algolia_objects = []
-        course_uuid = algolia_data['course_metadata'].json_metadata.get('uuid')
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-catalog-uuids-0',
+        # verify `delete_by` is called with the expected options for nonindexable content keys
+        unpublished_content_key = algolia_data['course_metadata_unpublished'].content_key
+        expected_delete_by_filters = {'filters': f'key:"{unpublished_content_key}"'}
+        mock_search_client().delete_by.assert_has_calls([
+            mock.call(expected_delete_by_filters)
+        ])
+
+        # create expected data to be added/updated in the Algolia index.
+        expected_algolia_objects_to_index = []
+        published_course_uuid = algolia_data['course_metadata_published'].json_metadata.get('uuid')
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-uuids-0',
             'enterprise_catalog_uuids': algolia_data['catalog_uuids'],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-customer-uuids-0',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-catalog-query-uuids-0',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-query-uuids-0',
             'enterprise_catalog_query_uuids': algolia_data['query_uuids'],
         })
 
         # verify partially_update_index is called with the correct Algolia object data
         # on the first invocation and with an empty list on the second invocation.
         mock_search_client().partially_update_index.assert_has_calls([
-            mock.call(expected_algolia_objects),
+            mock.call(expected_algolia_objects_to_index),
             mock.call([]),
         ])
 
         # Verify that we checked the cache twice, though
         mock_was_recently_indexed.assert_has_calls([
-            mock.call(self.course_metadata.content_key),
-            mock.call(self.course_metadata.content_key),
+            mock.call(self.course_metadata_published.content_key),
+            mock.call(self.course_metadata_published.content_key),
         ])
 
     @mock.patch('enterprise_catalog.apps.api.tasks._was_recently_indexed', return_value=False)
@@ -357,41 +378,48 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
              mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_FIELDS', self.ALGOLIA_FIELDS):
             tasks.index_enterprise_catalog_courses_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
-        # create expected Algolia data
-        expected_algolia_objects = []
-        course_uuid = algolia_data['course_metadata'].json_metadata.get('uuid')
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-catalog-uuids-0',
+        # verify `delete_by` is called with the expected options for nonindexable content keys
+        unpublished_content_key = algolia_data['course_metadata_unpublished'].content_key
+        expected_delete_by_filters = {'filters': f'key:"{unpublished_content_key}"'}
+        mock_search_client().delete_by.assert_has_calls([
+            mock.call(expected_delete_by_filters)
+        ])
+
+        # create expected data to be added/updated in the Algolia index.
+        expected_algolia_objects_to_index = []
+        published_course_uuid = algolia_data['course_metadata_published'].json_metadata.get('uuid')
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-uuids-0',
             'enterprise_catalog_uuids': [algolia_data['catalog_uuids'][0]],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-catalog-uuids-1',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-uuids-1',
             'enterprise_catalog_uuids': [algolia_data['catalog_uuids'][1]],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-customer-uuids-0',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': [algolia_data['customer_uuids'][0]],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-customer-uuids-1',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-customer-uuids-1',
             'enterprise_customer_uuids': [algolia_data['customer_uuids'][1]],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-catalog-query-uuids-0',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-query-uuids-0',
             'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][0]],
         })
-        expected_algolia_objects.append({
-            'key': algolia_data['course_metadata'].content_key,
-            'objectID': f'course-{course_uuid}-catalog-query-uuids-1',
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-query-uuids-1',
             'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][1]],
         })
 
         # verify partially_update_index is called with the correct Algolia object data
-        mock_search_client().partially_update_index.assert_called_once_with(expected_algolia_objects)
+        mock_search_client().partially_update_index.assert_called_once_with(expected_algolia_objects_to_index)
 
-        mock_was_recently_indexed.assert_called_once_with(self.course_metadata.content_key)
+        mock_was_recently_indexed.assert_called_once_with(self.course_metadata_published.content_key)

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 from enterprise_catalog.apps.api.v1.utils import (
     get_enterprise_utm_context,
-    is_any_course_run_enrollable,
+    is_any_course_run_active,
     update_query_parameters,
 )
 from enterprise_catalog.apps.catalog.constants import (
@@ -151,7 +151,7 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
             )
             if content_type == COURSE:
                 course_runs = json_metadata.get('course_runs', [])
-                json_metadata['active'] = is_any_course_run_enrollable(course_runs)
+                json_metadata['active'] = is_any_course_run_active(course_runs)
                 for course_run in course_runs:
                     course_run['enrollment_url'] = enterprise_catalog.get_content_enrollment_url(
                         content_resource=COURSE,

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -14,6 +14,7 @@ from rest_framework.settings import api_settings
 from six.moves.urllib.parse import quote_plus
 
 from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
+from enterprise_catalog.apps.api.v1.utils import is_any_course_run_active
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     COURSE_RUN,
@@ -623,7 +624,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
                     course_run.update({'enrollment_url': course_run_enrollment_url})
 
             json_metadata['course_runs'] = course_runs
-            json_metadata['active'] = False
+            json_metadata['active'] = is_any_course_run_active(course_runs)
 
         # course run
         if content_type == COURSE_RUN:

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -59,7 +59,26 @@ def get_enterprise_utm_context(enterprise_name):
     return utm_context
 
 
-def is_any_course_run_enrollable(course_runs):
+def is_course_run_active(course_run):
+    """
+    Checks whether a course run is active. That is, whether the course run is published,
+    enrollable, and marketable.
+
+    Arguments:
+        course_run (dict): The metadata about a course run.
+
+    Returns:
+        bool: True if course run is "active"
+    """
+    course_run_status = course_run.get('status') or ''
+    is_published = course_run_status.lower() == 'published'
+    is_enrollable = course_run.get('is_enrollable', False)
+    is_marketable = course_run.get('is_marketable', False)
+
+    return is_published and is_enrollable and is_marketable
+
+
+def is_any_course_run_active(course_runs):
     """
     Iterates over all course runs to check if there any course run that is available for enrollment.
 
@@ -67,9 +86,9 @@ def is_any_course_run_enrollable(course_runs):
         course_runs (list): list of course runs
 
     Returns:
-        bool: True if enrollable course run is found, else False
+        bool: True if active course run is found, else False
     """
     for course_run in course_runs:
-        if course_run.get('is_enrollable'):
+        if is_course_run_active(course_run):
             return True
     return False

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -129,7 +129,7 @@ class AlgoliaSearchClient:
         filters = set()
         for key in content_keys:
             filters.add(f'key:"{key}"')
-        content_keys_filter_query = 'OR '.join(list(filters))
+        content_keys_filter_query = ' OR '.join(list(filters))
 
         try:
             self.algolia_index.delete_by({'filters': content_keys_filter_query})

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -111,9 +111,8 @@ class AlgoliaSearchClient:
 
     def delete_content_keys(self, content_keys):
         """
-        Performs a `delete_by` operation with the filters provided via the `options` kwarg. Note
-        that this call only counts a single Algolia operation (i.e., versus counting each deleted object
-        as an operation).
+        Performs a `delete_by` operation for the specified content keys. Note: this call only counts
+        as a single Algolia operation (i.e., versus counting each deleted object as an operation).
 
         Arguments:
             content_keys (list): List of content_key strings.

--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -42,7 +42,7 @@ class UnchangeableMixin(admin.ModelAdmin):
 
 
 @admin.register(ContentMetadata)
-class ContentMetadataAdmin(UnchangeableMixin):
+class ContentMetadataAdmin(admin.ModelAdmin):
     """ Admin configuration for the custom ContentMetadata model. """
     list_display = (
         'content_key',
@@ -62,7 +62,7 @@ class ContentMetadataAdmin(UnchangeableMixin):
 class CatalogQueryAdmin(UnchangeableMixin):
     """ Admin configuration for the custom CatalogQuery model. """
     list_display = (
-        'id',
+        'uuid',
         'content_filter_hash',
         'get_content_filter',
     )

--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -42,7 +42,7 @@ class UnchangeableMixin(admin.ModelAdmin):
 
 
 @admin.register(ContentMetadata)
-class ContentMetadataAdmin(admin.ModelAdmin):
+class ContentMetadataAdmin(UnchangeableMixin):
     """ Admin configuration for the custom ContentMetadata model. """
     list_display = (
         'content_key',

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -106,7 +106,7 @@ def _should_index_course(course_metadata):
     return not advertised_course_run.get('hidden') and len(owners) > 0
 
 
-def get_indexable_course_keys(courses_content_metadata):
+def partition_course_keys_for_indexing(courses_content_metadata):
     """
     Returns both the indexable and non-indexable course content keys for Algolia.
 

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -76,6 +76,9 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'key': 'course-v1:edX+DemoX',
                 'uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
                 'content_language': 'en-us',
+                'status': 'published',
+                'is_enrollable': True,
+                'is_marketable': True,
             }]
             json_metadata.update({
                 'marketing_url': f'https://marketing.url/{self.content_key}',
@@ -84,6 +87,13 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'advertised_course_run_uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
                 'course_runs': course_runs,
             })
+        elif self.content_type == COURSE_RUN:
+            json_metadata.update({
+                'status': 'published',
+                'is_enrollable': True,
+                'is_marketable': True,
+            })
+
         return json_metadata
 
 

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -354,9 +354,9 @@ ENTERPRISE_LEARNER_PORTAL_BASE_URL = os.environ.get('ENTERPRISE_LEARNER_PORTAL_B
 
 # Algolia
 ALGOLIA = {
-    'INDEX_NAME': '',
-    'APPLICATION_ID': '',
-    'API_KEY': '',
+    'INDEX_NAME': 'enterprise_catalog_astankiewicz',
+    'APPLICATION_ID': 'testing2MLYZ9WWU0',
+    'API_KEY': '85cb5d95d235fe5a3120d1c6a3e21766',
 }
 
 # Set up system-to-feature roles mapping for edx-rbac

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -354,9 +354,9 @@ ENTERPRISE_LEARNER_PORTAL_BASE_URL = os.environ.get('ENTERPRISE_LEARNER_PORTAL_B
 
 # Algolia
 ALGOLIA = {
-    'INDEX_NAME': 'enterprise_catalog_astankiewicz',
-    'APPLICATION_ID': 'testing2MLYZ9WWU0',
-    'API_KEY': '85cb5d95d235fe5a3120d1c6a3e21766',
+    'INDEX_NAME': '',
+    'APPLICATION_ID': '',
+    'API_KEY': '',
 }
 
 # Set up system-to-feature roles mapping for edx-rbac


### PR DESCRIPTION
## Description

While QA'ing the new language facet, it was observed that when a course is no longer published, enrollable, or marketable, it still remains in the Algolia index and, as a result, appears in the Learner Portal search results resulting in a poor experience where a learner can't actually enroll in the course.

This PR ensures we're only adding/updating records for courses that _should_ be in the index, and deleting any records for courses that should _not_ be in the index anymore (e.g., it's no longer published or enrollable).

## Post-review

Squash commits into discrete sets of changes
