### PR TITLE
fix: re-enable archived in index

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -142,9 +142,6 @@ def _should_index_course(course_metadata):
     if not is_course_run_active(advertised_course_run):
         return False
 
-    if is_course_archived(course_json_metadata):
-        return False
-
     owners = course_json_metadata.get('owners') or []
     return not advertised_course_run.get('hidden') and len(owners) > 0
 
@@ -312,7 +309,7 @@ def is_course_archived(course):
         boolean: "Archived" availability or not
     """
     availability_list = get_course_availability(course)
-    return len(availability_list) == 0 or availability_list[0] == 'Archived'
+    return len(availability_list) == 0 or 'Archived' in availability_list
 
 
 def get_course_partners(course):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -59,7 +59,7 @@ class AlgoliaUtilsTests(TestCase):
         {'expected_result': False, 'is_enrollable': False},
         {'expected_result': False, 'is_marketable': False},
         {'expected_result': True, },
-        {'expected_result': False, 'course_run_availability': None},
+        {'expected_result': True, 'course_run_availability': None},
     )
     @ddt.unpack
     def test_should_index_course(


### PR DESCRIPTION
## Description

- had intended on stamping out Archived courses from the index
- learner portal assumes/requires archived courses
- restore this functionality until we can discuss the issue with those teams

## References

- [ENT-5432](https://openedx.atlassian.net/browse/ENT-5432)
