### PR TITLE
Added a new task to load missing programs metadata into the database.

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -52,6 +52,8 @@ class DiscoveryApiClient(BaseOAuthClient):
             'page_size': 100,
             # Ensure paginated results are consistently ordered by `aggregation_key` and `start`
             'ordering': 'aggregation_key,start',
+            # Ensure to fetch learner pathways as part of search/all endpoint response.
+            'include_learner_pathways': True,
         }
 
         page = 1

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -9,7 +9,7 @@ from enterprise_catalog.apps.api.v1.utils import is_course_run_active
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
-    PATHWAY,
+    LEARNER_PATHWAY,
     PROGRAM,
     PROGRAM_TYPES_MAP,
 )
@@ -994,7 +994,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'prices': get_program_prices(searchable_product),
             'banner_image_url': get_program_banner_image_url(searchable_product),
         })
-    elif searchable_product.get('content_type') == PATHWAY:
+    elif searchable_product.get('content_type') == LEARNER_PATHWAY:
         searchable_product.update({
             'course_keys': get_pathway_course_keys(searchable_product),
             'programs': get_pathway_program_uuids(searchable_product),

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -9,12 +9,13 @@ from enterprise_catalog.apps.catalog.waffle import (
 COURSE = 'course'
 COURSE_RUN = 'courserun'
 PROGRAM = 'program'
-PATHWAY = 'learnerpathway'
+LEARNER_PATHWAY = 'learnerpathway'
+
 CONTENT_TYPE_CHOICES = [
     (COURSE, 'Course'),
     (COURSE_RUN, 'Course Run'),
     (PROGRAM, 'Program'),
-    (PATHWAY, 'Learner Pathway'),
+    (LEARNER_PATHWAY, 'Learner Pathway'),
 ]
 
 # ContentFilter field types for validation.

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import (
     fetch_missing_course_metadata_task,
+    fetch_missing_pathway_metadata_task,
     update_catalog_metadata_task,
     update_full_content_metadata_task,
 )
@@ -37,6 +38,13 @@ class Command(BaseCommand):
             ' to update content_metadata of missing courses.'
         )
         return fetch_missing_course_metadata_task.s()
+
+    def _fetch_missing_pathway_metadata_task(self):
+        logger.info(
+            'Spinning off fetch_missing_pathway_metadata_task from update_content_metadata command'
+            ' to update content_metadata of missing pathways.'
+        )
+        return fetch_missing_pathway_metadata_task.s()
 
     def _update_full_content_metadata_task(self, *args, **kwargs):
         """
@@ -73,6 +81,9 @@ class Command(BaseCommand):
         a single `update_full_content_metadata_task` instance.
         """
         options.update(CatalogUpdateCommandConfig.current_options())
+
+        # Fetch program metadata for the programs that are missing.
+        self._fetch_missing_pathway_metadata_task()
 
         # Fetch course metadata for the courses that are missing.
         self._fetch_missing_course_metadata_task()

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -5,7 +5,7 @@ import factory
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     COURSE_RUN,
-    PATHWAY,
+    LEARNER_PATHWAY,
     PROGRAM,
     json_serialized_course_modes,
 )
@@ -59,7 +59,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
         model = ContentMetadata
 
     content_key = factory.Sequence(lambda n: f'metadata_item_{n}')
-    content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM, PATHWAY])
+    content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM, LEARNER_PATHWAY])
     parent_content_key = None   # Default to None
 
     @factory.lazy_attribute
@@ -99,14 +99,15 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
             })
         elif self.content_type == PROGRAM:
             json_metadata.update({
+                'uuid': self.content_key,
                 'content_type': PROGRAM,
                 'type': 'MicroMasters',
                 'hidden': True,
                 'marketing_url': f'https://marketing.url/{self.content_key}',
             })
-        elif self.content_type == PATHWAY:
+        elif self.content_type == LEARNER_PATHWAY:
             json_metadata.update({
-                'content_type': PATHWAY,
+                'content_type': LEARNER_PATHWAY,
                 'name': 'Data Engineer',
                 'status': 'active',
                 'overview': 'Pathway for a data engineer.',


### PR DESCRIPTION
## Description
Update command update_content_metadata from enterprise-catalog repo to save pathways content metadata as it is saving for programs and courses

## Ticket Link

Link to the associated ticket
[ENT-5362](https://openedx.atlassian.net/browse/ENT-5362)

## Post-review

Squash commits into discrete sets of changes
