### PR TITLE
fix: set CELERY_RESULT_EXTENDED = True

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -325,6 +325,9 @@ CELERY_BROKER_URL = '{}://{}:{}@{}/{}'.format(
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_TASK_IGNORE_RESULT = False
 CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
+# see https://github.com/celery/django-celery-results/issues/326
+# on CELERY_RESULT_EXTENDED
+CELERY_RESULT_EXTENDED = True
 
 # Celery task time limits.
 # Tasks will be asked to quit after 15 minutes...


### PR DESCRIPTION
... so task results persist the name and args of the task.
https://github.com/celery/django-celery-results/issues/326

A recent upgrade to celery results 2.4 made it so none of our task names or args were persisted in the `TaskResult` model.
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
