### PR TITLE
feat: deterministic content ordering and HighlightSet card_image_url

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -310,6 +310,7 @@ class HighlightSetSerializer(serializers.ModelSerializer):
             'title',
             'is_published',
             'enterprise_curation',
+            'card_image_url',
             'highlighted_content',
         ]
 
@@ -317,7 +318,7 @@ class HighlightSetSerializer(serializers.ModelSerializer):
         """
         Returns the data for the associated content included in this HighlightSet object.
         """
-        qs = obj.highlighted_content.all()
+        qs = obj.highlighted_content.order_by('created')
         return HighlightedContentSerializer(qs, many=True).data
 
 
@@ -344,8 +345,11 @@ class EnterpriseCurationConfigSerializer(serializers.ModelSerializer):
 
     def get_highlight_sets(self, obj):
         """
-        Returns minimal information around the HighlightSets that
-        exist for the EnterpriseCurationConfig.
+        Returns minimal information around the HighlightSets that exist for the EnterpriseCurationConfig.
+
+        Notes:
+        * Highlighted content UUIDs are sorted by the order in which they were added by the enterprise admin.
+          This may help inform frontend code determine which order to display content.
         """
         catalog_highlight_sets = obj.catalog_highlights.all()
         return [
@@ -353,7 +357,10 @@ class EnterpriseCurationConfigSerializer(serializers.ModelSerializer):
                 'uuid': highlight_set.uuid,
                 'is_published': highlight_set.is_published,
                 'title': highlight_set.title,
-                'highlighted_content_uuids': [item.uuid for item in highlight_set.highlighted_content.all()],
+                'card_image_url': highlight_set.card_image_url,
+                'highlighted_content_uuids': [
+                    item.uuid for item in highlight_set.highlighted_content.order_by('created')
+                ],
             }
             for highlight_set in catalog_highlight_sets
         ]

--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -1,13 +1,16 @@
 """
 Tests for curation-related views.
 """
+import itertools
 import uuid
 
 import ddt
+from faker import Faker
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
+from enterprise_catalog.apps.catalog.constants import COURSE, PROGRAM
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
 )
@@ -18,31 +21,54 @@ from enterprise_catalog.apps.curation.tests.factories import (
 )
 
 
+fake = Faker()
+
+
 class CurationAPITestBase(APITestMixin):
     """
     Provides shared test resource setup between curation-related API test classes.
 
-    Contains boilerplate to create one highlighted content within one highlight set within one curation config.
+    Contains boilerplate to create 5 highlighted content within 1 highlight set within 1 curation config for the default
+    enterprise, and again for another enterprise.
     """
     def setUp(self):
         super().setUp()
 
+        # Since the default behavior of ContentMetadataFactory is to generate ContentMetadata objects for all content
+        # types including ones not supported by Curations/Highlighting feature, we set up a content type generator that
+        # deterministically provides supported content types.
+        supported_content_types = [COURSE, PROGRAM]
+        content_type_generator = (
+            supported_content_types[idx % len(supported_content_types)]
+            for idx in itertools.count()
+        )
+
         # Create the main test objects that the test users should be able to access.
         self.curation_config_one = EnterpriseCurationConfigFactory(enterprise_uuid=self.enterprise_uuid)
         self.highlight_set_one = HighlightSetFactory(enterprise_curation=self.curation_config_one)
-        self.highlighted_content_one = HighlightedContentFactory(
-            catalog_highlight_set=self.highlight_set_one,
-            content_metadata=ContentMetadataFactory(content_key='test-key-1'),
-        )
+        self.card_image_urls_one = [fake.image_url() + '.jpg' for idx in range(5)]
+        self.highlighted_content_metadata_one = [
+            ContentMetadataFactory(card_image_url=url, content_type=next(content_type_generator))
+            for url in self.card_image_urls_one
+        ]
+        self.highlighted_content_list_one = [
+            HighlightedContentFactory(catalog_highlight_set=self.highlight_set_one, content_metadata=cm)
+            for cm in self.highlighted_content_metadata_one
+        ]
 
         # Create an extra EnterpriseCurationConfig corresponding to a different enterprise customer that the default
         # test user should not be able to access.
         self.curation_config_two = EnterpriseCurationConfigFactory(enterprise_uuid=uuid.uuid4())
         self.highlight_set_two = HighlightSetFactory(enterprise_curation=self.curation_config_two)
