### PR TITLE
fix: Pre-requisites not appearing for courses in Explore Catalog

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from enterprise_catalog.apps.api.v1 import export_utils
+from enterprise_catalog.apps.catalog import algolia_utils
+
+
+class ExportUtilsTests(TestCase):
+    """
+    Tests for the Enterprise Catalog API export utils
+    """
+
+    def test_retrieve_available_fields(self):
+        """
+        Test the export isn't retrieving fields which are not indexed
+        """
+        # assert that ALGOLIA_ATTRIBUTES_TO_RETRIEVE is a SUBSET of ALGOLIA_FIELDS
+        assert set(export_utils.ALGOLIA_ATTRIBUTES_TO_RETRIEVE) <= set(algolia_utils.ALGOLIA_FIELDS)

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -41,6 +41,7 @@ ALGOLIA_FIELDS = [
     'partner',
     'partners',
     'prerequisites',
+    'prerequisites_raw',
     'programs',
     'program_titles',
     'program_type',


### PR DESCRIPTION
## Description

- added the correct field for indexing
- added a test to check retrieved vs indexed fields

## References

- [ENT-5415](https://openedx.atlassian.net/browse/ENT-5415)
