### PR TITLE
feat: add program price, learning items, and banner image to program algolia record

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -506,6 +506,26 @@ def get_program_learning_items(program):
     return program.get('expected_learning_items') or []
 
 
+def get_program_prices(program):
+    """
+    Gets the prices (only USD for now) for a program. Used for the "prices" facet in Algolia.
+
+    Arguments:
+        program (dict): a dictionary representing a program.
+
+    Returns:
+        dict: { total_usd: priceValueInUSD }.
+    """
+    price_ranges = program.get('price_ranges') or []
+    try:
+        usd_price = [price for price in price_ranges if price.get('currency') == 'USD'][0]
+    except IndexError:
+        usd_price = None
+    if usd_price is not None:
+        return {'usd_total': usd_price['total']}
+    return None
+
+
 def get_course_program_types(course):
     """
     Gets list of program types associated with the course. Used for the "Programs"
@@ -787,6 +807,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'skill_names': get_program_skill_names(searchable_product),
             'level_type': get_program_level_type(searchable_product),
             'learning_items': get_program_learning_items(searchable_product),
+            'prices': get_program_prices(searchable_product),
         })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -824,6 +824,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'level_type': get_program_level_type(searchable_product),
             'learning_items': get_program_learning_items(searchable_product),
             'prices': get_program_prices(searchable_product),
+            'banner_image_url': get_program_banner_image_url(searchable_product),
         })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import logging
+from re import search
 import time
 
 from django.utils.translation import ugettext as _
@@ -492,6 +493,19 @@ def get_program_level_type(program):
     return max(set(level_types), key=level_types.count) if level_types else ''
 
 
+def get_program_learning_items(program):
+    """
+    Gets the expected_learning_items for a program. Used for the "learning_items" facet in Algolia.
+
+    Arguments:
+        program (dict): a dictionary representing a program.
+
+    Returns:
+        list(str): list of learning items.
+    """
+    return program.get('expected_learning_items') or []
+
+
 def get_course_program_types(course):
     """
     Gets list of program types associated with the course. Used for the "Programs"
@@ -772,6 +786,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'subjects': get_program_subjects(searchable_product),
             'skill_names': get_program_skill_names(searchable_product),
             'level_type': get_program_level_type(searchable_product),
+            'learning_items': get_program_learning_items(searchable_product),
         })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -1,7 +1,6 @@
 import copy
 import datetime
 import logging
-from re import search
 import time
 
 from django.utils.translation import ugettext as _
@@ -503,7 +502,7 @@ def get_program_learning_items(program):
     Returns:
         list(str): list of learning items.
     """
-    return program.get('expected_learning_items') or []
+    return program.get('expected_learning_items', [])
 
 
 def get_program_prices(program):
@@ -516,14 +515,31 @@ def get_program_prices(program):
     Returns:
         dict: { total_usd: priceValueInUSD }.
     """
-    price_ranges = program.get('price_ranges') or []
+    price_ranges = program.get('price_ranges', [])
     try:
-        usd_price = [price for price in price_ranges if price.get('currency') == 'USD'][0]
+        usd_price = [price for price in price_ranges if price.get('currency', '') == 'USD'][0]
     except IndexError:
         usd_price = None
     if usd_price is not None:
         return {'usd_total': usd_price['total']}
     return None
+
+
+def get_program_banner_image_url(program):
+    """
+    Gets the banner_image_url (only large is fetched), rest of urls can be deduced
+
+    Arguments:
+        program (dict): a dictionary representing a program.
+
+    Returns:
+        str: url to large size image
+    """
+    images = program.get('banner_image', {})
+    try:
+        return images.get('large').get('url')
+    except (KeyError, AttributeError):
+        return None
 
 
 def get_course_program_types(course):

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -56,6 +56,9 @@ ALGOLIA_FIELDS = [
     'original_image_url',
     'marketing_url',
     'enterprise_catalog_query_titles',
+    'learning_items',
+    'prices',
+    'banner_image_url',
 ]
 
 # default configuration for the index
