### PR TITLE
feat: add prices even if empty, for consistency ENT-5221

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -516,16 +516,13 @@ def get_program_prices(program):
         program (dict): a dictionary representing a program.
 
     Returns:
-        dict: { usd_total: priceValueInUSD }.
+        array of price dict values: e.g., [{'currency': 'USD', 'total': 169}]
     """
     price_ranges = program.get('price_ranges', [])
-    try:
-        usd_price = [price for price in price_ranges if price.get('currency', '') == 'USD'][0]
-    except IndexError:
-        usd_price = None
-    if usd_price is not None:
-        return {'usd_total': usd_price['total']}
-    return None
+    if not price_ranges:
+        return []
+    prices = [price for price in price_ranges if price.get('currency', '') == 'USD']
+    return prices
 
 
 def get_program_banner_image_url(program):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -558,8 +558,12 @@ class AlgoliaUtilsTests(TestCase):
     @ddt.data(
         (
             {'price_ranges': [{'currency': 'USD', 'total': 169}, {'currency': 'GBP', 'total': 1}]},
-            {'usd_total': 169},
+            [{'currency': 'USD', 'total': 169}],
         ),
+        (
+            {},
+            [],
+        )
     )
     @ddt.unpack
     def test_get_program_prices(self, program_metadata, expected_type):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -461,7 +461,7 @@ class AlgoliaUtilsTests(TestCase):
         ),
     )
     @ddt.unpack
-    def test_get_course_learning_items(self, program_metadata, expected_program_types):
+    def test_get_program_learning_items(self, program_metadata, expected_program_types):
         """
         Assert that the list of program types associated with a course is properly parsed and formatted.
         """


### PR DESCRIPTION
ENT-5221

If price_ranges does not exist, returns [] which is indexed in algolia as `prices: []`
if price_ranges has a USD entry, returns [ entry_as_is ] so we can extend easily to other currencies in future


## Ticket Link
[ENT-5221](https://openedx.atlassian.net/browse/ENT-5221)

## Post-review

Squash commits into discrete sets of changes
