### PR TITLE
feat: Only index needed image field

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -366,7 +366,7 @@ def get_program_course_details(program):
         mapped_course = {
             'key': course.get('key'),
             'title': course.get('title'),
-            'image': course.get('image'),
+            'image': course.get('image').get('src') if course.get('image') else None,
             'short_description': course.get('short_description'),
         }
         course_list.append(mapped_course)

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -366,7 +366,7 @@ def get_program_course_details(program):
         mapped_course = {
             'key': course.get('key'),
             'title': course.get('title'),
-            'image': course.get('image').get('src') if course.get('image') else None,
+            'image': course.get('image', {}).get('src'),
             'short_description': course.get('short_description'),
         }
         course_list.append(mapped_course)

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -662,11 +662,25 @@ class AlgoliaUtilsTests(TestCase):
 
     @ddt.data(
         (
-            {'courses': [{'key': 'akey', 'title': 'a_title', 'image': {'src': 'an_image'}, 'short_description': 'desc'}]},
+            {
+                'courses': [{
+                    'key': 'akey',
+                    'title': 'a_title',
+                    'image': {'src': 'an_image'},
+                    'short_description': 'desc'
+                }],
+            },
             [{'key': 'akey', 'title': 'a_title', 'image': 'an_image', 'short_description': 'desc'}],
         ),
         (
-            {'courses': [{'key': 'akey', 'title': 'a_title', 'image': {'invalid': 'an_image'}, 'short_description': 'desc'}]},
+            {
+                'courses': [{
+                    'key': 'akey',
+                    'title': 'a_title',
+                    'image': {'invalid': 'an_image'},
+                    'short_description': 'desc',
+                }],
+            },
             [{'key': 'akey', 'title': 'a_title', 'image': None, 'short_description': 'desc'}],
         ),
         (

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -662,8 +662,12 @@ class AlgoliaUtilsTests(TestCase):
 
     @ddt.data(
         (
-            {'courses': [{'key': 'akey', 'title': 'a_title', 'image': 'an_image', 'short_description': 'desc'}]},
+            {'courses': [{'key': 'akey', 'title': 'a_title', 'image': {'src': 'an_image'}, 'short_description': 'desc'}]},
             [{'key': 'akey', 'title': 'a_title', 'image': 'an_image', 'short_description': 'desc'}],
+        ),
+        (
+            {'courses': [{'key': 'akey', 'title': 'a_title', 'image': {'invalid': 'an_image'}, 'short_description': 'desc'}]},
+            [{'key': 'akey', 'title': 'a_title', 'image': None, 'short_description': 'desc'}],
         ),
         (
             {'courses': [{'key': 'akey'}]},


### PR DESCRIPTION
In prior work, I had left this indexing the entire image by mistake, we really don't need it, we need just image.src field in algolia. The frontend epxlore catalog is already written to handle both cases so it's a backward compatible change

We set image: null in case image is not to be found which works fine from the frontend perspecitve too and is accurate wrt representing the absence of an image

Change: don't index entire image field, it's not needed for algolia usage by MFEs right now

ENT-5439

## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
