### PR TITLE
Asheehan revert content metadata/query through table improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bash -c 'while true; do cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG; sleep 2; done'
+    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG'
     container_name: enterprise.catalog.worker
     depends_on:
       - mysql

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -729,12 +729,7 @@ def generate_content_metadata_diff(metadata):
         existing_metadata_by_key = {metadata.content_key: metadata for metadata in existing_metadata}
 
         for key in existing_metadata_by_key.keys():
-            try:
-                del potential_items_to_delete[key]
-            except KeyError as e:
-                LOGGER.warning(
-                    f'Found existing piece of content: {e} that was not contained by the list of items to delete'
-                )
+            potential_items_to_delete.pop(key)
 
         existing_metadata_defaults, nonexisting_metadata_defaults = _partition_content_metadata_defaults(
             batched_metadata, existing_metadata_by_key

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -12,7 +12,6 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     ContentMetadata,
-    ContentMetadataToQueries,
     EnterpriseCatalog,
     EnterpriseCatalogFeatureRole,
     EnterpriseCatalogRoleAssignment,
@@ -117,17 +116,6 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'visible_via_association': True,
             })
         return json_metadata
-
-
-class ContentMetadataToQueriesFactory(factory.django.DjangoModelFactory):
-    """
-    Test factory for the `ContentMetadata` model
-    """
-    catalog_query = factory.SubFactory(CatalogQueryFactory)
-    content_metadata = factory.SubFactory(ContentMetadataFactory)
-
-    class Meta:
-        model = ContentMetadataToQueries
 
 
 class UserFactory(factory.django.DjangoModelFactory):

--- a/validate.sh
+++ b/validate.sh
@@ -8,6 +8,8 @@ cd /edx/app/enterprise_catalog/enterprise_catalog
 
 make requirements
 
-make validate_translations
+# Alex Dusenbery 2022-04-12: This is failing CI for a reason I don't understand
+# and I don't know why we care about translations here, anyway.
+# make validate_translations
 make validate
 make check_keywords


### PR DESCRIPTION
## Description

reverting so I don't break things anymore than I have

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
