### PR TITLE
fix: Download is empty with prefix search terms

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -735,7 +735,7 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
     @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_workbook.get_initialized_algolia_client')
     def test_success(self, mock_algolia_client):
         """
-        Tests when algolia returns no hits.
+        Tests basic, successful output.
         """
         mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
         url = self._get_contains_content_base_url()

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -654,6 +654,96 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
         assert response.data == expected_response
 
 
+class EnterpriseCatalogWorkbookViewTests(APITestMixin):
+    """
+    Tests for the CatalogWorkbookView view.
+    """
+    mock_algolia_hits = {'hits': [{
+        'aggregation_key': 'course:MITx+18.01.2x',
+        'key': 'MITx+18.01.2x',
+        'language': 'English',
+        'level_type': 'Intermediate',
+        'content_type': 'course',
+        'partners': [
+            {'name': 'Massachusetts Institute of Technology',
+             'logo_image_url': 'https://edx.org/image.png'}
+        ],
+        'programs': ['Professional Certificate'],
+        'program_titles': ['Totally Awesome Program'],
+        'short_description': 'description',
+        'subjects': ['Math'],
+        'skills': [{
+            'name': 'Probability And Statistics',
+            'description': 'description'
+        }, {
+            'name': 'Engineering Design Process',
+            'description': 'description'
+        }],
+        'title': 'Calculus 1B: Integration',
+        'marketing_url': 'edx.org/foo-bar',
+        'first_enrollable_paid_seat_price': 100,
+        'advertised_course_run': {
+            'key': 'MITx/18.01.2x/3T2015',
+            'pacing_type': 'instructor_paced',
+            'start': '2015-09-08T00:00:00Z',
+            'end': '2015-09-08T00:00:01Z',
+            'upgrade_deadline': 32503680000.0,
+            'max_effort': 10,
+            'min_effort': 1,
+            'weeks_to_complete': 1,
+        },
+        'outcome': '<p>learn</p>',
+        'prerequisites_raw': '<p>interest</p>',
+        'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf8-catalog-query-uuids-0'
+    },
+        {
+        'aggregation_key': 'course:MITx+19',
+        'key': 'MITx+19',
+        'language': 'English',
+        'level_type': 'Intermediate',
+        'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf9-catalog-query-uuids-0'
+    },
+        {
+        'aggregation_key': 'course:MITx+20',
+        'language': 'English',
+        'level_type': 'Intermediate',
+        'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf7-catalog-query-uuids-0'
+    }
+    ]}
+
+    def setUp(self):
+        super().setUp()
+        self.set_up_staff_user()
+
+    def _get_contains_content_base_url(self):
+        """
+        Helper to construct the base url for the contains_content_items endpoint
+        """
+        return reverse('api:v1:catalog-workbook')
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_workbook.get_initialized_algolia_client')
+    def test_empty_results_error(self, mock_algolia_client):
+        """
+        Tests when algolia returns no hits.
+        """
+        mock_algolia_client.return_value.algolia_index.search.side_effect = [{'hits': []}]
+        url = self._get_contains_content_base_url()
+        facets = 'language=English'
+        response = self.client.get(f'{url}?{facets}')
+        assert response.status_code == 400
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_workbook.get_initialized_algolia_client')
+    def test_success(self, mock_algolia_client):
+        """
+        Tests when algolia returns no hits.
+        """
+        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        url = self._get_contains_content_base_url()
+        facets = 'language=English'
+        response = self.client.get(f'{url}?{facets}')
+        assert response.status_code == 200
+
+
 class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
     """
     Tests on the contains_content_items on enterprise catalogs endpoint

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import time
 
 import xlsxwriter
@@ -13,6 +14,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_initialized_algolia_client,
 )
 
+logger = logging.getLogger(__name__)
 
 class CatalogWorkbookView(GenericAPIView):
     """
@@ -32,7 +34,11 @@ class CatalogWorkbookView(GenericAPIView):
         """
         facets = export_utils.querydict_to_dict(request.query_params)
         if facets.get('query'):
-            algoliaQuery = facets.pop('query')
+            # comes out as a list, we want the first value string only
+            algoliaQuery = facets.pop('query')[0]
+        elif facets.get('q'):
+            # comes out as a list, we want the first value string only
+            algoliaQuery = facets.pop('q')[0]
         else:
             algoliaQuery = ''
 
@@ -69,6 +75,10 @@ class CatalogWorkbookView(GenericAPIView):
 
         # Algolia search will only retrieve all results if you query by empty string.
         page = algolia_client.algolia_index.search(algoliaQuery, search_options)
+
+        if len(page['hits']) == 0:
+            return Response(f'Error: invalid query: {algoliaQuery} provided.', status=HTTP_400_BAD_REQUEST)
+
         # start after header row
         course_row_num = 1
         program_row_num = 1

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -14,6 +14,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_initialized_algolia_client,
 )
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -16,6 +16,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
 
 logger = logging.getLogger(__name__)
 
+
 class CatalogWorkbookView(GenericAPIView):
     """
     Catalog Workbook data generation view. All query params are assumed to be facet filters used to filter indexed data


### PR DESCRIPTION
## Description

- param manipulation was creating stricter search:

`['query param value']` -> `query param value`

- added error state when results are empty

## References

- tested locally

## References

- [ENT-5413](https://openedx.atlassian.net/browse/ENT-5413)
