### PR TITLE
feat: Add relevant fields to the Explore Catalog CSV Download

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -458,7 +458,21 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
             'upgrade_deadline': 32503680000.0,
         },
         'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf8-catalog-query-uuids-0'
-    }]}
+    },
+        {
+        'aggregation_key': 'course:MITx+19',
+        'key': 'MITx+19',
+        'language': 'English',
+        'level_type': 'Intermediate',
+        'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf9-catalog-query-uuids-0'
+    },
+        {
+        'aggregation_key': 'course:MITx+20',
+        'language': 'English',
+        'level_type': 'Intermediate',
+        'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf7-catalog-query-uuids-0'
+    }
+    ]}
 
     mock_discovery_courses = [
         {

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -377,7 +377,12 @@ class CatalogCsvDataView(GenericAPIView):
         algolia_hits = []
         page = algolia_client.algolia_index.search(algoliaQuery, search_options)
         while len(page['hits']) > 0:
-            course_keys_chunk = [hit['key'] for hit in page.get('hits', [])]
+            course_keys_chunk = []
+            for hit in page.get('hits', []):
+                # ignore program data (for now)
+                if hit['content_type'] != 'course':
+                    continue
+                course_keys_chunk.append(hit['key'])
             query_params = {'keys': ','.join(course_keys_chunk)}
             courses = discovery_client.get_courses(query_params=query_params)
 
@@ -389,6 +394,7 @@ class CatalogCsvDataView(GenericAPIView):
             # combine discovery metadata with the algolia results
             # append the hit to the results
             for hit in page['hits']:
+                # ignore program data (for now)
                 if hit['content_type'] != 'course':
                     continue
                 if course_by_key.get(hit['key']):

--- a/enterprise_catalog/apps/api/v1/views.py
+++ b/enterprise_catalog/apps/api/v1/views.py
@@ -380,25 +380,26 @@ class CatalogCsvDataView(GenericAPIView):
             course_keys_chunk = []
             for hit in page.get('hits', []):
                 # ignore program data (for now)
-                if hit['content_type'] != 'course':
+                if hit.get('content_type') != 'course':
                     continue
-                course_keys_chunk.append(hit['key'])
+                if hit.get('key'):
+                    course_keys_chunk.append(hit.get('key'))
             query_params = {'keys': ','.join(course_keys_chunk)}
             courses = discovery_client.get_courses(query_params=query_params)
 
             # build a lookup dictionary for efficient lookup when combining
             course_by_key = {}
             for course in courses:
-                course_by_key[course['key']] = course
+                course_by_key[course.get('key')] = course
 
             # combine discovery metadata with the algolia results
             # append the hit to the results
             for hit in page['hits']:
                 # ignore program data (for now)
-                if hit['content_type'] != 'course':
+                if hit.get('content_type') != 'course':
                     continue
-                if course_by_key.get(hit['key']):
-                    hit['discovery_course'] = course_by_key.get(hit['key'])
+                if course_by_key.get(hit.get('key')):
+                    hit['discovery_course'] = course_by_key.get(hit.get('key'))
                 algolia_hits.append(hit)
 
             search_options['page'] = search_options['page'] + 1


### PR DESCRIPTION
## Description

- follow-on to #373
- be more defensive with accessing algolia results (missing keys)
- extend tests to cover edge-cases seen in PROD

## References

- [ENT-5295](https://openedx.atlassian.net/browse/ENT-5295)
