### PR TITLE
fix: adding missing attribute to retrieve to default content endpoint

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
+++ b/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
@@ -54,6 +54,7 @@ class DefaultCatalogResultsView(GenericAPIView):
         'availability',
         'program_type',
         'course_keys',
+        'authoring_organizations',
     ]
 
     @method_decorator(require_at_least_one_query_parameter('enterprise_catalog_query_titles'))


### PR DESCRIPTION
## Description

adding authoring_organizations

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
