### PR TITLE
chore: updating Makefile/running make upgrade to be like license-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ upgrade: piptools $(COMMON_CONSTRAINTS_TXT) ## update the requirements/*.txt fil
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	sed 's/edx-drf-extensions<7.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/drf-jwt<1.19.1//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	# Make sure to compile files after any other files they include!
 	sed 's/Django<2.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -8,6 +8,16 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 
 # This is a temporary solution to override the real common_constraints.txt
 # In edx-lint, until the pyjwt constraint in edx-lint has been removed.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -258,7 +258,7 @@ edx-drf-extensions==8.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-i18n-tools==0.7.0
+edx-i18n-tools==0.8.1
     # via -r requirements/dev.in
 edx-lint==5.2.0
     # via
@@ -283,7 +283,7 @@ edx-toggles==4.2.0
     #   -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.16.0
+faker==9.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -602,13 +602,13 @@ six==1.16.0
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
-    #   edx-i18n-tools
     #   edx-lint
     #   edx-rbac
     #   jsonschema
     #   pyjwkest
     #   pynacl
     #   python-dateutil
+    #   python-memcached
     #   social-auth-app-django
     #   tox
     #   virtualenv

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -210,7 +210,7 @@ edx-toggles==4.2.0
     # via -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.16.0
+faker==9.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -190,7 +190,7 @@ edx-toggles==4.2.0
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.16.0
+faker==9.0.0
     # via factory-boy
 filelock==3.3.0
     # via


### PR DESCRIPTION
## Description

Cleaning up Makefile to look like License Manager's (and then running `make upgrade`)

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
