### PR TITLE
bug: update content metadata task no longer reconstruct existing content metadata/query relations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG'
+    command: bash -c 'while true; do cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG; sleep 2; done'
     container_name: enterprise.catalog.worker
     depends_on:
       - mysql

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import ddt
 from celery import states
+from django.core.cache import cache
 from django.test import TestCase
 from django_celery_results.models import TaskResult
 
@@ -21,10 +22,15 @@ from enterprise_catalog.apps.catalog.constants import (
     LEARNER_PATHWAY,
     PROGRAM,
 )
-from enterprise_catalog.apps.catalog.models import CatalogQuery, ContentMetadata
+from enterprise_catalog.apps.catalog.models import (
+    CatalogQuery,
+    ContentMetadata,
+    ContentMetadataToQueries,
+)
 from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     ContentMetadataFactory,
+    ContentMetadataToQueriesFactory,
     EnterpriseCatalogFactory,
 )
 from enterprise_catalog.apps.catalog.utils import localized_utcnow
@@ -180,10 +186,19 @@ class UpdateCatalogMetadataTaskTests(TestCase):
     Tests for the `update_catalog_metadata_task`.
     """
 
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-        cls.catalog_query = CatalogQueryFactory()
+    def setUp(self):
+        self.catalog_query = CatalogQueryFactory()
+        super().setUp()
+
+    def tearDown(self):
+        self.catalog_query = None
+        ContentMetadataToQueries.all_objects.all().hard_delete()
+        CatalogQuery.objects.all().delete()
+        ContentMetadata.objects.all().delete()
+
+        # Discovery client may cache results, which will override mocked responses of subsequent tests
+        cache.clear()
+        super().tearDown()
 
     @mock.patch('enterprise_catalog.apps.api.tasks.update_contentmetadata_from_discovery')
     def test_update_catalog_metadata(self, mock_update_data_from_discovery):
@@ -201,6 +216,68 @@ class UpdateCatalogMetadataTaskTests(TestCase):
         bad_id = 412
         tasks.update_catalog_metadata_task.apply(args=(bad_id,))
         mock_update_data_from_discovery.assert_not_called()
+
+    @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient.get_metadata_by_query')
+    def test_update_catalog_metadata_creates_new_records(self, mock_discovery_metadata_by_query):
+        """
+        Assert that when discovery returns a new content record for a particular query, the task will create a new
+        content metadata/query relationship by means of the through table
+        """
+        assert len(ContentMetadataToQueries.all_objects.all()) == 0
+
+        mock_discovery_metadata_by_query.return_value = [
+            {
+                'key': 'test_update_catalog_metadata_creates_new_records',
+                'title': 'idk something new',
+                'content_type': 'courserun',
+            },
+        ]
+
+        tasks.update_catalog_metadata_task.apply(args=(self.catalog_query.id,))
+        assert len(ContentMetadataToQueries.all_objects.all()) == 1
+        assert len(ContentMetadataToQueries.objects.all()) == 1
+
+    @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient.get_metadata_by_query')
+    def test_update_catalog_metadata_deletes_old_records(self, mock_discovery_metadata_by_query):
+        """
+        Assert that when discovery indicates a content record removal for a particular query, the task will remove the
+        content metadata/query relationship by means of the through table
+        """
+
+        assert len(ContentMetadataToQueries.all_objects.all()) == 0
+
+        existing_metadata_query_relationship = ContentMetadataToQueriesFactory(catalog_query=self.catalog_query)
+        mock_discovery_metadata_by_query.return_value = [
+            existing_metadata_query_relationship.content_metadata.json_metadata
+        ]
+        ContentMetadataToQueriesFactory(catalog_query=self.catalog_query)
+
+        assert len(ContentMetadataToQueries.all_objects.all()) == 2
+        assert len(ContentMetadataToQueries.objects.all()) == 2
+
+        tasks.update_catalog_metadata_task.apply(args=(self.catalog_query.id,))
+
+        assert len(ContentMetadataToQueries.all_objects.all()) == 2
+        assert len(ContentMetadataToQueries.objects.all()) == 1
+
+    @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient.get_metadata_by_query')
+    def test_update_catalog_metadata_does_not_recreate_existing_records(self, mock_discovery_metadata_by_query):
+        """
+        Assert that when discovery indicates a content record still exists for a particular query, the task will not
+        remove the content metadata/query relationship
+        """
+        existing_metadata_query_relationship = ContentMetadataToQueriesFactory(catalog_query=self.catalog_query)
+        # The task will remove the extra query not indicated to still exist
+        ContentMetadataToQueriesFactory(catalog_query=self.catalog_query)
+        assert len(ContentMetadataToQueries.all_objects.all()) == 2
+
+        mock_discovery_metadata_by_query.return_value = [
+            existing_metadata_query_relationship.content_metadata.json_metadata
+        ]
+
+        tasks.update_catalog_metadata_task.apply(args=(self.catalog_query.id,))
+        assert len(ContentMetadataToQueries.all_objects.all()) == 2
+        assert len(ContentMetadataToQueries.objects.all()) == 1
 
 
 class FetchMissingCourseMetadataTaskTests(TestCase):

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -705,6 +705,49 @@ def _create_new_content_metadata(nonexisting_metadata_defaults):
     return metadata_list
 
 
+def generate_content_metadata_diff(metadata):
+    """
+    Creates, updates and differentiates content metadata objects.
+
+    Generates two lists of content metadata items, items to delete and items to create, based on a provided list of
+    metadata by comparing provided records with existing ones.
+
+    Arguments:
+        metadata (list): List of content metadata dictionaries.
+
+    Returns:
+        metadata_to_create_list: The list of ContentMetaData that have been created
+        metadata_to_delete_list: The list of ContentMetaData that need to be deleted
+        associated_metadata: Subset list of all existing records out of the metadata items provided
+    """
+    metadata_to_create_list = []
+    associated_metadata = []
+    potential_items_to_delete = {item.content_key: item for item in ContentMetadata.objects.all()}
+    for batched_metadata in batch(metadata, batch_size=100):
+        content_keys = [get_content_key(entry) for entry in batched_metadata]
+        existing_metadata = ContentMetadata.objects.filter(content_key__in=content_keys)
+        existing_metadata_by_key = {metadata.content_key: metadata for metadata in existing_metadata}
+
+        for key in existing_metadata_by_key.keys():
+            potential_items_to_delete.pop(key)
+
+        existing_metadata_defaults, nonexisting_metadata_defaults = _partition_content_metadata_defaults(
+            batched_metadata, existing_metadata_by_key
+        )
+
+        # Update existing ContentMetadata records
+        updated_metadata = _update_existing_content_metadata(existing_metadata_defaults, existing_metadata_by_key)
+        associated_metadata.extend(updated_metadata)
+
+        # Create new ContentMetadata records
+        created_metadata = _create_new_content_metadata(nonexisting_metadata_defaults)
+        metadata_to_create_list.extend(created_metadata)
+        associated_metadata.extend(created_metadata)
+
+    metadata_to_delete_list = list(potential_items_to_delete.values())
+    return metadata_to_create_list, metadata_to_delete_list, associated_metadata
+
+
 def create_content_metadata(metadata):
     """
     Creates or updates a ContentMetadata object.