-        self.highlighted_content_two = HighlightedContentFactory(
-            catalog_highlight_set=self.highlight_set_two,
-            content_metadata=ContentMetadataFactory(content_key='test-key-2'),
-        )
+        self.card_image_urls_two = [fake.image_url() + '.jpg' for idx in range(5)]
+        self.highlighted_content_metadata_two = [
+            ContentMetadataFactory(card_image_url=url, content_type=next(content_type_generator))
+            for url in self.card_image_urls_two
+        ]
+        self.highlighted_content_list_two = [
+            HighlightedContentFactory(catalog_highlight_set=self.highlight_set_two, content_metadata=cm)
+            for cm in self.highlighted_content_metadata_two
+        ]
 
 
 @ddt.ddt
@@ -167,6 +193,33 @@ class EnterpriseCurationConfigReadOnlyViewSetTests(CurationAPITestBase):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['uuid'] == str(self.curation_config_one.uuid)
 
+    def test_content_ordered_by_created(self):
+        """
+        Test that the highlighted content is serialized in the same order as they were added.
+        """
+        url = reverse('api:v1:enterprise-curations-detail', kwargs={'uuid': self.curation_config_one.uuid})
+        self.set_up_catalog_learner()
+
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        highlighted_content_uuids = response.json()['highlight_sets'][0]['highlighted_content_uuids']
+        expected_highlighted_content_uuids = [str(hc.uuid) for hc in self.highlighted_content_list_one]
+        assert highlighted_content_uuids == expected_highlighted_content_uuids
+
+    def test_selected_card_image_url_is_first(self):
+        """
+        Test that the `card_image_url` of the highlight set is that of the first highlighted content.
+
+        This is more of a basic smoke test, since HighlightSetViewSetTests::test_deterministic_card_image() is far more
+        thorough.
+        """
+        url = reverse('api:v1:enterprise-curations-detail', kwargs={'uuid': self.curation_config_one.uuid})
+        self.set_up_catalog_learner()
+
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['highlight_sets'][0]['card_image_url'] == self.card_image_urls_one[0]
+
 
 class EnterpriseCurationConfigViewSetTests(CurationAPITestBase):
     """
@@ -242,6 +295,20 @@ class HighlightSetReadOnlyViewSetTests(CurationAPITestBase):
         assert len(highlight_sets_results) == 1
         assert highlight_sets_results[0]['uuid'] == str(self.highlight_set_one.uuid)
 
+    def test_content_ordered_by_created(self):
+        """
+        Test that the highlighted content is serialized in the same order as they were added.
+        """
+        detail_url = reverse('api:v1:highlight-sets-detail', kwargs={'uuid': self.highlight_set_one.uuid})
+        self.set_up_catalog_learner()
+
+        response = self.client.get(detail_url)
+        assert response.status_code == status.HTTP_200_OK
+        highlighted_content = response.json()['highlighted_content']
+        highlighted_content_keys = [cm['content_key'] for cm in highlighted_content]
+        expected_highlighted_content_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        assert highlighted_content_keys == expected_highlighted_content_keys
+
 
 @ddt.ddt
 class HighlightSetViewSetTests(CurationAPITestBase):
@@ -297,3 +364,71 @@ class HighlightSetViewSetTests(CurationAPITestBase):
         url = reverse('api:v1:highlight-sets-detail', kwargs={'uuid': self.highlight_set_one.uuid})
         response_get = self.client.get(url)
         assert response_get.json()['title'] == 'Patch title'
+
+    def test_deterministic_card_image(self):
+        """
+        Test that the card image is always the earliest still-existing highlighted content added.
+
+        Before removing any content from the highlight set, the selected URL has an original index of 0:
+            0 1 2 3 4
+            ^
+        After removing the second element, the selected URL still has an original index of 0:
+            0 2 3 4
+            ^
+        After removing the first element, the selected URL now has an original index of 2:
+            2 3 4
+            ^
+        After adding an element, the selected URL still has an original index of 2:
+            2 3 4 (new)
+            ^
+        Finally, after removing ALL elements, the selected URL is null (JSON null).
+        """
+        detail_url = reverse('api:v1:highlight-sets-admin-detail', kwargs={'uuid': self.highlight_set_one.uuid})
+        self.set_up_staff()
+
+        response = self.client.get(detail_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['card_image_url'] == self.card_image_urls_one[0]
+
+        # Remove the highlighted content with original index of 1, and check that the selected card_image_url is still
+        # that of original index 0.
+        remove_url = reverse(
+            'api:v1:highlight-sets-admin-remove-content',
+            kwargs={'uuid': self.highlight_set_one.uuid},
+        )
+        response = self.client.post(
+            remove_url, {'content_keys': [self.highlighted_content_list_one[1].content_metadata.content_key]},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        # Sanity check that something was actually removed.
+        assert len(response.json()['highlight_set']['highlighted_content']) == 4
+        assert response.json()['highlight_set']['card_image_url'] == self.card_image_urls_one[0]
+
+        # Remove the highlighted content with original index of 0, and check that the selected card_image_url is updated
+        # to that of original index 2.
+        response = self.client.post(
+            remove_url, {'content_keys': [self.highlighted_content_list_one[0].content_metadata.content_key]},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.json()['highlight_set']['highlighted_content']) == 3
+        assert response.json()['highlight_set']['card_image_url'] == self.card_image_urls_one[2]
+
+        # Adding new content should have no impact to the card_image_url at the HighlightSet level.
+        add_url = reverse(
+            'api:v1:highlight-sets-admin-add-content',
+            kwargs={'uuid': self.highlight_set_one.uuid},
+        )
+        response = self.client.post(
+            add_url, {'content_keys': [self.highlighted_content_list_one[0].content_metadata.content_key]},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.json()['highlight_set']['highlighted_content']) == 4
+        assert response.json()['highlight_set']['card_image_url'] == self.card_image_urls_one[2]
+
+        # Remove ALL content.
+        response = self.client.post(
+            remove_url, {'content_keys': [cm.content_key for cm in self.highlighted_content_metadata_one]},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.json()['highlight_set']['highlighted_content']) == 0
+        assert response.json()['highlight_set']['card_image_url'] is None

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -173,9 +173,9 @@ class EnterpriseCatalogCRUDViewSetTests(APITestMixin):
             'title': 'Test Title',
             'enterprise_customer': self.enterprise_uuid,
             'enterprise_customer_name': self.enterprise_name,
-            'enabled_course_modes': '["verified"]',
+            'enabled_course_modes': ['verified'],
             'publish_audit_enrollment_urls': True,
-            'content_filter': '{"content_type":"course"}',
+            'content_filter': {'content_type': 'course'},
         }
 
     def _assert_correct_new_catalog_data(self, catalog_uuid):
@@ -390,7 +390,7 @@ class EnterpriseCatalogCRUDViewSetTests(APITestMixin):
             'enterprise_customer_name': enterprise_catalog_2.enterprise_name,
             'enabled_course_modes': enterprise_catalog_2.enabled_course_modes,
             'publish_audit_enrollment_urls': enterprise_catalog_2.publish_audit_enrollment_urls,
-            'content_filter': '{"a": "b"}',
+            'content_filter': {"a": "b"},
         }
 
         url = reverse('api:v1:enterprise-catalog-detail', kwargs={'uuid': enterprise_catalog_2.uuid})
@@ -1497,7 +1497,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         self.set_up_invalid_jwt_role()
         self.remove_role_assignments()
         url = self._get_generate_diff_base_url()
-        response = self.client.post(url, content_type='application/json',)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_generate_diff_get_supports_up_to_max_content_keys(self):
@@ -1534,11 +1534,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
 
         self.add_metadata_to_catalog(self.enterprise_catalog, [content])
         url = self._get_generate_diff_base_url()
-        response = self.client.post(
-            url,
-            data=json.dumps({"content_keys": [content.content_key]}),
-            content_type='application/json',
-        )
+        response = self.client.post(url, {"content_keys": [content.content_key]})
         assert response.data.get('items_found')[0].get('date_updated') == content_modified
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
@@ -1559,11 +1555,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
 
         self.add_metadata_to_catalog(self.enterprise_catalog, [content])
         url = self._get_generate_diff_base_url()
-        response = self.client.post(
-            url,
-            data=json.dumps({"content_keys": [content.content_key]}),
-            content_type='application/json',
-        )
+        response = self.client.post(url, {"content_keys": [content.content_key]})
         assert response.data.get('items_found')[0].get('date_updated') == customer_modified
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
@@ -1583,11 +1575,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         self.add_metadata_to_catalog(self.enterprise_catalog, [content])
         url = self._get_generate_diff_base_url()
 
-        response = self.client.post(
-            url,
-            data=json.dumps({"content_keys": [content.content_key]}),
-            content_type='application/json',
-        )
+        response = self.client.post(url, {"content_keys": [content.content_key]})
         assert response.data.get('items_found')[0].get('date_updated') == now
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
@@ -1609,8 +1597,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         url = self._get_generate_diff_base_url()
         response = self.client.post(
             url,
-            data=json.dumps({"content_keys": [content.content_key, content2.content_key, "bad+key", "bad+key2"]}),
-            content_type='application/json',
+            {"content_keys": [content.content_key, content2.content_key, "bad+key", "bad+key2"]},
         )
         assert response.status_code == 200
         response_data = response.data
@@ -1641,7 +1628,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         content = ContentMetadataFactory()
         self.add_metadata_to_catalog(self.enterprise_catalog, [content])
         url = self._get_generate_diff_base_url()
-        response = self.client.post(url, content_type='application/json')
+        response = self.client.post(url)
         assert response.data.get('items_not_included') == [{'content_key': content.content_key}]
         assert not response.data.get('items_not_found')
         assert not response.data.get('items_found')
@@ -1662,11 +1649,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         self.add_metadata_to_catalog(self.enterprise_catalog, [content, content2])
 
         url = self._get_generate_diff_base_url()
-        response = self.client.post(
-            url,
-            data=json.dumps({'content_keys': [content.content_key, content2.content_key]}),
-            content_type='application/json'
-        )
+        response = self.client.post(url, {'content_keys': [content.content_key, content2.content_key]})
         for item in response.data.get('items_found'):
             assert item.get('content_key') in [content.content_key, content2.content_key]
         assert not response.data.get('items_not_found')
@@ -1686,11 +1669,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         key = 'bad+key'
         key2 = 'bad+key2'
         url = self._get_generate_diff_base_url()
-        response = self.client.post(
-            url,
-            data=json.dumps({'content_keys': [key, key2]}),
-            content_type='application/json'
-        )
+        response = self.client.post(url, {'content_keys': [key, key2]})
         for item in response.data.get('items_not_found'):
             assert item in [{'content_key': key}, {'content_key': key2}]
         assert not response.data.get('items_found')
@@ -1866,11 +1845,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         request_json = {
             "content_keys": []
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
         detail = response.get('detail')
         self.assertEqual(detail, 'MISSING: catalog.has_learner_access')
 
@@ -1884,11 +1859,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         request_json = {
             "content_keys": []
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
         detail = response.get('detail')
         self.assertEqual(detail, 'MISSING: catalog.has_learner_access')
 
@@ -1902,11 +1873,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         request_json = {
             "content_keys": []
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
         self.assertEqual(response.get('filtered_content_keys'), [])
 
     def test_filter_content_items_not_in_catalogs(self):
@@ -1922,11 +1889,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         request_json = {
             "content_keys": ['key-not-part-of-catalog']
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
         self.assertEqual(response.get('filtered_content_keys'), [])
 
     def test_filter_content_items_in_catalogs(self):
@@ -1946,11 +1909,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         request_json = {
             "content_keys": [relevent_content_key],
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
         self.assertEqual(response.get('filtered_content_keys'), [relevent_content_key])
 
     def test_filter_content_items_parent_key(self):
@@ -1976,11 +1935,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
         request_json = {
             "content_keys": [parent_content_key],
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
         self.assertEqual(response.get('filtered_content_keys'), [parent_content_key])
 
     def test_filter_content_items_specified_catalogs(self):
@@ -2004,11 +1959,7 @@ class EnterpriseCustomerViewSetTests(APITestMixin):
             "content_keys": [relevant_content_key, content_key_outside_specified_catalog],
             "catalog_uuids": [str(second_catalog.uuid)]
         }
-        response = self.client.post(
-            url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(url, request_json).json()
 
         # response should only contain content keys found in the "second_catalog"
         self.assertEqual(response.get('filtered_content_keys'), [relevant_content_key])
@@ -2054,11 +2005,7 @@ class DistinctCatalogQueriesViewTests(APITestMixin):
                 str(enterprise_catalog_two.uuid),
             ]
         }
-        response = self.client.post(
-            self.url,
-            data=json.dumps(request_json),
-            content_type='application/json',
-        ).json()
+        response = self.client.post(self.url, request_json).json()
 
         if use_different_query:
             assert response['num_distinct_query_ids'] == 2

--- a/enterprise_catalog/apps/api/v1/views/curation/utils.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/utils.py
@@ -34,6 +34,16 @@ def get_enterprise_uuid_from_request_data(request):
 def get_content_keys_from_request_data(request):
     """
     Extracts content keys from the request payload.
