### PR TITLE
feat: allowing the default catalog view accept a course type facet

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -138,6 +138,21 @@ class EnterpriseCatalogDefaultCatalogResultsTests(APITestMixin):
             'You must provide at least one of the following query parameters: enterprise_catalog_query_titles.'
         ]
 
+    @mock.patch('enterprise_catalog.apps.api.v1.views.default_catalog_results.get_initialized_algolia_client')
+    def test_default_catalog_results_view_works_with_one_and_many_course_types(self, mock_algolia_client):
+        """
+        Test that the default catalog results view rejects requests where the query param course_type is not a list
+        """
+        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        url = self._get_contains_content_base_url()
+        facets = 'enterprise_catalog_query_titles=foo&course_type=course'
+        response = self.client.get(f'{url}?{facets}')
+        assert response.status_code == 200
+
+        facets = 'enterprise_catalog_query_titles=foo&course_type=course&course_type=notcourse'
+        response = self.client.get(f'{url}?{facets}')
+        assert response.status_code == 200
+
 
 @ddt.ddt
 class EnterpriseCatalogCRUDViewSetTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
+++ b/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
@@ -57,11 +57,15 @@ class DefaultCatalogResultsView(GenericAPIView):
         'authoring_organizations',
     ]
 
+    def get_queryset(self, **kwargs):
+        # Since this view does not hit any models, override the queryset
+        pass
+
     @method_decorator(require_at_least_one_query_parameter('enterprise_catalog_query_titles'))
     @action(detail=True)
     def get(self, request, **kwargs):
         """
-        GET entry point for the `CatalogCsvDataView`
+        GET entry point for the `DefaultCatalogResultsView`
         """
         facets = querydict_to_dict(request.query_params)
         invalid_facets = validate_query_facets(facets)
@@ -74,6 +78,10 @@ class DefaultCatalogResultsView(GenericAPIView):
             f'enterprise_catalog_query_titles:{facets.get("enterprise_catalog_query_titles")[0]}',
             f'content_type:{content_type}'
         ]
+
+        if content_type == 'course':
+            if course_types := facets.get("course_type"):
+                catalog_filter.append([f'course_type:{type}' in course_types])
 
         search_options = {
             'facetFilters': catalog_filter,


### PR DESCRIPTION
## Description

the default catalog view needs to be able to distinguish between edx course content and 2u course content. This PR allows for a course_type query param to the view that will filter the algolia search

## Ticket Link

Link to the associated ticket
[Prepare public catalog edx course content for exec ed being added to a la carte](https://2u-internal.atlassian.net/browse/ENT-6418)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
