### PR TITLE
feat: prioritise ranking by association over created timestamp

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -113,8 +113,8 @@ ALGOLIA_INDEX_SETTINGS = {
         'enterprise_customer_uuids',
     ],
     'customRanking': [
-        'asc(created)',
         'asc(visible_via_association)',
+        'asc(created)',
         'desc(recent_enrollment_count)',
     ],
 }


### PR DESCRIPTION
## Description
Some time ago we made changes in the ranking criteria for pathways such that those marked `visible_via_association` False should rank higher than those marked True.

But for a customer we are seeing that it isnt the case, after discovery it is found that `created` timestamp has been given higher priority than `visible_via_association` ranking which was causing issues.

This PR is to shuffle the priorities of both in ranking criteria.

## Ticket Link

Link to the associated ticket
[ENT-6377](https://2u-internal.atlassian.net/browse/ENT-6377)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
