### PR TITLE
fix: expose uuid in algolia fields so clients have access to it

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -37,6 +37,7 @@ ALGOLIA_FIELDS = [
     'enterprise_customer_uuids',
     'full_description',
     'key',  # for links to Course about pages from the Learner Portal search page
+    'uuid',
     'language',
     'level_type',
     'objectID',  # required by Algolia, e.g. "course-{uuid}"


### PR DESCRIPTION
## Description

Exposes the `uuid` field in the indexed Algolia objects so any consuming frontends has access to that field. Without it, there's no way to get at the `content_key` for program/pathway `ContentMetadata` from the Algolia search response itself.

## Ticket Link

N/A

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
