### PR TITLE
fix: do not index archived courses in algolia

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -142,6 +142,9 @@ def _should_index_course(course_metadata):
     if not is_course_run_active(advertised_course_run):
         return False
 
+    if is_course_archived(course_json_metadata):
+        return False
+
     owners = course_json_metadata.get('owners') or []
     return not advertised_course_run.get('hidden') and len(owners) > 0
 
@@ -296,6 +299,20 @@ def get_course_availability(course):
             COURSE_AVAILABILITY_MESSAGES.get(run_availability.lower(), DEFAULT_COURSE_AVAILABILITY)
         )
     return list(availability)
+
+
+def is_course_archived(course):
+    """
+    Determines if the availability for a course is "Archived"
+
+    Arguments:
+        course (dict): a dict representing with course metadata
+
+    Returns:
+        boolean: "Archived" availability or not
+    """
+    availability_list = get_course_availability(course)
+    return len(availability_list) == 0 or availability_list[0] == 'Archived'
 
 
 def get_course_partners(course):

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -80,6 +80,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'status': 'published',
                 'is_enrollable': True,
                 'is_marketable': True,
+                'availability': 'current',
             }]
             json_metadata.update({
                 'content_type': COURSE,


### PR DESCRIPTION
## Description

- take into account availability when deciding to index
- expand test coverage

## References

- [ENT-5432](https://openedx.atlassian.net/browse/ENT-5432)
