### PR TITLE
ENT-5221 algolia course_details field in program object

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -158,6 +158,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         request_params = {
             'ordering': 'key',
             'limit': DISCOVERY_OFFSET_SIZE,
+            'extended': 'True',
         }
         request_params.update(query_params or {})
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -61,6 +61,7 @@ ALGOLIA_FIELDS = [
     'enterprise_catalog_query_titles',
     'learning_items',
     'prices',
+    'course_details',
     'banner_image_url',
 ]
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -340,6 +340,23 @@ def _get_course_program_field(course, field):
     })
 
 
+def get_program_course_details(program):
+    """
+    Returns courses for a program, with just enough detail to use in frontend clients (for now)
+    """
+    courses = program.get('courses') or []
+    course_list = []
+    for course in courses:
+        mapped_course = {
+            'key': course.get('key'),
+            'title': course.get('title'),
+            'image': course.get('image'),
+            'short_description': course.get('short_description'),
+        }
+        course_list.append(mapped_course)
+    return course_list
+
+
 def _get_program_course_field(program, field):
     """
     Helper to pluck a list of values for the given field out of a program's courses.
@@ -861,6 +878,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'learning_items': get_program_learning_items(searchable_product),
             'prices': get_program_prices(searchable_product),
             'banner_image_url': get_program_banner_image_url(searchable_product),
+            'course_details': get_program_course_details(searchable_product),
         })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -22,6 +22,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_initialized_algolia_client,
     get_program_availability,
     get_program_banner_image_url,
+    get_program_course_details,
     get_program_learning_items,
     get_program_level_type,
     get_program_partners,
@@ -636,6 +637,21 @@ class AlgoliaUtilsTests(TestCase):
         """
         program_prices = get_program_prices(program_metadata)
         self.assertEqual(expected_type, program_prices)
+
+    @ddt.data(
+        (
+            {'courses': [{'key': 'akey', 'title': 'a_title', 'image': 'an_image', 'short_description': 'desc'}]},
+            [{'key': 'akey', 'title': 'a_title', 'image': 'an_image', 'short_description': 'desc'}],
+        ),
+        (
+            {'courses': []},
+            [],
+        ),
+    )
+    @ddt.unpack
+    def test_get_program_course_details(self, program_metadata, expected_details):
+        courses_list = get_program_course_details(program_metadata)
+        self.assertEqual(courses_list, expected_details)
 
     @ddt.data(
         (

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -644,6 +644,14 @@ class AlgoliaUtilsTests(TestCase):
             [{'key': 'akey', 'title': 'a_title', 'image': 'an_image', 'short_description': 'desc'}],
         ),
         (
+            {'courses': [{'key': 'akey'}]},
+            [{'key': 'akey', 'title': None, 'image': None, 'short_description': None}],
+        ),
+        (
+            {'courses': [{'title': 'only_title'}]},
+            [{'key': None, 'title': 'only_title', 'image': None, 'short_description': None}],
+        ),
+        (
             {'courses': []},
             [],
         ),


### PR DESCRIPTION
## Description

course_details sourced from the disocery field of programs > courses, will also be indexed in algolia


### TESting notes

Tested against ny local aloglia index and verified it ended up with these fields 

<img width="671" alt="Screen Shot 2022-02-10 at 5 10 29 PM" src="https://user-images.githubusercontent.com/528166/153505921-ce6a9de4-d468-4495-a160-1e325899b26b.png">


## Ticket Link

[ENT-5221](https://openedx.atlassian.net/browse/ENT-5221)

## Post-review

Squash commits into discrete sets of changes
