### PR TITLE
fix: refactor Algolia indexing to use ``replace_all_objects``

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -326,12 +326,6 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             # call it a second time, make assertions that only one thing happened below
             tasks.index_enterprise_catalog_courses_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
-        # verify `delete_by` is called with the expected options for nonindexable content keys
-        unpublished_content_key = algolia_data['course_metadata_unpublished'].content_key
-        mock_search_client().delete_content_keys.assert_has_calls([
-            mock.call([unpublished_content_key])
-        ])
-
         # create expected data to be added/updated in the Algolia index.
         expected_algolia_objects_to_index = []
         published_course_uuid = algolia_data['course_metadata_published'].json_metadata.get('uuid')
@@ -351,9 +345,9 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'enterprise_catalog_query_uuids': algolia_data['query_uuids'],
         })
 
-        # verify partially_update_index is called with the correct Algolia object data
+        # verify replace_all_objects is called with the correct Algolia object data
         # on the first invocation and with an empty list on the second invocation.
-        mock_search_client().partially_update_index.assert_has_calls([
+        mock_search_client().replace_all_objects.assert_has_calls([
             mock.call(expected_algolia_objects_to_index),
             mock.call([]),
         ])
@@ -376,12 +370,6 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         with mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_UUID_BATCH_SIZE', 1), \
              mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_FIELDS', self.ALGOLIA_FIELDS):
             tasks.index_enterprise_catalog_courses_in_algolia_task()  # pylint: disable=no-value-for-parameter
-
-        # verify `delete_by` is called with the expected options for nonindexable content keys
-        unpublished_content_key = algolia_data['course_metadata_unpublished'].content_key
-        mock_search_client().delete_content_keys.assert_has_calls([
-            mock.call([unpublished_content_key])
-        ])
 
         # create expected data to be added/updated in the Algolia index.
         expected_algolia_objects_to_index = []
@@ -417,7 +405,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][1]],
         })
 
-        # verify partially_update_index is called with the correct Algolia object data
-        mock_search_client().partially_update_index.assert_called_once_with(expected_algolia_objects_to_index)
+        # verify replace_all_objects is called with the correct Algolia object data
+        mock_search_client().replace_all_objects.assert_called_once_with(expected_algolia_objects_to_index)
 
         mock_was_recently_indexed.assert_called_once_with(self.course_metadata_published.content_key)


### PR DESCRIPTION
## Description

This PR is a (final) continuation of the Algolia indexing refactoring to ensure we don't have things in our Algolia index that shouldn't be there, as some search filters (e.g., content language) are exposing courses that are no longer in the catalog.

Previously, we were using `partial_update_objects` but it seems this will only create/update records with an exact match of an `objectId`. Due to how we batch the list of customer/catalog/catalog query UUIDs for each course (dynamic lists), there's no guarantee the `objectIds` will remain the same between indexing. As a result, we are leaving courses in the index that should no longer be there.

Instead, this refactor switches to use [`replace_all_objects`](https://www.algolia.com/doc/api-reference/api-methods/replace-all-objects/) which will create a temporary index with the exact objects we'd like in the index, and then, move all the objects from the temporary index into the actual index in an atomic reindex (aka no downtime).

When a course is no longer published or enrollable, we no longer have to explicitly delete content keys because we are essentially creating a brand new (temporary) index and replacing the existing one with the newly created one.

This should have a similar number of Algolia operations as we had with `partial_update_objects`.

## Post-review

Squash commits into discrete sets of changes
