### PR TITLE
feat: add course run data to catalog excel export

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -42,6 +42,18 @@ CSV_PROGRAM_HEADERS = [
     'Number of courses',
 ]
 
+CSV_COURSE_RUN_HEADERS = [
+    'Course Run Key',
+    'Pacing',
+    'Availability',
+    'Start Date',
+    'End Date',
+    'Verified Upgrade Deadline',
+    'Min Effort',
+    'Max Effort',
+    'Length',
+]
+
 ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
     'title',
     'key',
@@ -63,6 +75,7 @@ ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
     'program_type',
     'subtitle',
     'course_keys',
+    'course_runs',
 ]
 
 
@@ -157,6 +170,50 @@ def course_hit_to_row(hit):
 
     # Pre-requisites -> prerequisites_raw
     csv_row.append(strip_tags(hit.get('prerequisites_raw', '')))
+
+    return csv_row
+
+
+def course_hit_runs(hit):
+    """
+    Helper function to extract the course runs (list) or return empty list
+    """
+    return hit.get('course_runs', [])
+
+
+def course_run_to_row(course_run):
+    """
+    Helper function to construct a CSV row according for a single course_run.
+    """
+    csv_row = []
+    csv_row.append(course_run.get('key'))
+    csv_row.append(course_run.get('pacing_type'))
+    csv_row.append(course_run.get('availability'))
+
+    start_date = None
+    if course_run.get('start'):
+        start_date = parser.parse(course_run.get('start')).strftime("%Y-%m-%d")
+    csv_row.append(start_date)
+
+    end_date = None
+    if course_run.get('end'):
+        end_date = parser.parse(course_run.get('end')).strftime("%Y-%m-%d")
+    csv_row.append(end_date)
+
+    upgrade_deadline = None
+    if course_run.get('upgrade_deadline'):
+        raw_deadline = course_run.get('upgrade_deadline')
+        upgrade_deadline = datetime.datetime.fromtimestamp(raw_deadline).strftime("%Y-%m-%d")
+    csv_row.append(upgrade_deadline)
+
+    # Min Effort
+    csv_row.append(course_run.get('min_effort'))
+
+    # Max Effort
+    csv_row.append(course_run.get('max_effort'))
+
+    # Length
+    csv_row.append(course_run.get('weeks_to_complete'))
 
     return csv_row
 

--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -81,6 +81,12 @@ ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
 ]
 
 
