### PR TITLE
chore: upgrade django-dynamic-fixture version

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -176,7 +176,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
 django-extensions==3.1.3
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -132,7 +132,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
 django-extensions==3.1.3
     # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -123,7 +123,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/test.in
 django-extensions==3.1.3
     # via -r requirements/base.txt


### PR DESCRIPTION
## Description

New version of django-dynamic-fixture was introduced to support Django3.2


## Ticket Link

Link to the associated ticket
[Update or replace django-dynamic-fixture](https://github.com/edx/upgrades/issues/26)

