### PR TITLE
feat: fixed content last updated and added content metadata content keys filtering

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -1,0 +1,57 @@
+from datetime import timedelta
+
+from django.test import TestCase
+
+from enterprise_catalog.apps.api.v1.utils import get_most_recent_modified_time
+from enterprise_catalog.apps.catalog.utils import localized_utcnow
+
+
+class ApiUtilsTests(TestCase):
+    """
+    Tests for the Enterprise Catalog API client utils
+    """
+
+    def test_get_most_recent_modified_time_catalog_modified(self):
+        """
+        Test that the get_most_recent_modified_time function will account for catalog modified times
+        """
+        now = localized_utcnow()
+        catalog_time = now
+        customer_time = now - timedelta(hours=1)
+        content_time = now - timedelta(hours=1)
+        most_recent_time = get_most_recent_modified_time(content_time, catalog_time, customer_time)
+        assert most_recent_time == catalog_time
+
+    def test_get_most_recent_modified_time_customer_modified(self):
+        """
+        Test that the get_most_recent_modified_time function will account for customer modified times
+        """
+        now = localized_utcnow()
+        customer_time = now
+        catalog_time = now - timedelta(hours=1)
+        content_time = now - timedelta(hours=1)
+        most_recent_time = get_most_recent_modified_time(content_time, catalog_time, customer_time)
+        assert most_recent_time == customer_time
+
+    def test_get_most_recent_modified_time_content_modified(self):
+        """
+        Test that the get_most_recent_modified_time function will account for content modified times
+        """
+        now = localized_utcnow()
+        content_time = now
+        catalog_time = now - timedelta(hours=1)
+        customer_time = now - timedelta(hours=1)
+        most_recent_time = get_most_recent_modified_time(content_time, catalog_time, customer_time)
+        assert most_recent_time == content_time
+
+    def test_get_most_recent_modified_time_accounts_for_no_customer_modified(self):
+        """
+        Test that the get_most_recent_modified_time function will account for content modified times when customer
+        modified times do not exist
+        """
+        now = localized_utcnow()
+        content_time = now
+        catalog_time = now - timedelta(hours=1)
+        customer_time = None
+        most_recent_time = get_most_recent_modified_time(content_time, catalog_time, customer_time)
+        assert most_recent_time == content_time

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -12,10 +12,14 @@ app_name = 'v1'
 router = DefaultRouter()
 router.register(r'enterprise-catalogs', views.EnterpriseCatalogCRUDViewSet, basename='enterprise-catalog')
 router.register(r'enterprise-catalogs', views.EnterpriseCatalogContainsContentItems, basename='enterprise-catalog')
-router.register(r'enterprise-catalogs', views.EnterpriseCatalogGetContentMetadata, basename='enterprise-catalog')
 router.register(r'enterprise-customer', views.EnterpriseCustomerViewSet, basename='enterprise-customer')
 
 urlpatterns = [
+    url(
+        r'^enterprise-catalogs/(?P<uuid>[\S]+)/get_content_metadata',
+        views.EnterpriseCatalogGetContentMetadata.as_view({'get': 'get'}),
+        name='get-content-metadata'
+    ),
     url(
         r'^enterprise-catalogs/(?P<uuid>[\S]+)/generate_diff',
         views.EnterpriseCatalogDiff.as_view({'post': 'post'}),

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -92,3 +92,14 @@ def is_any_course_run_active(course_runs):
         if is_course_run_active(course_run):
             return True
     return False
+
+
+def get_most_recent_modified_time(content_modified, catalog_modified, customer_modified):
+    """
+    Helper function to get the appropriate content last modified time for a content metadata object under a specific
+    customer
+    """
+    content_modified = max([content_modified, catalog_modified])
+    if customer_modified:
+        content_modified = max([content_modified, customer_modified])
+    return content_modified

--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -1,6 +1,7 @@
 """
 Interface to Enterprise Customer details from edx-enterprise API using a volatile cache.
 """
+from dateutil import parser
 from django.conf import settings
 from django.core.cache import cache
 
@@ -39,6 +40,13 @@ class EnterpriseCustomerDetails:
         Return Enterprise Customer slug OR empty string if unavailable.
         """
         return self.customer_data.get('slug', '')
+
+    @property
+    def last_modified_date(self):
+        """
+        Return Enterprise Customer last modified datetime or None if unavailable.
+        """
+        return parser.parse(self.customer_data.get('modified', None))
 
 
 def _get_enterprise_customer_data(uuid):

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -17,6 +17,7 @@ from simple_history.models import HistoricalRecords
 
 from enterprise_catalog.apps.api.v1.utils import (
     get_enterprise_utm_context,
+    get_most_recent_modified_time,
     update_query_parameters,
 )
 from enterprise_catalog.apps.api_client.discovery_cache import (
@@ -239,10 +240,13 @@ class EnterpriseCatalog(TimeStampedModel):
         for content in self.content_metadata.all().values('modified', 'content_key'):
             content_key = content.get('content_key')
             found_content_keys.add(content_key)
+            content_modified = get_most_recent_modified_time(
+                content.get('modified'), self.modified, self.enterprise_customer.last_modified_date
+            )
             if content_key in distinct_content_keys:
                 items_found.append({
                     "content_key": content_key,
-                    "date_updated": content.get('modified')
+                    "date_updated": content_modified
                 })
             else:
                 items_not_included.append({'content_key': content_key})


### PR DESCRIPTION
Fast follow to https://github.com/edx/enterprise-catalog/pull/338 where now we can be more specific with what we request from the catalog service + no longer not detecting when enrollment URL's have changed.

## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