+def write_headers_to_sheet(worksheet, headers, cell_format):
+    for col_num, cell_data in enumerate(headers):
+        worksheet.set_column(0, col_num, 30)
+        worksheet.write(0, col_num, cell_data, cell_format)
+
+
 def program_hit_to_row(hit):
     """
     Helper function to construct a CSV row according to a single Algolia result program hit.
@@ -238,6 +244,17 @@ def querydict_to_dict(query_dict):
         v = query_dict.getlist(key)
         data[key] = v
     return data
+
+
+def facets_to_query(facets):
+    if facets.get('query'):
+        # comes out as a list, we want the first value string only
+        return facets.pop('query')[0]
+    elif facets.get('q'):
+        # comes out as a list, we want the first value string only
+        return facets.pop('q')[0]
+    else:
+        return ''
 
 
 def get_valid_facets():

--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -43,7 +43,9 @@ CSV_PROGRAM_HEADERS = [
 ]
 
 CSV_COURSE_RUN_HEADERS = [
-    'Course Run Key',
+    'Title',
+    'Key',
+    'Course Short Key',
     'Pacing',
     'Availability',
     'Start Date',
@@ -181,12 +183,14 @@ def course_hit_runs(hit):
     return hit.get('course_runs', [])
 
 
-def course_run_to_row(course_run):
+def course_run_to_row(course_key, course_title, course_run):
     """
     Helper function to construct a CSV row according for a single course_run.
     """
     csv_row = []
+    csv_row.append(course_title)
     csv_row.append(course_run.get('key'))
+    csv_row.append(course_key)
     csv_row.append(course_run.get('pacing_type'))
     csv_row.append(course_run.get('availability'))
 

--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -207,7 +207,7 @@ def course_run_to_row(course_key, course_title, course_run):
 
     start_date = None
     if course_run.get('start'):
-        start_date = parser.parse(course_run.get('start')).strftime()
+        start_date = parser.parse(course_run.get('start')).strftime(DATE_FORMAT)
     csv_row.append(start_date)
 
     end_date = None

--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -80,8 +80,13 @@ ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
     'course_runs',
 ]
 
+DATE_FORMAT = "%Y-%m-%d"
+
 
 def write_headers_to_sheet(worksheet, headers, cell_format):
+    """
+    Helper function to write a given list of strings as a header row in a given worksheet.
+    """
     for col_num, cell_data in enumerate(headers):
         worksheet.set_column(0, col_num, 30)
         worksheet.write(0, col_num, cell_data, cell_format)
@@ -120,18 +125,18 @@ def course_hit_to_row(hit):
     if hit.get('advertised_course_run'):
         start_date = None
         if hit['advertised_course_run'].get('start'):
-            start_date = parser.parse(hit['advertised_course_run']['start']).strftime("%Y-%m-%d")
+            start_date = parser.parse(hit['advertised_course_run']['start']).strftime(DATE_FORMAT)
         csv_row.append(start_date)
 
         end_date = None
         if hit['advertised_course_run'].get('end'):
-            end_date = parser.parse(hit['advertised_course_run']['end']).strftime("%Y-%m-%d")
+            end_date = parser.parse(hit['advertised_course_run']['end']).strftime(DATE_FORMAT)
         csv_row.append(end_date)
 
         upgrade_deadline = None
         if hit['advertised_course_run'].get('upgrade_deadline'):
             raw_deadline = hit['advertised_course_run']['upgrade_deadline']
-            upgrade_deadline = datetime.datetime.fromtimestamp(raw_deadline).strftime("%Y-%m-%d")
+            upgrade_deadline = datetime.datetime.fromtimestamp(raw_deadline).strftime(DATE_FORMAT)
         csv_row.append(upgrade_deadline)
 
         pacing_type = hit['advertised_course_run']['pacing_type']
@@ -191,7 +196,7 @@ def course_hit_runs(hit):
 
 def course_run_to_row(course_key, course_title, course_run):
     """
