### PR TITLE
Make fewer memcached gets during get_content_metadata action requests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     container_name: enterprise.catalog.memcached
     networks:
       - devstack_default
+    command: memcached -vv
 
   app:
     # Uncomment this line to use the official catalog base image

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -72,3 +72,10 @@ CORS_ORIGIN_WHITELIST = [
     'http://localhost:18000',
     'http://localhost:18130',
 ]
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': 'enterprise.catalog.memcached:11211',
+    }
+}


### PR DESCRIPTION
## Description

Hypothesis: The serialization of content metadata adds a content enrollment URL to the metadata instance - the function that determines the content enrollment URL uses an `EnterpriseCustomerDetails` instance that fetches a dictionary of customer data from memcached on each read, and there are many reads of this data (hundreds per request, somehow?).

Solution: Add a cached_property to hold this `EnterpriseCustomerDetails` instance in memory for the life of the associated `EnterpriseCatalog` instance, which should cause us to only read this data from memcached once, at the start of the request.
## Ticket Link

[The ticket](https://openedx.atlassian.net/browse/ENT-4742)

## Post-review

Squash commits into discrete sets of changes
