### PR TITLE
adds mgmt command argument and post data to force execute tasks using expiring_task_semaphore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ dev.destroy: dev.down # Kills containers and destroys volumes. If you get an err
 dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
 
+mysql-client:  # Opens mysql client in the mysql container shell
+	docker-compose exec -u 0 mysql env TERM=$(TERM) mysql enterprise_catalog
+
 %-shell: ## Run a shell, as root, on the specified service container
 	docker-compose exec -u 0 $* env TERM=$(TERM) bash
 

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1,6 +1,7 @@
 """
 Tests for the enterprise_catalog API celery tasks
 """
+import json
 import uuid
 from datetime import timedelta
 from unittest import mock
@@ -58,8 +59,8 @@ class TestTaskResultFunctions(TestCase):
 
         self.mock_task_result = TaskResult.objects.create(
             task_name=mock_task.name,
-            task_args=str(self.test_args),
-            task_kwargs=str(self.test_kwargs),
+            task_args=json.dumps(self.test_args),
+            task_kwargs=json.dumps(self.test_kwargs),
             status=states.SUCCESS,
             # Default to a state where the only recorded task result is for some "other" task
             task_id=self.other_task_id,
@@ -79,14 +80,14 @@ class TestTaskResultFunctions(TestCase):
         return mock_task(bound_task_object, *args, **kwargs)
 
     def test_semaphore_raises_recent_run_error_for_same_args(self):
-        self.mock_task_result.task_kwargs = str({})
+        self.mock_task_result.task_kwargs = '{}'
         self.mock_task_result.save()
 
         with self.assertRaises(tasks.TaskRecentlyRunError):
             self.mock_task_instance(*self.test_args)
 
     def test_semaphore_raises_recent_run_error_for_same_kwargs(self):
-        self.mock_task_result.task_args = str(tuple())
+        self.mock_task_result.task_args = '[]'
         self.mock_task_result.save()
 
         with self.assertRaises(tasks.TaskRecentlyRunError):

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -15,16 +15,24 @@ class Command(BaseCommand):
         'Reindex course data in Algolia, adding on enterprise-specific metadata'
     )
 
+    def add_arguments(self, parser):
+        # Argument to force execution of celery task, ignoring time since last execution
+        parser.add_argument(
+            '--force',
+            default=False,
+            action='store_true',
+        )
+
     def handle(self, *args, **options):
         """
         Runs a celery task to reindex algolia.  Blocks until celery task returns.
         """
         try:
-            result = index_enterprise_catalog_courses_in_algolia_task.apply_async().get()
-            message = (
+            force_task_execution = options.get('force', False)
+            index_enterprise_catalog_courses_in_algolia_task.apply_async(kwargs={'force': force_task_execution}).get()
+            logger.info(
                 'index_enterprise_catalog_courses_in_algolia_task from command reindex_algolia finished successfully.'
             )
-            logger.info(message)
         except Exception as exc:
             # celery weirdly hijacks and prefixes the path of the below Exception
             # with `celery.backends.base` when it's raised.

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -43,10 +43,10 @@ class UpdateContentMetadataCommandTests(TestCase):
         call_command(self.command_name)
 
         mock_group.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_a),
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_b),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with()
+        mock_full_metadata_task.si.assert_called_once_with(force=False)
 
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.group')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
@@ -62,7 +62,7 @@ class UpdateContentMetadataCommandTests(TestCase):
         call_command(self.command_name)
 
         mock_group.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_a),
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_b),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with()
+        mock_full_metadata_task.si.assert_called_once_with(force=False)

--- a/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
@@ -16,9 +16,18 @@ class Command(BaseCommand):
         'Add full course metadata to ContentMetadata records',
     )
 
+    def add_arguments(self, parser):
+        # Argument to force execution of celery task, ignoring time since last execution
+        parser.add_argument(
+            '--force',
+            default=False,
+            action='store_true',
+        )
+
     def handle(self, *args, **options):
         try:
-            result = update_full_content_metadata_task.apply_async().get()
+            force_task_execution = options.get('force', False)
+            result = update_full_content_metadata_task.apply_async(kwargs={'force': force_task_execution}).get()
             message = (
                 'update_full_content_metadata task from update_full_content_metadata command finished'
                 ' successfully with result %s'


### PR DESCRIPTION
## Description

Allows for our three management commands to be `force` run.  Useful in situations where you want to run the same `task(input)` more than once in a given hour.  Beneficial locally; will become useful in other environments in a later PR that introduces `ConfigurationModels` for these commands.

## Ticket Link

Link to the associated ticket
[4206](https://openedx.atlassian.net/browse/ENT-4206)

## Testing Instructions

Use the `make app-shell` bash shell to trigger the commands and observe any relevant output in the app-logs and worker-logs. e.g.
```
make app-shell
./manage.py update_content_metadata
./manage.py update_content_metadata # second invocation should fail because of task-locking
./manage.py update_content_metadata --force # see that this succeeds
```