### PR TITLE
feat: Include the titles of programs as an Algolia field

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -25,6 +25,7 @@ ALGOLIA_FIELDS = [
     'objectID',  # required by Algolia, e.g. "course-{uuid}"
     'partners',
     'programs',
+    'program_titles',
     'recent_enrollment_count',
     'short_description',
     'subjects',
@@ -232,6 +233,23 @@ def get_course_partners(course):
     return partners
 
 
+def _get_course_program_field(course, field):
+    """
+    Helper to pluck a list of values for the given field out of a course's programs.
+
+    Arguments:
+        course (dict): a dictionary representing a course
+        field (str): the name of a field to return values of.
+    Returns:
+        list: a list of the values for a certain field in a program associated with the course.
+    """
+    programs = course.get('programs') or []
+    return list({
+        value for program in programs
+        if (value := program.get(field))
+    })
+
+
 def get_course_program_types(course):
     """
     Gets list of program types associated with the course. Used for the "Programs"
@@ -243,15 +261,21 @@ def get_course_program_types(course):
     Returns:
         list: a list of program types associated with the course
     """
-    program_types = set()
-    programs = course.get('programs') or []
+    return _get_course_program_field(course, 'type')
 
-    for program in programs:
-        program_type = program.get('type')
-        if program_type:
-            program_types.add(program_type)
 
-    return list(program_types)
+def get_course_program_titles(course):
+    """
+    Gets list of program titles associated with the course. Used for the "Program titles"
+    facet in Algolia.
+
+    Arguments:
+        course (dict): a dictionary representing a course.
+
+    Returns:
+        list: a list of program titles associated with the course.
+    """
+    return _get_course_program_field(course, 'title')
 
 
 def get_course_subjects(course):
@@ -369,6 +393,7 @@ def _algolia_object_from_course(course, algolia_fields):
         'availability': get_course_availability(searchable_course),
         'partners': get_course_partners(searchable_course),
         'programs': get_course_program_types(searchable_course),
+        'program_titles': get_course_program_titles(searchable_course),
         'subjects': get_course_subjects(searchable_course),
         'card_image_url': get_course_card_image_url(searchable_course),
         'advertised_course_run': get_advertised_course_run(searchable_course),

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -13,6 +13,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_course_card_image_url,
     get_course_language,
     get_course_partners,
+    get_course_program_titles,
     get_course_program_types,
     get_course_skill_names,
     get_course_subjects,
@@ -303,14 +304,44 @@ class AlgoliaUtilsTests(TestCase):
             {'programs': [{'type': 'Professional Certificate'}]},
             ['Professional Certificate'],
         ),
+        (
+            {'programs': [{'title': 'Synchronicity'}]},
+            [],
+        ),
+        (
+            {'programs': [{'type': '', 'title': 'Yes'}]},
+            [],
+        ),
     )
     @ddt.unpack
     def test_get_course_program_types(self, course_metadata, expected_program_types):
         """
-        Assert that the list of programs associated with a course is properly parsed and formatted.
+        Assert that the list of program types associated with a course is properly parsed and formatted.
         """
         program_types = get_course_program_types(course_metadata)
         assert program_types == expected_program_types
+
+    @ddt.data(
+        (
+            {'programs': [{'type': 'Masters', 'title': 'Reverse Psychology'}]},
+            ['Reverse Psychology'],
+        ),
+        (
+            {'programs': [{'type': 'Professional Certificate'}]},
+            [],
+        ),
+        (
+            {'programs': [{'type': 'Professional Certificate', 'title': ''}]},
+            [],
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_program_titles(self, course_metadata, expected_program_titles):
+        """
+        Assert that the list of program titles associated with a course is properly parsed and formatted.
+        """
+        program_titles = get_course_program_titles(course_metadata)
+        assert program_titles == expected_program_titles
 
     @ddt.data(
         (


### PR DESCRIPTION
...so that we can facet searches by the title of a program (rather than the type of a program).

## Description

This is the work to provide program titles as a facet-able field to Algolia.

## Ticket Link

Link to the associated ticket
[ENT-4365](https://openedx.atlassian.net/browse/ENT-4365)

## Post-review

Squash commits into discrete sets of changes
