### PR TITLE
fix: make content metadata django admin fields readonly

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -58,8 +58,9 @@ class ContentMetadataAdmin(UnchangeableMixin):
         'content_key',
         'parent_content_key',
     )
-    filter_horizontal = (
+    readonly_fields = (
         'associated_content_metadata',
+        'catalog_queries'
     )
 
 


### PR DESCRIPTION
## Description

Improve load time of the content metadata django admin view by making the `associated_content_metadata` and `catalog_queries` fields readonly

## Ticket Link

https://2u-internal.atlassian.net/browse/ENT-6552

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
