### PR TITLE
chore: un-pin django-celery-results, upgrade to 2.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -80,10 +80,8 @@ django==3.2.14
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-celery-results==2.4.0
+    # via -r requirements/base.in
 django-config-models==2.3.0
     # via -r requirements/base.in
 django-cors-headers==3.13.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,9 +17,6 @@ Django>=3.2,<4.0
 # the next major release, ensure the installed version is within boundaries.
 celery>=5.2.2,<6.0.0
 
-# Hard dependency on psycopg2 in version 2.3.0
-django-celery-results<2.3.0
-
 # Inflect 4.0.0 requires python>=3.6
 inflect<4.0.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -178,9 +178,8 @@ django==3.2.14
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
+django-celery-results==2.4.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 django-config-models==2.3.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -138,7 +138,7 @@ django==3.2.14
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
+django-celery-results==2.4.0
     # via -r requirements/test.txt
 django-config-models==2.3.0
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -102,7 +102,7 @@ django==3.2.14
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
+django-celery-results==2.4.0
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -113,7 +113,7 @@ django==3.2.14
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
+django-celery-results==2.4.0
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -126,10 +126,8 @@ distlib==0.3.5
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+django-celery-results==2.4.0
+    # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
 django-cors-headers==3.13.0

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -154,7 +154,7 @@ django==3.2.14
     #   edx-toggles
     #   jsonfield
     #   jsonfield2
-django-celery-results==2.2.0
+django-celery-results==2.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
* Fixes https://github.com/openedx/enterprise-catalog/security/dependabot/31
* Can un-pin because https://github.com/celery/django-celery-results/releases/tag/v2.3.1 removes the
hard dependency on psycopg2.
* https://github.com/celery/django-celery-results/releases/tag/v2.4.0 does the fixing of the sec alert.