### PR TITLE
fix: index all ContentMetadata records of type course

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -308,8 +308,7 @@ def index_enterprise_catalog_courses_in_algolia_task(self):
             exc=RequiredTaskUnreadyError(),
         )
 
-    recently_modified_records = ContentMetadata.recently_modified_records(ONE_HOUR * 2)
-    courses_content_metadata = recently_modified_records.filter(content_type=COURSE)
+    courses_content_metadata = ContentMetadata.objects.filter(content_type=COURSE)
     indexable_content_keys, nonindexable_content_keys = partition_course_keys_for_indexing(courses_content_metadata)
     _reindex_algolia(
         indexable_content_keys=indexable_content_keys,


### PR DESCRIPTION
## Description

Since we are now clearing out the Algolia index and replacing it with fresh records each time `reindex_algolia` is run, we should no longer filter ContentMetadata records by when they were modified as we could easily end up in a situation where we accidentally index 0 courses, and break the search results for all customers.

Instead of indexing only the recently modified `ContentMetadata` course objects, this PR switches to index all `ContentMetadata` course objects, regardless of when it was last modified. This will ensure we always have all courses indexed each run of the job.

## Post-review

Squash commits into discrete sets of changes
