### PR TITLE
feat: adding course_type as a facet in algolia

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -69,6 +69,7 @@ ALGOLIA_FIELDS = [
     'banner_image_url',
     'visible_via_association',
     'created',
+    'course_type',
 ]
 
 # default configuration for the index
@@ -105,6 +106,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'original_image_url',
         'marketing_url',
         'enterprise_catalog_query_titles',
+        'course_type',
     ],
     'unretrievableAttributes': [
         'enterprise_catalog_uuids',


### PR DESCRIPTION
## Description

To add exec ed to explore catalog, we need to make sure exec ed courses are faceted

## Ticket Link

Link to the associated ticket
[facet course type](https://2u-internal.atlassian.net/browse/ENT-6379)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
