### PR TITLE
feat: Add relevant fields to the Explore Catalog CSV Download

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -431,6 +431,7 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
         'key': 'MITx+18.01.2x',
         'language': 'English',
         'level_type': 'Intermediate',
+        'content_type': 'course',
         'partners': [
             {'name': 'Massachusetts Institute of Technology',
              'logo_image_url': 'https://edx.org/image.png'}

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -389,6 +389,8 @@ class CatalogCsvDataView(GenericAPIView):
             # combine discovery metadata with the algolia results
             # append the hit to the results
             for hit in page['hits']:
+                if hit['content_type'] != 'course':
+                    continue
                 if course_by_key.get(hit['key']):
                     hit['discovery_course'] = course_by_key.get(hit['key'])
                 algolia_hits.append(hit)


### PR DESCRIPTION
## Description

- follow-on to #371
- ignore programs for CSV download (recently added to the index)

## References

- [ENT-5295](https://openedx.atlassian.net/browse/ENT-5295)