@@ -513,7 +516,7 @@ def get_program_prices(program):
         program (dict): a dictionary representing a program.
 
     Returns:
-        dict: { total_usd: priceValueInUSD }.
+        dict: { usd_total: priceValueInUSD }.
     """
     price_ranges = program.get('price_ranges', [])
     try:

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -19,6 +19,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_course_subjects,
     get_initialized_algolia_client,
     get_program_availability,
+    get_program_banner_image_url,
     get_program_learning_items,
     get_program_level_type,
     get_program_partners,
@@ -567,6 +568,28 @@ class AlgoliaUtilsTests(TestCase):
         """
         program_prices = get_program_prices(program_metadata)
         self.assertEqual(expected_type, program_prices)
+
+    @ddt.data(
+        (
+            {'banner_image': {'large': {'url': 'https://test'}}},
+            'https://test',
+        ),
+        (
+            {'banner_image': {}},
+            None,
+        ),
+        (
+            {'banner_image': {'large': {}}},
+            None,
+        ),
+    )
+    @ddt.unpack
+    def test_get_program_banner_image(self, program_metadata, expected_type):
+        """
+        Assert that the prices associated with a program is properly parsed.
+        """
+        image_url = get_program_banner_image_url(program_metadata)
+        self.assertEqual(expected_type, image_url)
 
     @ddt.data(
         (

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -22,6 +22,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_program_learning_items,
     get_program_level_type,
     get_program_partners,
+    get_program_prices,
     get_program_skill_names,
     get_program_subjects,
     get_program_title,
@@ -552,6 +553,20 @@ class AlgoliaUtilsTests(TestCase):
         """
         program_type = get_program_type(program_metadata)
         self.assertEqual(expected_type, program_type)
+
+    @ddt.data(
+        (
+            {'price_ranges': [{'currency': 'USD', 'total': 169}, {'currency': 'GBP', 'total': 1}]},
+            {'usd_total': 169},
+        ),
+    )
+    @ddt.unpack
+    def test_get_program_prices(self, program_metadata, expected_type):
+        """
+        Assert that the prices associated with a program is properly parsed.
+        """
+        program_prices = get_program_prices(program_metadata)
+        self.assertEqual(expected_type, program_prices)
 
     @ddt.data(
         (

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -19,6 +19,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_course_subjects,
     get_initialized_algolia_client,
     get_program_availability,
+    get_program_learning_items,
     get_program_level_type,
     get_program_partners,
     get_program_skill_names,
@@ -446,6 +447,24 @@ class AlgoliaUtilsTests(TestCase):
         """
         program_types = get_course_program_types(course_metadata)
         assert program_types == expected_program_types
+
+    @ddt.data(
+        (
+            {'expected_learning_items': ['a', 'b', 'x']},
+            ['a', 'b', 'x'],
+        ),
+        (
+            {},
+            [],
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_learning_items(self, program_metadata, expected_program_types):
+        """
+        Assert that the list of program types associated with a course is properly parsed and formatted.
+        """
+        learning_items = get_program_learning_items(program_metadata)
+        assert learning_items == expected_program_types
 
     @ddt.data(
         (


### PR DESCRIPTION
We need this value to show more information in the explore catalog

fields being added: (no facets or searchable facets needed right now, these fields are justt needed to display in dialog for programs)

- learning_items: maps to expected_learning_items in discovery
- NOT WORKING AS OF THIS PR: total_usd: usd price extracted from the `price_ranges` field in discovery (somehow content metadata does not have this field hence we are not populating this as of this PR)
- banner_image_url: the 'large' image url extracted from the banner_image field in discovery, we only use larger here, but it's easy to derive the urls for medium and small from it

ENT-5221

### Testing notes

Ran `./manage.py reindex_algolia` after clearing my dev_bpant index in staging, and ensuring the program fields appeared 

added some automated unit tests for the parser methods
