### PR TITLE
feat: Support for adding content while creating highlight set

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -1,18 +1,14 @@
 import logging
 from uuid import UUID
 
+from edx_django_utils.cache import RequestCache
 from edx_rbac.decorators import permission_required
 from edx_rbac.mixins import PermissionRequiredForListingMixin
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
-from rest_framework.status import (
-    HTTP_200_OK,
-    HTTP_201_CREATED,
-    HTTP_400_BAD_REQUEST,
-)
 from rest_framework_xml.renderers import XMLRenderer
 
 from enterprise_catalog.apps.api.v1.pagination import (
@@ -46,7 +42,18 @@ from enterprise_catalog.apps.curation.models import (
 )
 
 
+REQUEST_CACHE_NAMESPACE = 'CURATION_REQUEST_CACHE'
+CONTENT_PER_HIGHLIGHTSET_LIMIT = 12
+HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = 8
 logger = logging.getLogger(__name__)
+
+
+class LimitExceeded(Exception):
+    """
+    Use for any errors related to exceeding backend limits on object creation, such as maximum highlighted content per
+    highlight set.
+    """
+    pass
 
 
 class EnterpriseCurationConfigBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
@@ -133,7 +140,7 @@ class EnterpriseCurationConfigViewSet(EnterpriseCurationConfigBaseViewSet, views
         if not self.requested_enterprise_uuid:
             return Response(
                 f'An enterprise UUID was not specified.',
-                status=HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST
             )
 
         try:
@@ -146,7 +153,7 @@ class EnterpriseCurationConfigViewSet(EnterpriseCurationConfigBaseViewSet, views
         if existing_curation_config_for_enterprise:
             return Response(
                 f'An EnterpriseCurationConfig already exists for enterprise UUID {self.requested_enterprise_uuid}',
-                status=HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST
             )
 
         return super().create(request, *args, **kwargs)
@@ -176,7 +183,25 @@ class HighlightSetBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
 
     @property
     def requested_content_keys(self):
-        return utils.get_content_keys_from_request_data(self.request)
+        """
+        A cached list of content_keys from the `content_keys` attribute of the request body.
+
+        TODO: Ideally, pull this nifty decorator (linked below) into edx-django-util so that more codebases other than
+        edx-platform can use it, including this function which would otherwise be one line.
+        https://github.com/edx/edx-platform/blob/2173a98ef8f5986ce6af9536b0ec2b2b413c818e/openedx/core/lib/cache_utils.py#L19
+        """
+        cache_key = 'requested_content_keys'
+
+        # First, check the cache and return the requested_content_keys if found:
+        request_cache = RequestCache(REQUEST_CACHE_NAMESPACE)
+        cached_response = request_cache.get_cached_response(cache_key)
+        if cached_response.is_found:
+            return cached_response.value
+
+        # Cache miss, so we need to calculate the requested_content_keys and store it:
+        requested_content_keys = utils.get_content_keys_from_request_data(self.request)
+        request_cache.set(cache_key, requested_content_keys)
+        return requested_content_keys
 
     def get_permission_object(self):
         """
@@ -237,20 +262,95 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         the requested enterprise UUID.
         """
         try:
-            existing_curation_config_for_enterprise = EnterpriseCurationConfig.objects.get(enterprise_uuid=self.requested_enterprise_uuid)
+            existing_curation_config_for_enterprise = EnterpriseCurationConfig.objects.get(
+                enterprise_uuid=self.requested_enterprise_uuid
+            )
         except EnterpriseCurationConfig.DoesNotExist:
             existing_curation_config_for_enterprise = None
 
         return existing_curation_config_for_enterprise
 
+    def _add_requested_content(self, highlight_set):
+        """
+        Helper function to add requested content to the given highlight set.
+
+        Arguments:
+            highlight_set (HighlightSet model instance): The highlight set to attempt to add content to.
+
+        Returns:
+            3-tuple of lists of str: Each tuple element represents "added", "ignored", and "existing" content_keys.
+            Requested content keys are bucketed into one of those three lists.  "Ignored" content_keys are ones that
+            don't exist in the catalog, and "existing" content_keys are ones that already exist inside the highlight
+            set.
+
+        Raises:
+            LimitExceeded:
+                If the requested content keys would cause the resulting highlight set to contain more than the maximum
+                allowed content.
+        """
+        # Prepare the 3 output lists that collectively bucket all elements in the requested `content_keys` argument.
+        added_content_keys = []  # requested content_keys that are successfully added as part of handling this request.
+        ignored_content_keys = []  # requested content_keys that do not exist in the catalog.
+        existing_content_keys = []  # requested content_keys that were already added in a previous request.
+
+        # Determine `valid_requested_content_keys_to_add`.  Eventually equivalent to the union of `added_content_keys`
+        # and `existing_content_keys`.  I.e. These are content_keys which are valid options to add to a highlight set.
+        valid_requested_content_to_add = sorted(
+            ContentMetadata.objects.filter(content_key__in=self.requested_content_keys),
+            key=lambda cm: self.requested_content_keys.index(cm.content_key)
+        )
+        valid_requested_content_keys_to_add = [cm.content_key for cm in valid_requested_content_to_add]
+
+        # Store the remainder in `ignored_content_keys`, representing content_keys that we will not even attempt to add.
+        # Use a comprehension instead of set logic so that order is preserved.
+        ignored_content_keys = [k for k in self.requested_content_keys if k not in valid_requested_content_keys_to_add]
+        if ignored_content_keys:
+            logger.warning('The following content_keys were not found: %s', ignored_content_keys)
+
+        # Determine `all_prior_content_keys`, the content_keys already added to the highlight set prior to this request.
+        # I.e. a superset of `existing_content_keys`.
+        all_prior_highlighted_content = (
+            HighlightedContent.objects
+                              .filter(catalog_highlight_set=highlight_set)
+                              .values('content_metadata__content_key')
+        )
+        all_prior_content_keys = [hc['content_metadata__content_key'] for hc in all_prior_highlighted_content]
+
+        # Before actually creating the HighlightedContent objects, validate any limits that we want to impose.
+        proposed_final_count = len(set(all_prior_content_keys).union(valid_requested_content_keys_to_add))
+        if proposed_final_count > CONTENT_PER_HIGHLIGHTSET_LIMIT:
+            raise LimitExceeded(
+                f'Request exceeds the backend maximum content count per highlight set ({CONTENT_PER_HIGHLIGHTSET_LIMIT}).'
+            )
+
+        # Use a loop to create objects one-at-a-time instead of a single bulk create because we currently rely on each
+        # object having sequential and unique `created` timestamps, used for output ordering.
+        for content_metadata_item in valid_requested_content_to_add:
+            __, created = HighlightedContent.objects.get_or_create(
+                catalog_highlight_set=highlight_set,
+                content_metadata=content_metadata_item,
+            )
+            if created:
+                added_content_keys.append(content_metadata_item.content_key)
+            else:
+                existing_content_keys.append(content_metadata_item.content_key)
+
+        return (added_content_keys, ignored_content_keys, existing_content_keys)
+
     def create(self, request, *args, **kwargs):
         """
         Create a new HighlightSet
+
+        Arguments:
+        - `request.data["enterprise_customer"]` (str): UUID of enterprise customer for which to create a highlight set.
+        - `request.data["title"]` (str): Desired title of the highlight set.
+        - `request.data["is_published"]` (bool, optional): True if the highlight set should be published.
+        - `request.data["content_keys"]` (list of str, optional): A list of content keys to add.
         """
         if not self.requested_enterprise_uuid:
             return Response(
                 f'An enterprise UUID was not specified.',
-                status=HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST
             )
 
         curation_config = self._validate_existing_enterprise_curation_config()
@@ -258,11 +358,35 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
             return Response(
                 f'An EnterpriseCurationConfig must exist for enterprise UUID {self.requested_enterprise_uuid} '
                 'in order to create a HighlightSet',
-                status=HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST
             )
         request.data['enterprise_curation'] = str(curation_config.uuid)
 
-        return super().create(request, *args, **kwargs)
+        # Validate that creating this HighlightSet would not cause the maximum number of highlight sets per enterprise
+        # customer to be exceeded.
+        existing_highlightset_count = len(HighlightSet.objects.filter(enterprise_curation=curation_config))
+        if existing_highlightset_count == HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT:
+            return Response(
+                'Request exceeds the backend maximum highlight set per enterprise customer '
+                '({HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT}).',
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        response = super().create(request, *args, **kwargs)
+
+        # If the highlight set is created successfully, we can add requested content to it.
+        if status.is_success(response.status_code) and self.requested_content_keys:
+            highlight_set = HighlightSet.objects.get(uuid=response.data['uuid'])
+            try:
+                added_content_keys, ignored_content_keys, _ = self._add_requested_content(highlight_set)
+            except LimitExceeded as e:
+                return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
+            serializer = self.get_serializer(highlight_set)
+            response_data = serializer.data
+            response_data.update({'ignored_content_keys': ignored_content_keys})
+            return Response(response_data, status=response.status_code, headers=response.headers)
+        else:
+            return response
 
     @action(detail=True, methods=['post'], url_path='add-content')
     def add_content(self, request, uuid, *args, **kwargs):
@@ -273,31 +397,11 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         - `uuid` (str): UUID of the HighlightSet to add content to.
         - `request.data["content_keys"]` (list of str): A list of content keys to add.
         """
-        highlighted_content = []
-        ignored_content_keys = []
-        added_content_keys = []
-        existing_content_keys = []
-        for content_key in self.requested_content_keys:
-            try:
-                content_metadata = ContentMetadata.objects.get(content_key=content_key)
-            except ContentMetadata.DoesNotExist:
-                logger.warning('content_key not found: %s', str(content_key))
-                ignored_content_keys.append(content_key)
-            else:
-                highlighted_content.append(content_metadata)
-
         highlight_set = HighlightSet.objects.get(uuid=uuid)
-
-        for content_metadata_item in highlighted_content:
-            __, created = HighlightedContent.objects.get_or_create(
-                catalog_highlight_set=highlight_set,
-                content_metadata=content_metadata_item,
-            )
-            if created:
-                added_content_keys.append(content_metadata_item.content_key)
-            else:
-                existing_content_keys.append(content_metadata_item.content_key)
-
+        try:
+            added_content_keys, ignored_content_keys, existing_content_keys = self._add_requested_content(highlight_set)
+        except LimitExceeded as e:
+            return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
         return Response(
             {
                 'ignored_content_keys': ignored_content_keys,
@@ -305,7 +409,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                 'existing_content_keys': existing_content_keys,
                 'highlight_set': HighlightSetSerializer(highlight_set).data,
             },
-            status=HTTP_201_CREATED,
+            status=status.HTTP_201_CREATED,
         )
 
     @action(detail=True, methods=['post'], url_path='remove-content')
@@ -336,5 +440,5 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                 'ignored_content_keys': list(set(content_keys).difference(removed_content_keys)),
                 'highlight_set': HighlightSetSerializer(highlight_set).data,
             },
-            status=HTTP_201_CREATED,
+            status=status.HTTP_201_CREATED,
         )

--- a/enterprise_catalog/apps/api/v1/views/curation/utils.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/utils.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from uuid import UUID
 
 from rest_framework.exceptions import ParseError
@@ -38,12 +39,11 @@ def get_content_keys_from_request_data(request):
     The order of keys are preserved, while duplicates are removed.
 
     Args:
-        - request (rest_framework.request.Request): The request object containing the request payload.
+        request (rest_framework.request.Request): The request object containing the request payload.
 
     Returns:
-        list of str: content keys.
+        list of str: content keys, or empty list if the `content_keys` request argument does not exist.
     """
     content_keys_raw = request.data.get('content_keys', [])
-    # set() removes duplicates but does not preserve order, so we must synchronize the order again with the original
-    # list based on the FIRST occurrence of each element in the original list.
-    return sorted(set(content_keys_raw), key=lambda x: content_keys_raw.index(x))
+    # Remove duplicates by converting to an OrderedDict and back to a list (storing/pulling keys only).
+    return list(OrderedDict.fromkeys(content_keys_raw))

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -89,10 +89,10 @@ MIDDLEWARE = (
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'crum.CurrentRequestUserMiddleware',
     'waffle.middleware.WaffleMiddleware',
-
     # Lets simple history track which user made changes via API.  Manual changes via django admin already have the user
     # tracked via SimpleHistoryAdmin.
     'simple_history.middleware.HistoryRequestMiddleware',
+    'edx_django_utils.cache.middleware.RequestCacheMiddleware',
 )
 
 # Enable CORS


### PR DESCRIPTION
Also:
* [limits] Implement hard-coded limits to HighlightSet and HighlightedContent counts.
* [performance] Pull in RequestCache functionality from edx-django-util to cache the requested content_keys and avoid repeated calls to deduplication logic.
* [performance] In one code path, consolidate queries against ContentMetadata form N to 1 query.

ENT-6556