### PR TITLE
fix: add the setting that indicates the name of the JWT auth cookie.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,8 @@ services:
       - .:/edx/app/enterprise_catalog/enterprise_catalog
       - ../src:/edx/src:cached
 
-    # This should be the same as the `CMD` in the legacy devapp build stage
-    # of the Dockerfile
-    command: bash -c 'gunicorn --reload --workers=2 --name enterprise_catalog -b :18160 -c /edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_catalog.wsgi:application'
+    # Use the Django devserver, so that we can hot-reload code changes
+    command: bash -c 'while true; do python /edx/app/enterprise_catalog/enterprise_catalog/manage.py runserver 0.0.0.0:18160; sleep 2; done'
     ports:
       - "18160:18160"
     depends_on:

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -233,6 +233,7 @@ JWT_AUTH = {
     'JWT_LEEWAY': 1,
     'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
+    'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
     'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',


### PR DESCRIPTION
## Description

This sets `USE_JWT_COOKIE` to true in the `JWT_AUTH` config for this service.  Without this key/value, JWT-based auth was effectively not used at all in the service; instead, all authentication fell back to either Session authentication (in the case of requests from a browser) or OAuth authentication (in the case of serivce-to-service requests).

### Impacts

The fact that this was previously missing accounts for why there were so few `core.User` records in the enterprise-catalog production database - Session authentication does not create user records upon successful authentication.  (Note: records are only written to the `django_session` table when data in the session has changed, which is rare in the case of enterprise-catalog: [Django-when are sessions saved?)](https://docs.djangoproject.com/en/3.2/topics/http/sessions/#when-sessions-are-saved)

How did this cause the bug below?
* One of the symptoms of the bug was that the error went away in a new browser - which likely meant that the user had to re-login in a new browser, perhaps they had a stale session cookie in the first browser they tried.

How does this fix the bug below?
* As long as the SSO flow populates a JWT cookie for the SSO'd user, this change ensures that enterprise-catalog will look for a JWT Authentication token in the cookie named `edx-jwt-cookie` and use that token to authenticate.  As long as the JWT is valid, the authentication will be successful.  Prior to this change, the drf-jwt library (upon which edx-drf-extensions/auth/jwt depends) had no way of knowing _which_ cookie to look for an auth token in.

## Ticket Link

[Learners get Axios Error when they click on a Course Tile in the Learner Portal after logging in via SSO](https://openedx.atlassian.net/browse/ENT-4885)

## Post-review

Squash commits into discrete sets of changes
