### PR TITLE
fix: include important titles in all algolia shards

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -54,6 +54,7 @@ UNREADY_TASK_RETRY_COUNTDOWN_SECONDS = 60 * 5
 # ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
 IMPORTANT_CATALOG_TITLES = ['A la carte', 'Business', 'Education']
 
+
 def _fetch_courses_by_keys(course_keys):
     """
     Fetches course data from discovery's /api/v1/courses endpoint for the provided course keys.

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -51,7 +51,7 @@ ONE_HOUR = timedelta(hours=1)
 
 UNREADY_TASK_RETRY_COUNTDOWN_SECONDS = 60 * 5
 
-# ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
+# ENT-4980 every batch "shard" record in Algolia should have all of these that pertain to the course
 EXPLORE_CATALOG_TITLES = ['A la carte', 'Business', 'Education']
 
 
@@ -398,7 +398,7 @@ def _batched_metadata_with_queries(json_metadata, sorted_queries):
     them together.
     """
 
-    # ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
+    # ENT-4980 every batch "shard" record in Algolia should have all of these that pertain to the course
     course_catalog_query_titles = list(map(lambda x: x[1], sorted_queries))
     explore_catalog_membership = list(filter(lambda y: y in EXPLORE_CATALOG_TITLES, course_catalog_query_titles))
     batched_metadata = []

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -399,7 +399,8 @@ def _batched_metadata_with_queries(json_metadata, sorted_queries):
     """
 
     # ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
-    important_catalog_membership = list(filter(lambda y: y in IMPORTANT_CATALOG_TITLES, map(lambda x: x[1], sorted_queries)))
+    course_catalog_query_titles = list(map(lambda x: x[1], sorted_queries))
+    important_catalog_membership = list(filter(lambda y: y in IMPORTANT_CATALOG_TITLES, course_catalog_query_titles))
     batched_metadata = []
     for batch_index, query_batch in enumerate(batch(sorted_queries, batch_size=ALGOLIA_UUID_BATCH_SIZE)):
         json_metadata_with_uuids = copy.deepcopy(json_metadata)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -51,6 +51,8 @@ ONE_HOUR = timedelta(hours=1)
 
 UNREADY_TASK_RETRY_COUNTDOWN_SECONDS = 60 * 5
 
+# ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
+IMPORTANT_CATALOG_TITLES = ['A la carte', 'Business', 'Education']
 
 def _fetch_courses_by_keys(course_keys):
     """
@@ -394,16 +396,20 @@ def _batched_metadata_with_queries(json_metadata, sorted_queries):
     Batched catalog queries are represented as tuples (<query uuid>, <query title>). Unzip the two fields and update
     them together.
     """
+
+    # ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
+    important_catalog_membership = list(filter(lambda y: y in IMPORTANT_CATALOG_TITLES, map(lambda x: x[1], sorted_queries)))
     batched_metadata = []
     for batch_index, query_batch in enumerate(batch(sorted_queries, batch_size=ALGOLIA_UUID_BATCH_SIZE)):
         json_metadata_with_uuids = copy.deepcopy(json_metadata)
 
         query_uuids, query_titles = list(map(list, zip(*query_batch)))
+        # filter out `None` from `query_titles`, join with important titles, dedupe (set), sort
+        batch_titles = sorted(set([title for title in query_titles if title] + important_catalog_membership))
         metadata_to_update = {
             'objectID': f"{json_metadata['objectID']}-catalog-query-uuids-{batch_index}",
             'enterprise_catalog_query_uuids': sorted(query_uuids),
-            # filter out `None` from `query_titles`
-            'enterprise_catalog_query_titles': sorted([title for title in query_titles if title]),
+            'enterprise_catalog_query_titles': batch_titles,
         }
         json_metadata_with_uuids.update(metadata_to_update)
         batched_metadata.append(json_metadata_with_uuids)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -52,7 +52,7 @@ ONE_HOUR = timedelta(hours=1)
 UNREADY_TASK_RETRY_COUNTDOWN_SECONDS = 60 * 5
 
 # ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
-IMPORTANT_CATALOG_TITLES = ['A la carte', 'Business', 'Education']
+EXPLORE_CATALOG_TITLES = ['A la carte', 'Business', 'Education']
 
 
 def _fetch_courses_by_keys(course_keys):
@@ -400,14 +400,14 @@ def _batched_metadata_with_queries(json_metadata, sorted_queries):
 
     # ENT-4980 every batch "shard" record in algoilia should have all of these that pertain to the course
     course_catalog_query_titles = list(map(lambda x: x[1], sorted_queries))
-    important_catalog_membership = list(filter(lambda y: y in IMPORTANT_CATALOG_TITLES, course_catalog_query_titles))
+    explore_catalog_membership = list(filter(lambda y: y in EXPLORE_CATALOG_TITLES, course_catalog_query_titles))
     batched_metadata = []
     for batch_index, query_batch in enumerate(batch(sorted_queries, batch_size=ALGOLIA_UUID_BATCH_SIZE)):
         json_metadata_with_uuids = copy.deepcopy(json_metadata)
 
         query_uuids, query_titles = list(map(list, zip(*query_batch)))
-        # filter out `None` from `query_titles`, join with important titles, dedupe (set), sort
-        batch_titles = sorted(set([title for title in query_titles if title] + important_catalog_membership))
+        # filter out `None` from `query_titles`, join with explore titles, dedupe (set), sort
+        batch_titles = sorted(set([title for title in query_titles if title] + explore_catalog_membership))
         metadata_to_update = {
             'objectID': f"{json_metadata['objectID']}-catalog-query-uuids-{batch_index}",
             'enterprise_catalog_query_uuids': sorted(query_uuids),

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -552,11 +552,13 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][0]],
             'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]],
         })
+
+        # the title is also in the second batch
         expected_algolia_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-catalog-query-uuids-1',
             'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][1]],
-            'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]],  # the title is also in the second batch
+            'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]],
         })
 
         # verify replace_all_objects is called with the correct Algolia object data

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -507,3 +507,60 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         mock_search_client().replace_all_objects.assert_called_once_with(expected_algolia_objects_to_index)
 
         mock_was_recently_indexed.assert_called_once_with(self.course_metadata_published.content_key)
+
+
+    @mock.patch('enterprise_catalog.apps.api.tasks._was_recently_indexed', return_value=False)
+    @mock.patch('enterprise_catalog.apps.api.tasks.get_initialized_algolia_client', return_value=mock.MagicMock())
+    def test_index_algolia_with_important_catalog_titles(self, mock_search_client, mock_was_recently_indexed):
+        """
+        Assert that every Algolia batch contains all the important catalog titles
+        """
+        algolia_data = self._set_up_factory_data_for_algolia()
+        # override the important titles with test data to show every batch contains them
+        important_titles = [algolia_data['query_titles'][0]]
+
+        with mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_UUID_BATCH_SIZE', 1), \
+             mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_FIELDS', self.ALGOLIA_FIELDS), \
+             mock.patch('enterprise_catalog.apps.api.tasks.IMPORTANT_CATALOG_TITLES', important_titles):
+            tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
+
+        # create expected data to be added/updated in the Algolia index.
+        expected_algolia_objects_to_index = []
+        published_course_uuid = algolia_data['course_metadata_published'].json_metadata.get('uuid')
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-uuids-0',
+            'enterprise_catalog_uuids': [algolia_data['catalog_uuids'][0]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-uuids-1',
+            'enterprise_catalog_uuids': [algolia_data['catalog_uuids'][1]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-customer-uuids-0',
+            'enterprise_customer_uuids': [algolia_data['customer_uuids'][0]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-customer-uuids-1',
+            'enterprise_customer_uuids': [algolia_data['customer_uuids'][1]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-query-uuids-0',
+            'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][0]],
+            'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-catalog-query-uuids-1',
+            'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][1]],
+            'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]], # the title is also in the second batch
+        })
+
+        # verify replace_all_objects is called with the correct Algolia object data
+        mock_search_client().replace_all_objects.assert_called_once_with(expected_algolia_objects_to_index)
+
+        mock_was_recently_indexed.assert_called_once_with(self.course_metadata_published.content_key)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -512,15 +512,15 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
     @mock.patch('enterprise_catalog.apps.api.tasks.get_initialized_algolia_client', return_value=mock.MagicMock())
     def test_index_algolia_with_important_catalog_titles(self, mock_search_client, mock_was_recently_indexed):
         """
