### PR TITLE
feat: adding upcoming course runs to algolia

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -655,7 +655,7 @@ def get_upcoming_course_runs(course):
         course (dict)
 
     Returns:
-        str: the number of course runs in the future
+        int: the number of course runs in the future
     """
     course_runs = course.get('course_runs') or []
     active_course_runs = [run for run in course_runs if is_course_run_active(run)]

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -51,6 +51,7 @@ ALGOLIA_FIELDS = [
     'title',
     'type',
     'advertised_course_run',  # a part of the advertised course run
+    'upcoming_course_runs',
     'first_enrollable_paid_seat_price',
     'original_image_url',
     'marketing_url',
@@ -646,6 +647,23 @@ def get_advertised_course_run(course):
     return course_run
 
 
+def get_upcoming_course_runs(course):
+    """
+    Get number of upcoming course runs.
+
+    Argument:
+        course (dict)
+
+    Returns:
+        str: the number of course runs in the future
+    """
+    course_runs = course.get('course_runs') or []
+    active_course_runs = [run for run in course_runs if is_course_run_active(run)]
+    if get_advertised_course_run(course) is not None:
+        return len(active_course_runs) - 1
+    return len(active_course_runs)
+
+
 def _get_course_run_by_uuid(course, course_run_uuid):
     """
     Find a course_run based on uuid
@@ -735,6 +753,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'subjects': get_course_subjects(searchable_product),
             'card_image_url': get_course_card_image_url(searchable_product),
             'advertised_course_run': get_advertised_course_run(searchable_product),
+            'upcoming_course_runs': get_upcoming_course_runs(searchable_product),
             'skill_names': get_course_skill_names(searchable_product),
             'skills': get_course_skills(searchable_product),
             'first_enrollable_paid_seat_price': get_course_first_paid_enrollable_seat_price(searchable_product),

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -9,6 +9,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     _should_index_course,
     configure_algolia_index,
     get_advertised_course_run,
+    get_upcoming_course_runs,
     get_course_availability,
     get_course_card_image_url,
     get_course_language,
@@ -33,6 +34,8 @@ from enterprise_catalog.apps.catalog.tests.factories import (
 
 
 ADVERTISED_COURSE_RUN_UUID = uuid4()
+FUTURE_COURSE_RUN_UUID_1 = uuid4()
+FUTURE_COURSE_RUN_UUID_2 = uuid4()
 
 
 @ddt.ddt
@@ -312,6 +315,51 @@ class AlgoliaUtilsTests(TestCase):
         """
         advertised_course_run = get_advertised_course_run(searchable_course)
         assert advertised_course_run == expected_course_run
+
+    @ddt.data(
+        (
+            {
+                'course_runs': [
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': ADVERTISED_COURSE_RUN_UUID,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'availability': 'Current'
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': FUTURE_COURSE_RUN_UUID_1,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'availability': 'Upcoming'
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': FUTURE_COURSE_RUN_UUID_1,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'unpublished',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'availability': 'Starting Soon'
+                    }
+                ],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            1,
+        ),
+    )
+    @ddt.unpack
+    def test_get_upcoming_course_runs(self, searchable_course, expected_course_runs):
+        """
+        Assert get_advertised_course_runs fetches just enough info about advertised course run
+        """
+        upcoming_course_runs = get_upcoming_course_runs(searchable_course)
+        assert upcoming_course_runs == expected_course_runs
 
     @ddt.data(
         (

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -9,7 +9,6 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     _should_index_course,
     configure_algolia_index,
     get_advertised_course_run,
-    get_upcoming_course_runs,
     get_course_availability,
     get_course_card_image_url,
     get_course_language,
@@ -26,6 +25,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_program_subjects,
     get_program_title,
     get_program_type,
+    get_upcoming_course_runs,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE
 from enterprise_catalog.apps.catalog.tests.factories import (


### PR DESCRIPTION
## Description
This will add in a variable to Algolia that allows us to see the number of upcoming course runs that will be shown in explore catalog's modal subheader. 

## Ticket Link

[ENT-5086](https://openedx.atlassian.net/browse/ENT-5086)

## Post-review

Squash commits into discrete sets of changes
