### PR TITLE
fix: refactor enrollment url creation

### DIFF
--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -65,7 +65,9 @@ class EnterpriseCustomerDetails:
         """
         Return Enterprise Customer last modified datetime or None if unavailable.
         """
-        return parser.parse(self.customer_data.get('modified', None))
+        if modified_value := self.customer_data.get('modified', None):
+            return parser.parse(modified_value)
+        return None
 
 
 def _get_enterprise_customer_data(uuid):

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -58,9 +58,9 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ContentMetadata
 
-    content_key = factory.Sequence(lambda n: f'metadata_item_{n}')
+    content_key = factory.Sequence(lambda n: f'{str(n).zfill(5)}_metadata_item')
     content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM, LEARNER_PATHWAY])
-    parent_content_key = None   # Default to None
+    parent_content_key = None
 
     @factory.lazy_attribute
     def json_metadata(self):
@@ -94,11 +94,15 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
         elif self.content_type == COURSE_RUN:
             json_metadata.update({
                 'content_type': COURSE_RUN,
+                'content_language': 'en-us',
                 'status': 'published',
                 'is_enrollable': True,
                 'is_marketable': True,
+                'availability': 'current',
             })
         elif self.content_type == PROGRAM:
+            # programs in the wild do not have a key
+            json_metadata.pop('key')
             json_metadata.update({
                 'uuid': self.content_key,
                 'content_type': PROGRAM,

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -295,7 +295,10 @@ class TestModels(TestCase):
             INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS=INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS
         ):
             enterprise_catalog = factories.EnterpriseCatalogFactory(enterprise_uuid=enterprise_uuid)
-            content_metadata = factories.ContentMetadataFactory(content_key=content_key)
+            content_metadata = factories.ContentMetadataFactory(
+                content_key=content_key,
+                content_type=COURSE,
+            )
             enterprise_catalog.catalog_query.contentmetadata_set.add(*[content_metadata])
 
             mock_enterprise_api_client.return_value.get_enterprise_customer.return_value = {
@@ -321,11 +324,7 @@ class TestModels(TestCase):
             else:
                 mock_license_manager_client().get_customer_agreement.return_value = None
 
-            content_enrollment_url = enterprise_catalog.get_content_enrollment_url(
-                content_resource=COURSE,
-                content_key=content_key,
-                parent_content_key=None,
-            )
+            content_enrollment_url = enterprise_catalog.get_content_enrollment_url(content_metadata)
 
             if should_direct_to_lp:
                 assert settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL in content_enrollment_url


### PR DESCRIPTION
## Description

Compute the `enrollment_url` field from `ContentMetadata` instances, rather than serializations thereof.  So now we can do this: `enterprise_catalog.get_content_enrollment_url(content_metadata_record)` instead of passing in various field values from a ContentMetadata record.

Why do this?
In the near future, I want to be able to check if a related CatalogQuery allows `exec_ed_2u` types of courses to be present, as a safety mechanism before including an enrollment URL, e.g.
```python
if content_metadata.course_type == 'exec_ed_2u' and not self.catalog_query.allow_exec_ed_2u:
    return None
# ...otherwise compute the enrollment URL
```
Furthermore, it helps clean up the abstraction layer that previously was defined in the serializer's `to_representation` - that method had to know to pluck the resource type, content key, and parent content key out of the content metadata instance. With this change, we can take a catalog instance, pass a content_metadata record into it, and expect an enrollment URL to be returned - without having to know, as the caller, what the various components that determine the enrollment URL are.

FWIW, I verified (via script) that every program content metadata record that currently exists in our production environment has an `enrollment_url` set to null.  This is because program metadata records do not have a `key` field in their JSON metadata.  Therefore, I consider it "safe" to explicitly set to null in the lines: 
```python
elif content_type == PROGRAM:
    json_metadata['enrollment_url'] = None
```
(rather than calling `get_content_enrollment_url()` and expecting a null result, as we do today on the master branch).
## Ticket Link
https://2u-internal.atlassian.net/browse/ENT-6150

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
