### PR TITLE
feat: Handle and update catalog query UUID

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_serializers.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_serializers.py
@@ -1,0 +1,92 @@
+from uuid import uuid4
+
+from django.db import transaction
+from django.test import TestCase
+from rest_framework import serializers
+
+from enterprise_catalog.apps.api.v1.serializers import (
+    find_and_modify_catalog_query,
+)
+from enterprise_catalog.apps.catalog.models import CatalogQuery
+from enterprise_catalog.apps.catalog.utils import get_content_filter_hash
+
+
+class FindCatalogQueryTest(TestCase):
+    """
+    Tests for API utils
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.old_uuid = uuid4()
+        self.old_filter = {'key': ['arglblargl']}
+        self.old_catalog_query = CatalogQuery.objects.create(
+            content_filter=self.old_filter,
+            content_filter_hash=get_content_filter_hash(self.old_filter),
+            uuid=self.old_uuid
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        # clean up any stale test objects
+        CatalogQuery.objects.all().delete()
+
+    def test_new_uuid_old_filter_saves_query_with_new_uuid(self):
+        old_filter = {'key': ['course:testing']}
+        CatalogQuery.objects.create(
+            content_filter=old_filter,
+            content_filter_hash=get_content_filter_hash(old_filter)
+        )
+        new_uuid = uuid4()
+        result = find_and_modify_catalog_query(old_filter, new_uuid)
+        self.assertEqual((result.content_filter, result.uuid), (old_filter, new_uuid))
+
+    def test_new_uuid_new_filter_creates_new_query(self):
+        new_uuid = uuid4()
+        new_filter = {'key': ['course:testingnnnnnn']}
+        result = find_and_modify_catalog_query(new_filter, new_uuid)
+        self.assertEqual((result.content_filter, result.uuid), (new_filter, new_uuid))
+
+    def test_old_uuid_new_filter_saves_query_with_new_filter(self):
+        old_uuid = uuid4()
+        old_filter = {'key': ['plpplplpl']}
+        new_filter = {'key': ['roger']}
+        CatalogQuery.objects.create(
+            content_filter=old_filter,
+            content_filter_hash=get_content_filter_hash(old_filter),
+            uuid=old_uuid
+        )
+        result = find_and_modify_catalog_query(new_filter, old_uuid)
+        self.assertEqual((result.content_filter, result.uuid), (new_filter, old_uuid))
+
+    def test_old_uuid_old_filter_changes_nothing(self):
+        result = find_and_modify_catalog_query(self.old_filter, self.old_uuid)
+        self.assertEqual(result, self.old_catalog_query)
+
+    def test_no_uuid_old_filter_changes_nothing(self):
+        result = find_and_modify_catalog_query(self.old_filter)
+        self.assertEqual(result, self.old_catalog_query)
+
+    def test_no_uuid_new_filter_creates_new_query(self):
+        new_filter = {'key': ['mmmmmmmm']}
+        result = find_and_modify_catalog_query(new_filter)
+        self.assertEqual(result.content_filter, new_filter)
+
+    def test_validation_error_raised_on_duplication(self):
+        dupe_filter = {'key': ['summerxbreeze']}
+        uuid_to_update = uuid4()
+        CatalogQuery.objects.create(
+            content_filter=dupe_filter,
+            uuid=uuid4()
+        )
+        CatalogQuery.objects.create(
+            content_filter={'key': ['tempfilter']},
+            uuid=uuid_to_update
+        )
+        with transaction.atomic():
+            self.assertRaises(
+                serializers.ValidationError,
+                find_and_modify_catalog_query,
+                dupe_filter,
+                uuid_to_update
+            )

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -89,6 +89,13 @@ class CatalogQuery(TimeStampedModel):
         """
         return json.dumps(self.content_filter, indent=4)
 
+    @classmethod
+    def get_by_uuid(cls, uuid):
+        try:
+            return cls.objects.get(uuid=uuid)
+        except cls.DoesNotExist:
+            return None
+
     def __str__(self):
         """
         Return human-readable string representation.


### PR DESCRIPTION
## Description

Adds/modifies handling of query and content filter creates and updates from query parameters coming from LMS.

## Ticket Link

[Query Syncing from LMS to Enterprise Catalog](https://openedx.atlassian.net/browse/ENT-4429)

## Testing Scenarios:
The following were tested manually (and most later tested via code tests):
- new UUID; old filter > should update old filter with that UUID
- new UUID; new filter > should create a new query
- old UUID; new filter > should update existing query found by UUID with new filter
- old UUID; duplicated filter - should throw IntegrityError
- old UUID; old filter (aka no changes) - should return existing query
- no UUID, new filter > should create a new query
- no UUID, old filter > should return existing query
- no UUID, no filter > should return existing query on update catalog call

## Post-review

Squash commits into discrete sets of changes
