### PR TITLE
feat: adding algolia field and associated tests

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -501,6 +501,12 @@ def get_advertised_course_run(course):
         'start': full_course_run.get('start'),
         'end': full_course_run.get('end'),
     }
+    # only include upgrade deadline if there is a verified seat present in the course runs
+    upgrade_deadline = _get_verified_upgrade_deadline(full_course_run)
+    if upgrade_deadline is not None:
+        course_run['upgrade_deadline'] = upgrade_deadline
+    if full_course_run.get('enrollment_end') is not None:
+        course_run['enrollment_end'] = full_course_run.get('enrollment_end')
     return course_run
 
 
@@ -520,6 +526,24 @@ def _get_course_run_by_uuid(course, course_run_uuid):
     except IndexError:
         return None
     return course_run
+
+
+def _get_verified_upgrade_deadline(full_course_run):
+    """
+    Check to see if course has a verified seat option, and if so, return the verified upgrade deadline
+
+    Arguments:
+        full_course_run (dict): a course_run or None
+
+    Returns:
+        str: VUD or None
+    """
+
+    if "seats" in full_course_run:
+        for seat in full_course_run.get("seats"):
+            if seat.get('type') == 'verified':
+                return seat.get('upgrade_deadline')
+    return None
 
 
 def get_course_first_paid_enrollable_seat_price(course):

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -539,10 +539,10 @@ def _get_verified_upgrade_deadline(full_course_run):
         str: VUD or None
     """
 
-    if "seats" in full_course_run:
-        for seat in full_course_run.get("seats"):
-            if seat.get('type') == 'verified':
-                return seat.get('upgrade_deadline')
+    seats = full_course_run.get('seats') or []
+    for seat in seats:
+        if seat.get('type') == 'verified':
+            return seat.get('upgrade_deadline')
     return None
 
 

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -247,6 +247,55 @@ class AlgoliaUtilsTests(TestCase):
             },
             None,
         ),
+        (
+            {
+                'course_runs': [{
+                    'key': 'course-v1:org+course+1T2021',
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z',
+                    'availability': 'Current',
+                    'enrollment_end': '2021-09-30T23:59:00Z',
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                'key': 'course-v1:org+course+1T2021',
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
+                'enrollment_end': '2021-09-30T23:59:00Z',
+            }
+        ),
+        (
+            {
+                'course_runs': [{
+                    'key': 'course-v1:org+course+1T2021',
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z',
+                    'seats': [{
+                            'type':'audit',
+                            'upgrade_deadline':None,
+                        },
+                        {
+                            'type':'verified',
+                            'upgrade_deadline':'2015-01-04T15:52:00Z',
+                        }
+                    ],
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                'key': 'course-v1:org+course+1T2021',
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
+                'upgrade_deadline': '2015-01-04T15:52:00Z',
+            }
+        )
     )
     @ddt.unpack
     def test_get_advertised_course_run(self, searchable_course, expected_course_run):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -279,8 +279,7 @@ class AlgoliaUtilsTests(TestCase):
                     'seats': [{
                         'type': 'audit',
                         'upgrade_deadline': None,
-                    },
-                        {
+                    }, {
                         'type': 'verified',
                         'upgrade_deadline': '2015-01-04T15:52:00Z',
                     }],

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -277,14 +277,13 @@ class AlgoliaUtilsTests(TestCase):
                     'start': '2013-10-16T14:00:00Z',
                     'end': '2014-10-16T14:00:00Z',
                     'seats': [{
-                            'type':'audit',
-                            'upgrade_deadline':None,
-                        },
+                        'type': 'audit',
+                        'upgrade_deadline': None,
+                    },
                         {
-                            'type':'verified',
-                            'upgrade_deadline':'2015-01-04T15:52:00Z',
-                        }
-                    ],
+                        'type': 'verified',
+                        'upgrade_deadline': '2015-01-04T15:52:00Z',
+                    }],
                 }],
                 'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
             },

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,3 +14,4 @@ gunicorn                  # For running the application locally
 #transifex-client         # For managing translations
 inflect
 ddt
+python-memcached

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -522,6 +522,8 @@ python-dateutil==2.8.2
     #   faker
 python-dotenv==0.19.0
     # via docker-compose
+python-memcached==1.59
+    # via -r requirements/dev.in
 python-slugify==5.0.2
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
## Description

Addition of `enrollment_end` and verified track `upgrade_deadline` variables to algolia in order to filter courses whose deadlines have passed. Also includes a tiny bug fix for local testing so you don't have to manually install a directory. 

## Ticket Link

Link to the associated ticket
[ENT-4986](https://openedx.atlassian.net/browse/ENT-4986)

## Post-review

Squash commits into discrete sets of changes