-    Helper function to construct a CSV row according for a single course_run.
+    Helper function to construct a CSV row corresponding to a single course_run.
     """
     csv_row = []
     csv_row.append(course_title)
@@ -202,18 +207,18 @@ def course_run_to_row(course_key, course_title, course_run):
 
     start_date = None
     if course_run.get('start'):
-        start_date = parser.parse(course_run.get('start')).strftime("%Y-%m-%d")
+        start_date = parser.parse(course_run.get('start')).strftime()
     csv_row.append(start_date)
 
     end_date = None
     if course_run.get('end'):
-        end_date = parser.parse(course_run.get('end')).strftime("%Y-%m-%d")
+        end_date = parser.parse(course_run.get('end')).strftime(DATE_FORMAT)
     csv_row.append(end_date)
 
     upgrade_deadline = None
     if course_run.get('upgrade_deadline'):
         raw_deadline = course_run.get('upgrade_deadline')
-        upgrade_deadline = datetime.datetime.fromtimestamp(raw_deadline).strftime("%Y-%m-%d")
+        upgrade_deadline = datetime.datetime.fromtimestamp(raw_deadline).strftime(DATE_FORMAT)
     csv_row.append(upgrade_deadline)
 
     # Min Effort
@@ -247,6 +252,9 @@ def querydict_to_dict(query_dict):
 
 
 def facets_to_query(facets):
+    """
+    Helper function to extract the search query out of a given set of facet params.
+    """
     if facets.get('query'):
         # comes out as a list, we want the first value string only
         return facets.pop('query')[0]

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -692,6 +692,18 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
             'min_effort': 1,
             'weeks_to_complete': 1,
         },
+        'course_runs': [
+            {
+                'key': 'MITx/18.01.2x/3T2015',
+                'pacing_type': 'instructor_paced',
+                'start': '2015-09-08T00:00:00Z',
+                'end': '2015-09-08T00:00:01Z',
+                'upgrade_deadline': 32503680000.0,
+                'max_effort': 10,
+                'min_effort': 1,
+                'weeks_to_complete': 1,
+            }
+        ],
         'outcome': '<p>learn</p>',
         'prerequisites_raw': '<p>interest</p>',
         'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf8-catalog-query-uuids-0'

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -56,9 +56,25 @@ class CatalogWorkbookView(GenericAPIView):
         # don't allow temp files, for example the Google APP Engine, set the
         # 'in_memory' Workbook() constructor option as shown in the docs.
         workbook = xlsxwriter.Workbook(output)
-        course_worksheet = None
-        program_worksheet = None
-        course_run_worksheet = None
+        header_cell_format = workbook.add_format({'bold': True})
+
+        course_worksheet = workbook.add_worksheet('Courses')
+        # write headers
+        for col_num, cell_data in enumerate(export_utils.CSV_COURSE_HEADERS):
+            course_worksheet.set_column(0, col_num, 30)
+            course_worksheet.write(0, col_num, cell_data, header_cell_format)
+
+        program_worksheet = workbook.add_worksheet('Programs')
+        # write headers
+        for col_num, cell_data in enumerate(export_utils.CSV_PROGRAM_HEADERS):
+            program_worksheet.set_column(0, col_num, 30)
+            program_worksheet.write(0, col_num, cell_data, header_cell_format)
+
+        course_run_worksheet = workbook.add_worksheet('Course Runs')
+        # write headers
+        for col_num, cell_data in enumerate(export_utils.CSV_COURSE_RUN_HEADERS):
+            course_run_worksheet.set_column(0, col_num, 30)
+            course_run_worksheet.write(0, col_num, cell_data, header_cell_format)
 
         algolia_client = get_initialized_algolia_client()
 
@@ -82,52 +98,31 @@ class CatalogWorkbookView(GenericAPIView):
         if len(page['hits']) == 0:
             return Response(f'Error: invalid query: {algoliaQuery} provided.', status=HTTP_400_BAD_REQUEST)
 
-        # start after header row
+        # content row index, starting at 1 which is after header row
         course_row_num = 1
         program_row_num = 1
         course_run_row_num = 1
         while len(page['hits']) > 0:
             for hit in page.get('hits', []):
                 if hit.get('content_type') == 'course':
-                    if not course_worksheet:
-                        course_worksheet = workbook.add_worksheet('Courses')
-                        # write headers
-                        cell_format = workbook.add_format({'bold': True})
-                        for col_num, cell_data in enumerate(export_utils.CSV_COURSE_HEADERS):
-                            course_worksheet.set_column(0, col_num, 30)
-                            course_worksheet.write(0, col_num, cell_data, cell_format)
-
-                    if not course_run_worksheet:
-                        course_run_worksheet = workbook.add_worksheet('Course Runs')
-                        # write headers
-                        cell_format = workbook.add_format({'bold': True})
-                        for col_num, cell_data in enumerate(export_utils.CSV_COURSE_RUN_HEADERS):
-                            course_run_worksheet.set_column(0, col_num, 30)
-                            course_run_worksheet.write(0, col_num, cell_data, cell_format)
-
                     course_row = export_utils.course_hit_to_row(hit)
-                    # Write row data.
+                    # Write course row data.
                     for col_num, cell_data in enumerate(course_row):
                         course_worksheet.write(course_row_num, col_num, cell_data)
                     course_row_num = course_row_num + 1
-
+                    # extract the course title and key for the course_run tab
+                    course_title = hit.get('title')
+                    course_key = hit.get('aggregation_key')
                     for course_run in export_utils.course_hit_runs(hit):
-                        course_run_row = export_utils.course_run_to_row(course_run)
-                        # Write row data.
+                        course_run_row = export_utils.course_run_to_row(course_key, course_title, course_run)
+                        # Write course_run row data.
                         for col_num, cell_data in enumerate(course_run_row):
-                            course_run_worksheet.write(course_row_num, col_num, cell_data)
+                            course_run_worksheet.write(course_run_row_num, col_num, cell_data)
                         course_run_row_num = course_run_row_num + 1
                 if hit.get('content_type') == 'program':
-                    if not program_worksheet:
-                        program_worksheet = workbook.add_worksheet('Programs')
-                        # write headers
-                        cell_format = workbook.add_format({'bold': True})
-                        for col_num, cell_data in enumerate(export_utils.CSV_PROGRAM_HEADERS):
-                            program_worksheet.set_column(0, col_num, 30)
-                            program_worksheet.write(0, col_num, cell_data, cell_format)
-                    row = export_utils.program_hit_to_row(hit)
-                    # Write row data.
-                    for col_num, cell_data in enumerate(row):
+                    program_row = export_utils.program_hit_to_row(hit)
+                    # Write program row data.
+                    for col_num, cell_data in enumerate(program_row):
                         program_worksheet.write(program_row_num, col_num, cell_data)
                     program_row_num = program_row_num + 1
             search_options['page'] = search_options['page'] + 1

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -35,14 +35,7 @@ class CatalogWorkbookView(GenericAPIView):
         GET entry point for the `CatalogWorkbookView`
         """
         facets = export_utils.querydict_to_dict(request.query_params)
