### PR TITLE
fix: filter exec-ed/bootcamp data from enterprise catalog service

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -18,6 +18,28 @@ CONTENT_TYPE_CHOICES = [
     (LEARNER_PATHWAY, 'Learner Pathway'),
 ]
 
+# ContentMetadata allow/block lists
+
+# deliberate omissions:
+# 'executive-education'
+# 'executive-education-2u'
+# 'bootcamp-2u'
+# 'empty'
+
+CONTENT_COURSE_TYPE_ALLOW_LIST = [
+    'audit',
+    'professional',
+    'verified-audit',
+    'credit-verified-audit',
+    'masters',
+    'masters-verified-audit',
+    'verified',
+    'spoc-verified-audit',
+    'honor',
+    'verified-honor',
+    'credit-verified-honor',
+]
+
 # ContentFilter field types for validation.
 CONTENT_FILTER_FIELD_TYPES = {
     'key': {'type': list, 'subtype': str},

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -716,7 +716,6 @@ def _should_allow_metadata(metadata_entry):
     Returns:
         bool: If we should save the metadata as a ContentMetaData object
     """
-    entry_content_key = get_content_key(metadata_entry)
     if get_content_type(metadata_entry) != 'course':
         return True
     entry_course_type = metadata_entry.get('course_type')

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -213,3 +213,101 @@ class TestModels(TestCase):
         assert course_cm not in associated_metadata
         assert course_run_cm not in associated_metadata
         assert program_cm in associated_metadata
+
+    @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
+    @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient')
+    def test_contentmetadata_update_from_discovery_ignore_exec_ed(self, mock_client):
+        """
+        update_contentmetadata_from_discovery should update or create ContentMetadata
+        objects from the discovery service /search/all api call.
+        this test should filter out content which does not meet our course_type criteria
+        """
+        # this course SHOULD appear in the catalog we save
+        audit_course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+testX'),
+            ('key', 'edX+testX'),
+            ('title', 'test course'),
+            ('course_type', 'audit'),
+        ])
+        # this course SHOULD NOT appear in the catalog we save
+        exec_ed_course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+testX'),
+            ('key', 'edX+testX'),
+            ('title', 'test course'),
+            ('course_type', 'executive-education-2u'),
+        ])
+        course_run_metadata = OrderedDict([
+            ('aggregation_key', 'courserun:edX+testX'),
+            ('key', 'course-v1:edX+testX+1'),
+            ('title', 'test course run'),
+        ])
+        program_metadata = OrderedDict([
+            ('aggregation_key', 'program:fake-uuid'),
+            ('title', 'test program'),
+            ('uuid', 'fake-uuid'),
+        ])
+        mock_client.return_value.get_metadata_by_query.return_value = [
+            audit_course_metadata,
+            exec_ed_course_metadata,
+            course_run_metadata,
+            program_metadata,
+        ]
+        catalog = factories.EnterpriseCatalogFactory()
+
+        self.assertEqual(ContentMetadata.objects.count(), 0)
+        update_contentmetadata_from_discovery(catalog.catalog_query)
+        mock_client.assert_called_once()
+        self.assertEqual(ContentMetadata.objects.count(), 3)
+
+        associated_metadata = catalog.content_metadata
+
+        # Assert stored content metadata is correct for each type
+        course_cm = ContentMetadata.objects.get(content_key=audit_course_metadata['key'])
+        self.assertEqual(course_cm.content_type, COURSE)
+        self.assertEqual(course_cm.parent_content_key, None)
+        self.assertEqual(course_cm.json_metadata, audit_course_metadata)
+        assert course_cm in associated_metadata
+
+        course_run_cm = ContentMetadata.objects.get(content_key=course_run_metadata['key'])
+        self.assertEqual(course_run_cm.content_type, COURSE_RUN)
+        self.assertEqual(course_run_cm.parent_content_key, audit_course_metadata['key'])
+        self.assertEqual(course_run_cm.json_metadata, course_run_metadata)
+        assert course_run_cm in associated_metadata
+
+        program_cm = ContentMetadata.objects.get(content_key=program_metadata['uuid'])
+        self.assertEqual(program_cm.content_type, PROGRAM)
+        self.assertEqual(program_cm.parent_content_key, None)
+        self.assertEqual(program_cm.json_metadata, program_metadata)
+        assert program_cm in associated_metadata
+
+        # Run again with existing ContentMetadata database objects, temporarily modifying
+        # the json_metadata of the existing course to remove a field that will later be
+        # added. Assert the existing json_metadata field is updated with the correct metadata
+        # to include /search/all fields (e.g., aggregation_key).
+        course_cm = ContentMetadata.objects.get(content_key=audit_course_metadata['key'])
+        course_cm.json_metadata = {
+            'key': audit_course_metadata['key'],
+            'title': audit_course_metadata['title'],
+            'course_type': audit_course_metadata['course_type'],
+        }
+        course_cm.save()
+        update_contentmetadata_from_discovery(catalog.catalog_query)
+        self.assertEqual(ContentMetadata.objects.count(), 3)  # assert all ContentMetadata objects are preserved
+        course_cm = ContentMetadata.objects.get(content_key=audit_course_metadata['key'])
+        # assert json_metadata is updated to include fields plucked from /search/all metadata.
+        self.assertEqual(
+            json.dumps(course_cm.json_metadata, sort_keys=True),
+            json.dumps(audit_course_metadata, sort_keys=True),
+        )
+
+        # Run again and expect that we will unassociate some content metadata
+        # from catalog query while perserving the content metadata objects
+        # themselves.
+        mock_client.return_value.get_metadata_by_query.return_value = [program_metadata]
+        update_contentmetadata_from_discovery(catalog.catalog_query)
+        self.assertEqual(ContentMetadata.objects.count(), 3)
+
+        associated_metadata = catalog.content_metadata
+        assert course_cm not in associated_metadata
+        assert course_run_cm not in associated_metadata
+        assert program_cm in associated_metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -18,3 +18,6 @@ wheel==0.37.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
+
+# Temporary while https://github.com/jazzband/pip-tools/issues/1617 is addressed
+pip<22.1


### PR DESCRIPTION
## Description

New 2u content types like GetSmarter Exec. Ed and Bootcamps have been added to Discovery as `course` content types with new `course_type` values. Enterprise Catalogs haven't had to filter based on `course_type` and so many have started to erroneously include these new content types. As a result, exec ed courses are appearing in enterprise catalogs in the explore catalog, learner portal, and LMS integration synced content. Learners are discovering this content.

This change filters these new courses via an allow-list until we're ready to address them as an enterprise product.

## References

- [ENT-5823](https://2u-internal.atlassian.net/browse/ENT-5823)
