### PR TITLE
bug: accounting for the  availabilty when indexing algolia

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -203,6 +203,7 @@ def get_course_availability(course):
     COURSE_AVAILABILITY_MESSAGES = {
         'current': 'Available Now',
         'upcoming': 'Upcoming',
+        'starting soon': 'Starting Soon',
     }
     course_runs = course.get('course_runs') or []
     active_course_runs = [run for run in course_runs if is_course_run_active(run)]

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -290,6 +290,27 @@ class AlgoliaUtilsTests(TestCase):
             },
             ['Archived'],
         ),
+        (
+            {
+                'course_runs': [{
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'availability': 'Starting Soon'
+                }]
+            },
+            ['Starting Soon'],
+        ),
+        (
+            {
+                'course_runs': [{
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                }]
+            },
+            ['Archived'],
+        ),
     )
     @ddt.unpack
     def test_get_course_availability(self, course_metadata, expected_availability):


### PR DESCRIPTION
## Description

[Jira](https://openedx.atlassian.net/browse/ENT-4890)

courses were being indexed as archived when they had a course run switch to a `starting soon` availability because when retrieving, the state after `upcoming` (ie starting soon) wasn't being accounted for. 

Also added a unit test for when no availability is present

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
