### PR TITLE
fix: filter exec-ed/bootcamp data from enterprise catalog service

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -26,7 +26,7 @@ CONTENT_TYPE_CHOICES = [
 # 'bootcamp-2u'
 # 'empty'
 
-CONTENT_COURSE_TYPE_ALLOW_LIST = [
+CONTENT_COURSE_TYPE_ALLOW_LIST = {
     'audit',
     'professional',
     'verified-audit',
@@ -38,7 +38,7 @@ CONTENT_COURSE_TYPE_ALLOW_LIST = [
     'honor',
     'verified-honor',
     'credit-verified-honor',
-]
+}
 
 # ContentFilter field types for validation.
 CONTENT_FILTER_FIELD_TYPES = {


### PR DESCRIPTION
## Description

- quick follow-on to https://github.com/openedx/enterprise-catalog/pull/448
- improve lookup performance with a set

## References

- [ENT-5823](https://2u-internal.atlassian.net/browse/ENT-5823)
- https://github.com/openedx/enterprise-catalog/pull/448