-        if facets.get('query'):
-            # comes out as a list, we want the first value string only
-            algoliaQuery = facets.pop('query')[0]
-        elif facets.get('q'):
-            # comes out as a list, we want the first value string only
-            algoliaQuery = facets.pop('q')[0]
-        else:
-            algoliaQuery = ''
+        algoliaQuery = export_utils.facets_to_query(facets)
 
         invalid_facets = export_utils.validate_query_facets(facets)
         if invalid_facets:
@@ -56,25 +49,16 @@ class CatalogWorkbookView(GenericAPIView):
         # don't allow temp files, for example the Google APP Engine, set the
         # 'in_memory' Workbook() constructor option as shown in the docs.
         workbook = xlsxwriter.Workbook(output)
-        header_cell_format = workbook.add_format({'bold': True})
+        header_format = workbook.add_format({'bold': True})
 
         course_worksheet = workbook.add_worksheet('Courses')
-        # write headers
-        for col_num, cell_data in enumerate(export_utils.CSV_COURSE_HEADERS):
-            course_worksheet.set_column(0, col_num, 30)
-            course_worksheet.write(0, col_num, cell_data, header_cell_format)
+        export_utils.write_headers_to_sheet(course_worksheet, export_utils.CSV_COURSE_HEADERS, header_format)
 
         program_worksheet = workbook.add_worksheet('Programs')
-        # write headers
-        for col_num, cell_data in enumerate(export_utils.CSV_PROGRAM_HEADERS):
-            program_worksheet.set_column(0, col_num, 30)
-            program_worksheet.write(0, col_num, cell_data, header_cell_format)
+        export_utils.write_headers_to_sheet(program_worksheet, export_utils.CSV_PROGRAM_HEADERS, header_format)
 
         course_run_worksheet = workbook.add_worksheet('Course Runs')
-        # write headers
-        for col_num, cell_data in enumerate(export_utils.CSV_COURSE_RUN_HEADERS):
-            course_run_worksheet.set_column(0, col_num, 30)
-            course_run_worksheet.write(0, col_num, cell_data, header_cell_format)
+        export_utils.write_headers_to_sheet(course_run_worksheet, export_utils.CSV_COURSE_RUN_HEADERS,header_format)
 
         algolia_client = get_initialized_algolia_client()
 

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -58,7 +58,7 @@ class CatalogWorkbookView(GenericAPIView):
         export_utils.write_headers_to_sheet(program_worksheet, export_utils.CSV_PROGRAM_HEADERS, header_format)
 
         course_run_worksheet = workbook.add_worksheet('Course Runs')
-        export_utils.write_headers_to_sheet(course_run_worksheet, export_utils.CSV_COURSE_RUN_HEADERS,header_format)
+        export_utils.write_headers_to_sheet(course_run_worksheet, export_utils.CSV_COURSE_RUN_HEADERS, header_format)
 
         algolia_client = get_initialized_algolia_client()
 

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -96,15 +96,15 @@ class CatalogWorkbookView(GenericAPIView):
                         for col_num, cell_data in enumerate(export_utils.CSV_COURSE_HEADERS):
                             course_worksheet.set_column(0, col_num, 30)
                             course_worksheet.write(0, col_num, cell_data, cell_format)
-                    
+
                     if not course_run_worksheet:
                         course_run_worksheet = workbook.add_worksheet('Course Runs')
                         # write headers
                         cell_format = workbook.add_format({'bold': True})
                         for col_num, cell_data in enumerate(export_utils.CSV_COURSE_RUN_HEADERS):
                             course_run_worksheet.set_column(0, col_num, 30)
