### PR TITLE
fix: handle when image is None

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -366,7 +366,7 @@ def get_program_course_details(program):
         mapped_course = {
             'key': course.get('key'),
             'title': course.get('title'),
-            'image': course.get('image', {}).get('src'),
+            'image': course.get('image').get('src') if course.get('image') else None,
             'short_description': course.get('short_description'),
         }
         course_list.append(mapped_course)

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -695,6 +695,10 @@ class AlgoliaUtilsTests(TestCase):
             {'courses': []},
             [],
         ),
+        (
+            {'courses': [{'image': None, 'key': 'akey'}]},
+            [{'key': 'akey', 'image': None, 'short_description': None, 'title': None}],
+        )
     )
     @ddt.unpack
     def test_get_program_course_details(self, program_metadata, expected_details):


### PR DESCRIPTION
Fixes error for image field being None when parsing

ENT-5439

was reported in: https://edx.app.opsgenie.com/alert/detail/e3d5e6e7-21ca-4765-89da-3db8b361199f-1646797192694/details

## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

Squash commits into discrete sets of changes