+
+    The order of keys are preserved, while duplicates are removed.
+
+    Args:
+        - request (rest_framework.request.Request): The request object containing the request payload.
+
+    Returns:
+        list of str: content keys.
     """
-    content_keys = request.data.get('content_keys', [])
-    return content_keys
+    content_keys_raw = request.data.get('content_keys', [])
+    # set() removes duplicates but does not preserve order, so we must synchronize the order again with the original
+    # list based on the FIRST occurrence of each element in the original list.
+    return sorted(set(content_keys_raw), key=lambda x: content_keys_raw.index(x))

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import factory
 from factory.fuzzy import FuzzyText
+from faker import Faker
 
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
@@ -22,10 +23,11 @@ from enterprise_catalog.apps.core.models import User
 
 
 USER_PASSWORD = 'password'
-FAKE_IMAGE_URL = 'https://fake.url/image.jpg'
 FAKE_ADVERTISED_COURSE_RUN_UUID = uuid4()
 FAKE_CONTENT_AUTHOR_NAME = 'Partner Name'
 FAKE_CONTENT_AUTHOR_UUID = uuid4()
+
+fake = Faker()
 
 
 class CatalogQueryFactory(factory.django.DjangoModelFactory):
@@ -61,6 +63,10 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
     """
     class Meta:
         model = ContentMetadata
