### PR TITLE
fix: update Makefile isort flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ coverage: clean
 	$(BROWSER) htmlcov/index.html
 
 isort_check: ## check that isort has been run
-	isort --check-only --diff -rc enterprise_catalog/
+	isort --check-only --diff enterprise_catalog/
 
 isort: ## run isort to sort imports in all Python files
-	isort --recursive --atomic enterprise_catalog/
+	isort --atomic enterprise_catalog/
 
 style: ## run Python style checker
 	pycodestyle enterprise_catalog *.py


### PR DESCRIPTION
## Description

The current version of `isort` was throwing deprecation warnings:

```
root@app:/edx/app/enterprise_catalog/enterprise_catalog# make isort
isort --recursive --atomic enterprise_catalog/
Fixing /edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
Skipped 3 files
/venv/lib/python3.8/site-packages/isort/main.py:1261: UserWarning: W0501: The following deprecated CLI flags were used and ignored: --recursive!
  warn(
/venv/lib/python3.8/site-packages/isort/main.py:1265: UserWarning: W0500: Please see the 5.0.0 Upgrade guide: https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html
  warn(
```

Which points to these docs:

```
--recursive or -rc
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.
```

## Testing

```
root@app:/edx/app/enterprise_catalog/enterprise_catalog# make isort
isort --atomic enterprise_catalog/
Fixing /edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/v1/tests/test_utils.py
Skipped 3 files
```
