### PR TITLE
fix: add batch_size kwarg to bulk_update to prevent timeout

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -492,7 +492,7 @@ def _update_existing_content_metadata(existing_metadata_defaults, existing_metad
             metadata_list.append(content_metadata)
 
     metadata_fields_to_update = ['content_key', 'parent_content_key', 'content_type', 'json_metadata']
-    ContentMetadata.objects.bulk_update(metadata_list, metadata_fields_to_update)
+    ContentMetadata.objects.bulk_update(metadata_list, metadata_fields_to_update, batch_size=10)
     return metadata_list
 
 


### PR DESCRIPTION
## Description

Due to this error (`django.db.utils.OperationalError: (2006, 'MySQL server has gone away')`), I'm adding the `batch_size` kwarg to the new `ContentMetadata.objects.bulk_update()` call to prevent timeout. Currently, it is trying to update ~100 ContentMetadata objects at once, including the `json_metadata` field which can contain a large blob of JSON.

Without batching the `bulk_update`, it is likely the MySQL operation is timing out and/or running out of memory. By batching the `bulk_update`, it should be able to reasonably update 10 `ContentMetadata` objects at once.

## Ticket Link

https://openedx.atlassian.net/browse/ENT-4208

## Post-review

Squash commits into discrete sets of changes
