### PR TITLE
fix: move update existing content metadata batch size to settings.

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -568,13 +568,7 @@ def _update_existing_content_metadata(existing_metadata_defaults, existing_metad
             metadata_list.append(content_metadata)
 
     metadata_fields_to_update = ['content_key', 'parent_content_key', 'content_type', 'json_metadata']
-    # Using batch_size of 10 or higher makes us prone to exceeding
-    # the MySql default `max_allowed_packet` size of 4MB.
-    # This can occur because we have a good handful of records
-    # that are around 600k each (really big `json_metadata` values),
-    # and 0.6MB * 10 = 6MB > 4MB (in the worse case where we're updating
-    # mostly our largest records in a single query).
-    batch_size = 8
+    batch_size = settings.UPDATE_EXISTING_CONTENT_METADATA_BATCH_SIZE
     for batched_metadata in batch(metadata_list, batch_size=batch_size):
         try:
             ContentMetadata.objects.bulk_update(

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -386,3 +386,14 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     SYSTEM_ENTERPRISE_LEARNER_ROLE: [ENTERPRISE_CATALOG_LEARNER_ROLE],
     SYSTEM_ENTERPRISE_ADMIN_ROLE: [ENTERPRISE_CATALOG_LEARNER_ROLE],
 }
+
+# Set the query batch size with which existing content metadata records
+# are updated during the `update_catalog_metadata_task()` celery task.
+# Using batch_size of 6 or higher makes us prone to exceeding
+# the MySql default `max_allowed_packet` size of 4MB.
+# This can occur because we have a good handful of records
+# that are around 600k each (really big `json_metadata` values),
+# and 0.6MB * 6 = 3.6MB + [all other query tokens] > 4MB
+# (in the worse case where we're updating
+# mostly our largest records in a single query).
+UPDATE_EXISTING_CONTENT_METADATA_BATCH_SIZE = 5


### PR DESCRIPTION
...make it smaller by default (5).  Moving to settings allows us to change without a deploy.

https://openedx.atlassian.net/browse/ENT-5188. See the "results" section in this ticket description for reasoning on why the value of 5.  tl;dr we can still hit a worse case where the total size of the updated records + other query tokens is greater than the current `max_allowed_packet` size of 4MB.