-                            course_run_worksheet.write(0, col_num, cell_data, cell_format) 
-                    
+                            course_run_worksheet.write(0, col_num, cell_data, cell_format)
+
                     course_row = export_utils.course_hit_to_row(hit)
                     # Write row data.
                     for col_num, cell_data in enumerate(course_row):

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -15,6 +15,7 @@ from enterprise_catalog.apps.catalog.constants import (
     PROGRAM_TYPES_MAP,
 )
 from enterprise_catalog.apps.catalog.models import ContentMetadata
+from enterprise_catalog.apps.catalog.utils import localized_utcnow
 
 
 logger = logging.getLogger(__name__)
@@ -932,7 +933,7 @@ def get_course_runs(course):
         this_course_run = _get_course_run(full_course_run)
         if this_course_run.get('end'):
             course_run_end = parser.parse(this_course_run.get('end'))
-            if course_run_end.timestamp() < datetime.datetime.now().timestamp():
+            if course_run_end < localized_utcnow():
                 # skip old course runs
                 continue
         output.append(_get_course_run(full_course_run))

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -17,6 +17,7 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_course_prerequisites,
     get_course_program_titles,
     get_course_program_types,
+    get_course_runs,
     get_course_skill_names,
     get_course_subjects,
     get_initialized_algolia_client,