@@ -747,14 +790,13 @@ def associate_content_metadata_with_query(metadata, catalog_query):
     Returns:
         list: The list of content_keys for the metadata associated with the query.
     """
-    metadata_list = create_content_metadata(metadata)
+    metadata_to_create_list, metadata_to_delete_list, associated_metadata = generate_content_metadata_diff(metadata)
 
-    # Setting `clear=True` will remove all prior relationships between
-    # the CatalogQuery's associated ContentMetadata objects
-    # before setting all new relationships from `metadata_list`.
-    # https://docs.djangoproject.com/en/2.2/ref/models/relations/#django.db.models.fields.related.RelatedManager.set
-    catalog_query.contentmetadata_set.set(metadata_list, clear=True)
-    associated_content_keys = [metadata.content_key for metadata in metadata_list]
+    for item in metadata_to_delete_list:
+        catalog_query.contentmetadata_set.remove(item)
+    for item in metadata_to_create_list:
+        catalog_query.contentmetadata_set.add(item)
+    associated_content_keys = [metadata.content_key for metadata in associated_metadata]
     return associated_content_keys
 
 

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -12,6 +12,7 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     ContentMetadata,
+    ContentMetadataToQueries,
     EnterpriseCatalog,
     EnterpriseCatalogFeatureRole,
     EnterpriseCatalogRoleAssignment,
@@ -116,6 +117,17 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'visible_via_association': True,
             })
         return json_metadata
+
+
+class ContentMetadataToQueriesFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `ContentMetadata` model
+    """
+    catalog_query = factory.SubFactory(CatalogQueryFactory)
+    content_metadata = factory.SubFactory(ContentMetadataFactory)
+
+    class Meta:
+        model = ContentMetadataToQueries
 
 
 class UserFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION

## Description

The update content metadata task now, instead of clearing the entire content metadata/catalog query through table, only creates/removes relationships of new/old data. 

## Ticket Link

Link to the associated ticket
[ENT-5424](https://openedx.atlassian.net/browse/ENT-5424)

## Post-review

Squash commits into discrete sets of changes