+        exclude = ('card_image_url_prefix', 'card_image_url')
+
+    card_image_url_prefix = factory.Faker('image_url')
+    card_image_url = factory.LazyAttribute(lambda p: f'{p.card_image_url_prefix}.jpg')
 
     content_key = factory.Sequence(lambda n: f'{str(n).zfill(5)}_metadata_item')
     content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM, LEARNER_PATHWAY])
@@ -77,7 +83,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
             owners = [{
                 'uuid': str(FAKE_CONTENT_AUTHOR_UUID),
                 'name': FAKE_CONTENT_AUTHOR_NAME,
-                'logo_image_url': FAKE_IMAGE_URL,
+                'logo_image_url': fake.image_url() + '.jpg',
             }]
             course_runs = [{
                 'key': 'course-v1:edX+DemoX',
@@ -91,7 +97,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
             json_metadata.update({
                 'content_type': COURSE,
                 'marketing_url': f'https://marketing.url/{self.content_key}',
-                'image_url': FAKE_IMAGE_URL,
+                'image_url': self.card_image_url,
                 'owners': owners,
                 'advertised_course_run_uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
                 'course_runs': course_runs,
@@ -111,7 +117,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
             authoring_organizations = [{
                 'uuid': str(FAKE_CONTENT_AUTHOR_UUID),
                 'name': FAKE_CONTENT_AUTHOR_NAME,
-                'logo_image_url': FAKE_IMAGE_URL,
+                'logo_image_url': self.card_image_url,
             }]
             json_metadata.update({
                 'uuid': self.content_key,

--- a/enterprise_catalog/apps/curation/models.py
+++ b/enterprise_catalog/apps/curation/models.py
@@ -86,6 +86,37 @@ class HighlightSet(TimeStampedModel):
     class Meta:
         app_label = 'curation'
 
+    @property
+    def card_image_url(self):
+        """
+        Returns the card image URL representing this highlight set.
+
+        Notes:
+        * `card_image_url` is derived by using the image of the earliest content added by the enterprise admin.  That
+          way, the image is deterministic, and relatively stable after subsequent modifications of the highlight set
+          selections.  After the initial highlight set creation, the only thing that can change the highlight set card
+          image is removal of the first content added.
+
+        Returns:
+            str: URL of the selected card image.  None if no card image is found.
+        """
+        # In our add_content() view function, multiple requested content keys may be added in the same transaction, but
+        # in practice that still results in distinct `created` values, which means we can still use that field for
+        # sorting without worrying about duplicates.
+        sorted_content = self.highlighted_content.order_by('created')
+
+        # Finally, pick an image.  Ostensibly, it's that of the first highlighted content, but we also want to make sure
+        # that we pick an existing card image.
+        for content in sorted_content:
+            url = content.card_image_url
+            if url:
+                return url
+
+        # At this stage, one of the following must be true:
+        #   * this highlight set does not contain any content, or
+        #   * no content in this highlight set contains a card image.
+        return None
+
 
 class HighlightedContent(TimeStampedModel):
     """
@@ -164,7 +195,7 @@ class HighlightedContent(TimeStampedModel):
         * `COURSERUN` and `LEARNER_PATHWAY` content types are not supported, and result in `None`.
 
         Returns:
-            str: URL of the card image.
+            str: URL of the card image.  None if no card image is found.
         """
         if not self.content_metadata:
             return None

--- a/enterprise_catalog/apps/curation/tests/test_models.py
+++ b/enterprise_catalog/apps/curation/tests/test_models.py
@@ -9,7 +9,6 @@ from enterprise_catalog.apps.catalog.constants import COURSE, PROGRAM
 from enterprise_catalog.apps.catalog.tests.factories import (
     FAKE_CONTENT_AUTHOR_NAME,
     FAKE_CONTENT_AUTHOR_UUID,
-    FAKE_IMAGE_URL,
     ContentMetadataFactory,
 )
 from enterprise_catalog.apps.curation.tests.factories import (
@@ -37,4 +36,5 @@ class TestModels(TestCase):
         authoring_organizations_under_test = highlighted_content.authoring_organizations
         self.assertEqual(authoring_organizations_under_test[0]['uuid'], str(FAKE_CONTENT_AUTHOR_UUID))
         self.assertEqual(authoring_organizations_under_test[0]['name'], FAKE_CONTENT_AUTHOR_NAME)
-        self.assertEqual(authoring_organizations_under_test[0]['logo_image_url'], FAKE_IMAGE_URL)
+        self.assertTrue(authoring_organizations_under_test[0]['logo_image_url'].startswith('https://'))
+        self.assertTrue(authoring_organizations_under_test[0]['logo_image_url'].endswith('.jpg'))

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -130,6 +130,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'PAGE_SIZE': 10,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 # Internationalization


### PR DESCRIPTION
This adds two closely-related features:
* Deterministic content ordering: Anywhere a list of highlighted content is serialized, the ordering of that list always mirrors the order in which they were added to that HighlightSet.
* HighlightSet `card_image_url`: Anywhere a HighlightSet is serialized or summarized, a `card_image_url` field is included and always borrowed from the first content added to that HighlightSet.

ENT-6495

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
