### PR TITLE
FC-0001: Add filter by GET params  to enterprise-catalogs

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
@@ -80,6 +80,10 @@ class EnterpriseCatalogCRUDViewSet(BaseViewSet, viewsets.ModelViewSet):
         Returns the queryset corresponding to all catalogs the requesting user has access to.
         """
         all_catalogs = EnterpriseCatalog.objects.all().order_by('created')
+        enterprise_customer = self.request.GET.get('enterprise_customer', False)
+        if enterprise_customer:
+            all_catalogs = all_catalogs.filter(enterprise_uuid=enterprise_customer)
+
         if self.request_action == 'list':
             if not self.admin_accessible_enterprises:
                 return EnterpriseCatalog.objects.none()


### PR DESCRIPTION
(3 of 5) for closes https://github.com/openedx/public-engineering/issues/61
##### Latest: https://github.com/openedx/edx-enterprise/pull/1582

## Description

Due to removal [edx-enterprise](https://github.com/openedx/edx-enterprise/blob/decc608453f733ba53203345de9b0af842d60f3b/enterprise/api/v1/views.py#L1003) endpoints, update the exists endpoint according to the query filter from ecommerce 