@@ -49,6 +50,7 @@ from enterprise_catalog.apps.catalog.tests.factories import (
 ADVERTISED_COURSE_RUN_UUID = uuid4()
 FUTURE_COURSE_RUN_UUID_1 = uuid4()
 FUTURE_COURSE_RUN_UUID_2 = uuid4()
+PAST_COURSE_RUN_UUID_1 = uuid4()
 
 
 @ddt.ddt
@@ -266,6 +268,7 @@ class AlgoliaUtilsTests(TestCase):
                     'pacing_type': 'instructor_paced',
                     'start': '2013-10-16T14:00:00Z',
                     'end': '2014-10-16T14:00:00Z',
+                    'availability': 'Current',
                     'min_effort': 10,
                     'max_effort': 14,
                     'weeks_to_complete': 13,
@@ -277,6 +280,7 @@ class AlgoliaUtilsTests(TestCase):
                 'pacing_type': 'instructor_paced',
                 'start': '2013-10-16T14:00:00Z',
                 'end': '2014-10-16T14:00:00Z',
+                'availability': 'Current',
                 'min_effort': 10,
                 'max_effort': 14,
                 'weeks_to_complete': 13,
@@ -300,6 +304,7 @@ class AlgoliaUtilsTests(TestCase):
                     'pacing_type': 'instructor_paced',
                     'start': '2013-10-16T14:00:00Z',
                     'end': '2014-10-16T14:00:00Z',
+                    'availability': 'Current',
                     'min_effort': 10,
                     'max_effort': 14,
                     'weeks_to_complete': 13,
@@ -318,6 +323,7 @@ class AlgoliaUtilsTests(TestCase):
                 'pacing_type': 'instructor_paced',
                 'start': '2013-10-16T14:00:00Z',
                 'end': '2014-10-16T14:00:00Z',
+                'availability': 'Current',
                 'min_effort': 10,
                 'max_effort': 14,
                 'weeks_to_complete': 13,
@@ -332,6 +338,7 @@ class AlgoliaUtilsTests(TestCase):
                     'pacing_type': 'instructor_paced',
                     'start': '2013-10-16T14:00:00Z',
                     'end': '2014-10-16T14:00:00Z',
+                    'availability': 'Current',
                     'min_effort': 10,
                     'max_effort': 14,
                     'weeks_to_complete': 13,
@@ -347,6 +354,7 @@ class AlgoliaUtilsTests(TestCase):
                 'pacing_type': 'instructor_paced',
                 'start': '2013-10-16T14:00:00Z',
                 'end': '2014-10-16T14:00:00Z',
+                'availability': 'Current',
                 'min_effort': 10,
                 'max_effort': 14,
                 'weeks_to_complete': 13,
@@ -405,6 +413,114 @@ class AlgoliaUtilsTests(TestCase):
         Assert get_advertised_course_runs fetches just enough info about advertised course run
         """
         upcoming_course_runs = get_upcoming_course_runs(searchable_course)
+        assert upcoming_course_runs == expected_course_runs
+
+    @ddt.data(
+        (
+            {
+                'course_runs': [
+                    {
+                        'key': 'course-v1:org+course+1T2000',
+                        'uuid': PAST_COURSE_RUN_UUID_1,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'published',
+                        'is_enrollable': False,
+                        'is_marketable': False,
+                        'availability': 'Archived',
+                        'start': "2000-01-04T00:00:00Z",
+                        'end': "2001-12-31T23:59:00Z",
+                        'min_effort': 2,
+                        'max_effort': 6,
+                        'weeks_to_complete': 6,
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': ADVERTISED_COURSE_RUN_UUID,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'availability': 'Current',
+                        'start': "2018-01-04T00:00:00Z",
+                        'end': "3022-12-31T23:59:00Z",
+                        'min_effort': 2,
+                        'max_effort': 6,
+                        'weeks_to_complete': 6,
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T3000',
+                        'uuid': FUTURE_COURSE_RUN_UUID_1,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'availability': 'Upcoming',
+                        'start': "3000-01-04T00:00:00Z",
+                        'end': "3022-12-31T23:59:00Z",
+                        'min_effort': 2,
+                        'max_effort': 6,
+                        'weeks_to_complete': 6,
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T3022',
+                        'uuid': FUTURE_COURSE_RUN_UUID_1,
+                        'pacing_type': 'instructor_paced',
+                        'status': 'unpublished',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'availability': 'Starting Soon',
+                        'start': "3000-01-04T00:00:00Z",
+                        'end': "3022-12-31T23:59:00Z",
+                        'min_effort': 2,
+                        'max_effort': 6,
+                        'weeks_to_complete': 6,
+                    }
+                ],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            [
+                {
+                    'key': 'course-v1:org+course+1T2021',
+                    'pacing_type': 'instructor_paced',
+                    'availability': 'Current',
+                    'start': "2018-01-04T00:00:00Z",
+                    'end': "3022-12-31T23:59:00Z",
+                    'min_effort': 2,
+                    'max_effort': 6,
+                    'weeks_to_complete': 6,
+                    'upgrade_deadline': 32503680000.0
+                },
+                {
+                    'key': 'course-v1:org+course+1T3000',
+                    'pacing_type': 'instructor_paced',
+                    'availability': 'Upcoming',
+                    'start': "3000-01-04T00:00:00Z",
+                    'end': "3022-12-31T23:59:00Z",
+                    'min_effort': 2,
+                    'max_effort': 6,
+                    'weeks_to_complete': 6,
+                    'upgrade_deadline': 32503680000.0
+                },
+                {
+                    'key': 'course-v1:org+course+1T3022',
+                    'pacing_type': 'instructor_paced',
+                    'availability': 'Starting Soon',
+                    'start': "3000-01-04T00:00:00Z",
+                    'end': "3022-12-31T23:59:00Z",
+                    'min_effort': 2,
+                    'max_effort': 6,
+                    'weeks_to_complete': 6,
+                    'upgrade_deadline': 32503680000.0
+                }
+            ],
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_runs(self, searchable_course, expected_course_runs):
+        """
+        Assert get_advertised_course_runs fetches just enough info about advertised course run
+        """
+        upcoming_course_runs = get_course_runs(searchable_course)
         assert upcoming_course_runs == expected_course_runs
 
     @ddt.data(


### PR DESCRIPTION
## Description

- include more course_run content in algolia index
- add a new tab to the catalog export endpoint that shows all current and upcoming/starting-soon course runs

## Testing

- updated some existing CI
- tested locally against a subset of production data
- example output from the local setup: 
<img width="1031" alt="Screen Shot 2022-04-26 at 12 31 03 PM" src="https://user-images.githubusercontent.com/31442/165348694-a7f6826f-df26-4625-ae42-74f1f0020071.png">

## References

- [ENT-5761](https://openedx.atlassian.net/browse/ENT-5761)

## Deploy

- merge, deploy, kick off new algolia index process
- the new indexer and the new tab are in 1 merge
- the new tab will be empty until the new index is populated (an acceptable situation)
