### PR TITLE
feat: create enrollment urls for exec ed 2u courses

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -19,6 +19,7 @@ CONTENT_TYPE_CHOICES = [
 ]
 
 EXEC_ED_2U_COURSE_TYPE = 'executive-education-2u'
+EXEC_ED_2U_ENTITLEMENT_MODE = 'paid-executive-education'
 
 # ContentMetadata allow/block lists
 

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -32,7 +32,7 @@ class CatalogQueryFactory(factory.django.DjangoModelFactory):
         model = CatalogQuery
 
     content_filter = factory.Dict({'content_type': factory.Faker('words', nb=3)})
-    title = factory.Faker('word')
+    title = factory.Faker('text')
 
 
 class EnterpriseCatalogFactory(factory.django.DjangoModelFactory):
@@ -43,9 +43,9 @@ class EnterpriseCatalogFactory(factory.django.DjangoModelFactory):
         model = EnterpriseCatalog
 
     uuid = factory.LazyFunction(uuid4)
-    title = factory.Faker('word')
+    title = factory.Faker('text')
     enterprise_uuid = factory.LazyFunction(uuid4)
-    enterprise_name = factory.Faker('word')
+    enterprise_name = factory.Faker('company')
     catalog_query = factory.SubFactory(CatalogQueryFactory)
     enabled_course_modes = json_serialized_course_modes()
     publish_audit_enrollment_urls = False   # Default to False
@@ -140,7 +140,7 @@ class EnterpriseCatalogFeatureRoleFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `EnterpriseCatalogFeatureRole` model.
     """
-    name = factory.Faker('word')
+    name = factory.Faker('text')
 
     class Meta:
         model = EnterpriseCatalogFeatureRole


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6150

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
