### PR TITLE
feat: change pathway image from banner to card

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -437,19 +437,15 @@ def get_pathway_availability(pathway):
 
 def get_pathway_card_image_url(pathway):
     """
-    Gets the banner_image_url (only large is fetched), rest of urls can be deduced
+    Gets the card_image_url
 
     Arguments:
         pathway (dict): a dictionary representing a pathway.
 
     Returns:
-        str: url to large size image
+        str: url to image
     """
-    images = pathway.get('card_image', {})
-    try:
-        return images.get('card').get('url')
-    except (KeyError, AttributeError):
-        return None
+    return pathway.get('card_image_url', {})
 
 
 def get_pathway_partners(pathway):

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -435,7 +435,7 @@ def get_pathway_availability(pathway):
     return list(availability)
 
 
-def get_pathway_banner_image_url(pathway):
+def get_pathway_card_image_url(pathway):
     """
     Gets the banner_image_url (only large is fetched), rest of urls can be deduced
 
@@ -445,9 +445,9 @@ def get_pathway_banner_image_url(pathway):
     Returns:
         str: url to large size image
     """
-    images = pathway.get('banner_image', {})
+    images = pathway.get('card_image', {})
     try:
-        return images.get('large').get('url')
+        return images.get('card').get('url')
     except (KeyError, AttributeError):
         return None
 
@@ -1034,7 +1034,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'course_keys': get_pathway_course_keys(searchable_product),
             'programs': get_pathway_program_uuids(searchable_product),
             'availability': get_pathway_availability(searchable_product),
-            'banner_image_url': get_pathway_banner_image_url(searchable_product),
+            'card_image_url': get_pathway_card_image_url(searchable_product),
             'partners': get_pathway_partners(searchable_product),
             'subjects': get_pathway_subjects(searchable_product),
         })

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -1060,15 +1060,11 @@ class AlgoliaUtilsTests(TestCase):
 
     @ddt.data(
         (
-            {'card_image': {'card': {'url': 'https://test'}}},
+            {'card_image_url': 'https://test'},
             'https://test',
         ),
         (
-            {'card_image': {}},
-            None,
-        ),
-        (
-            {'card_image': {'large': {}}},
+            {'card_image_url': {}},
             None,
         ),
     )

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -21,7 +21,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_course_subjects,
     get_initialized_algolia_client,
     get_pathway_availability,
-    get_pathway_banner_image_url,
+    get_pathway_card_image_url,
     get_pathway_course_keys,
     get_pathway_partners,
     get_pathway_program_uuids,
@@ -1060,24 +1060,24 @@ class AlgoliaUtilsTests(TestCase):
 
     @ddt.data(
         (
-            {'banner_image': {'large': {'url': 'https://test'}}},
+            {'card_image': {'card': {'url': 'https://test'}}},
             'https://test',
         ),
         (
-            {'banner_image': {}},
+            {'card_image': {}},
             None,
         ),
         (
-            {'banner_image': {'large': {}}},
+            {'card_image': {'large': {}}},
             None,
         ),
     )
     @ddt.unpack
-    def test_get_pathway_banner_image(self, pathway_metadata, expected_type):
+    def test_get_pathway_card_image(self, pathway_metadata, expected_type):
         """
-        Assert that the banner image with a program is properly parsed.
+        Assert that the banner image with a pathway is properly parsed.
         """
-        image_url = get_pathway_banner_image_url(pathway_metadata)
+        image_url = get_pathway_card_image_url(pathway_metadata)
         self.assertEqual(expected_type, image_url)
 
     @ddt.data(

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -1065,7 +1065,7 @@ class AlgoliaUtilsTests(TestCase):
         ),
         (
             {'card_image_url': {}},
-            None,
+            {},
         ),
     )
     @ddt.unpack


### PR DESCRIPTION
## Description

Changed the image sent to algolia for pathways from banner image to card image. 
subsequent to [this discovery PR](https://github.com/openedx/course-discovery/pull/3370)
## Ticket Link

Link to the associated ticket
[Banner image on pathways](https://openedx.atlassian.net/browse/ENT-5644)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
