### PR TITLE
feat: add aggregation_key to attributesForFaceting

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -351,7 +351,7 @@ class EnterpriseCurationConfigSerializer(serializers.ModelSerializer):
         * Highlighted content UUIDs are sorted by the order in which they were added by the enterprise admin.
           This may help inform frontend code determine which order to display content.
         """
-        catalog_highlight_sets = obj.catalog_highlights.all()
+        catalog_highlight_sets = obj.catalog_highlights.all().order_by('-created')
         return [
             {
                 'uuid': highlight_set.uuid,

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -110,6 +110,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'enterprise_catalog_query_titles',
         'course_type',
         'course_length',
+        'aggregation_key',
     ],
     'unretrievableAttributes': [
         'enterprise_catalog_uuids',


### PR DESCRIPTION
## Description

Adds `aggregation_key` to the Algolia index configuration's `attributesForFaceting` fields. Necessary as the "Confirm and publish" step of the content highlights creation queries for specific content based on this `aggregation_key` to get the associated metadata for specific content items.

## Ticket Link

N/A

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
