### PR TITLE
fix: ENT-4865 - Removed curricula from Algolia index for program objects

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -410,7 +410,7 @@ def _batched_metadata_with_queries(json_metadata, sorted_queries):
 @expiring_task_semaphore()
 def index_enterprise_catalog_in_algolia_task(self, force=False):  # pylint: disable=unused-argument
     """
-    Index course data in Algolia with enterprise-related fields.
+    Index course and program data in Algolia with enterprise-related fields.
 
     Note: It is especially important that this task uses the increased maximum ``CELERY_TASK_SOFT_TIME_LIMIT`` and
     ``CELERY_TASK_TIME_LIMIT`` as it makes somewhat time-intensive reads/writes to the database along with sending

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -20,7 +20,6 @@ ALGOLIA_FIELDS = [
     'card_image_url',  # for display on course cards
     'content_type',
     'courses',
-    'curricula',
     'degree',
     'enterprise_catalog_uuids',
     'enterprise_catalog_query_uuids',


### PR DESCRIPTION
## Description

This PR removes the "curricula" field from the Algolia index for Program type objects. This field was added as part of https://github.com/edx/enterprise-catalog/pull/320 and increases the size of the Algolia objects beyond the permissible limit.

## Ticket Link

Link to the associated ticket
[ENT-4865](https://openedx.atlassian.net/browse/ENT-4865)


