### PR TITLE
fix: add trailing slash to distinct-catalog-queries path

### DIFF
--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -72,8 +72,8 @@ urlpatterns = [
         EnterpriseCatalogRefreshDataFromDiscovery.as_view({'post': 'post'}),
         name='update-enterprise-catalog'
     ),
-    path('distinct-catalog-queries', DistinctCatalogQueriesView.as_view(),
-         name='distinct-catalog-queries',
+    path('distinct-catalog-queries/', DistinctCatalogQueriesView.as_view(),
+         name='distinct-catalog-queries'
          ),
 ]
 


### PR DESCRIPTION
## Description

Add trailing slash in path.

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-5770)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