-        Assert that every Algolia batch contains all the important catalog titles
+        Assert that every Algolia batch contains all the explore UI catalog titles
         """
         algolia_data = self._set_up_factory_data_for_algolia()
-        # override the important titles with test data to show every batch contains them
-        important_titles = [algolia_data['query_titles'][0]]
+        # override the explore UI titles with test data to show every batch contains them
+        explore_titles = [algolia_data['query_titles'][0]]
 
         with mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_UUID_BATCH_SIZE', 1), \
              mock.patch('enterprise_catalog.apps.api.tasks.ALGOLIA_FIELDS', self.ALGOLIA_FIELDS), \
-             mock.patch('enterprise_catalog.apps.api.tasks.IMPORTANT_CATALOG_TITLES', important_titles):
+             mock.patch('enterprise_catalog.apps.api.tasks.EXPLORE_CATALOG_TITLES', explore_titles):
             tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         # create expected data to be added/updated in the Algolia index.

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -508,7 +508,6 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
 
         mock_was_recently_indexed.assert_called_once_with(self.course_metadata_published.content_key)
 
-
     @mock.patch('enterprise_catalog.apps.api.tasks._was_recently_indexed', return_value=False)
     @mock.patch('enterprise_catalog.apps.api.tasks.get_initialized_algolia_client', return_value=mock.MagicMock())
     def test_index_algolia_with_important_catalog_titles(self, mock_search_client, mock_was_recently_indexed):
@@ -557,7 +556,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-catalog-query-uuids-1',
             'enterprise_catalog_query_uuids': [algolia_data['query_uuids'][1]],
-            'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]], # the title is also in the second batch
+            'enterprise_catalog_query_titles': [algolia_data['query_titles'][0]],  # the title is also in the second batch
         })
 
         # verify replace_all_objects is called with the correct Algolia object data


### PR DESCRIPTION
This is meant to be a quick-hit fix for ENT-4980 and we'll circle back with a more "correct" fix later. The "correct" fix plan at the moment is to add a new facet to algolia which contains these "important" catalog titles for display (won't be broken up or differ between shards).

TLDR on the bug: when you query a facet which is broken up between batched/sharded records, algolia only seems to return the matching batch's version of the facet data, not the aggregated value of that facet. Fine to locate a course but not okay if your display assumes you see the aggregated value.

This quick-fix essentially keeps track of "important" catalog titles (business, education, a la carte) and ensures that every algolia batch/shard for a course always has the all the titles for "important" catalogs (not just the ones which happen to exist in that batch). I added a test which which ensures every batch contains all the important catalog titles. So, no matter which batch is returned as a result, the UI can display properly (tag courses with all the important catalogs).

- [ENT-4980](https://openedx.atlassian.net/browse/ENT-4980)
