### PR TITLE
feat: adding backoff/retry and logging to DiscoveryAPIClient

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -24,12 +24,14 @@ class DiscoveryApiClient(BaseOAuthClient):
     Object builds an API client to make calls to the Discovery Service.
     """
 
+    # the maximum number of retries to attempt a call
     MAX_RETRIES = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_MAX_RETRIES", 4)
+    # the number of seconds to sleep beteween tries, which is doubled every attempt 
     BACKOFF_FACTOR = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR", 2)
 
     def _calculate_backoff(self, attempt_count):
         """
-        Calcualte the seconds to sleep based on attempt_count
+        Calculate the seconds to sleep based on attempt_count
         """
         return (self.BACKOFF_FACTOR * (2 ** (attempt_count - 1)))
 

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -2,8 +2,10 @@
 Discovery service api client code.
 """
 import logging
+import time
 
 from celery.exceptions import SoftTimeLimitExceeded
+from django.conf import settings
 
 from .base_oauth import BaseOAuthClient
 from .constants import (
@@ -22,18 +24,40 @@ class DiscoveryApiClient(BaseOAuthClient):
     Object builds an API client to make calls to the Discovery Service.
     """
 
+    MAX_RETRIES = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_MAX_RETRIES", 4)
+    BACKOFF_FACTOR = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR", 2)
+
+    def _calculate_backoff(self, attempt_count):
+        """
+        Calcualte the seconds to sleep based on attempt_count
+        """
+        return (self.BACKOFF_FACTOR * (2 ** (attempt_count - 1)))
+
     def _retrieve_metadata_for_content_filter(self, content_filter, page, request_params):
         """
         Makes a request to discovery's /search/all/ endpoint with the specified
         content_filter, page, and request_params
         """
         LOGGER.info('Retrieving results from course-discovery for page %s...', page)
-        response = self.client.post(
-            DISCOVERY_SEARCH_ALL_ENDPOINT,
-            json=content_filter,
-            params=request_params,
-        ).json()
-        return response
+        attempts = 0
+        while True:
+            attempts = attempts + 1
+            response = self.client.post(
+                DISCOVERY_SEARCH_ALL_ENDPOINT,
+                json=content_filter,
+                params=request_params,
+            )
+            if attempts <= self.MAX_RETRIES and response.status_code >= 400:
+                sleep_seconds = self._calculate_backoff(attempts)
+                LOGGER.warning(
+                    f'failed request detected from {DISCOVERY_SEARCH_ALL_ENDPOINT}, '
+                    'backing-off before retrying, '
+                    f'sleeping {sleep_seconds} seconds...'
+                )
+                time.sleep(sleep_seconds)
+            else:
+                break
+        return response.json()
 
     def get_metadata_by_query(self, catalog_query):
         """

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -26,7 +26,7 @@ class DiscoveryApiClient(BaseOAuthClient):
 
     # the maximum number of retries to attempt a call
     MAX_RETRIES = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_MAX_RETRIES", 4)
-    # the number of seconds to sleep beteween tries, which is doubled every attempt 
+    # the number of seconds to sleep beteween tries, which is doubled every attempt
     BACKOFF_FACTOR = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR", 2)
 
     def _calculate_backoff(self, attempt_count):

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -44,9 +44,11 @@ class TestDiscoveryApiClient(TestCase):
 
         catalog_query = CatalogQueryFactory()
         client = DiscoveryApiClient()
+        # setting this to 0 means we wont wait between retries
         client.BACKOFF_FACTOR = 0
 
         client.get_metadata_by_query(catalog_query)
+        # the retry logic will end up calling this 5 times
         assert mock_oauth_client.return_value.post.call_count == 5
 
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -18,6 +18,7 @@ class TestDiscoveryApiClient(TestCase):
         get_metadata_by_query should call discovery endpoint, but not call
         traverse_pagination if traverse_pagination is false.
         """
+        mock_oauth_client.return_value.post.return_value.status_code = 200
         mock_oauth_client.return_value.post.return_value.json.return_value = {
             'results': [{'key': 'fakeX'}],
         }
@@ -30,6 +31,23 @@ class TestDiscoveryApiClient(TestCase):
 
         expected_response = [{'key': 'fakeX'}]
         self.assertEqual(actual_response, expected_response)
+
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_get_metadata_by_query_with_retry_and_error(self, mock_oauth_client):
+        """
+        get_metadata_by_query should call discovery endpoint, but not call
+        traverse_pagination if traverse_pagination is false.
+        """
+
+        mock_oauth_client.return_value.post.return_value.status_code = 400
+        mock_oauth_client.return_value.post.return_value.json.return_value = {}
+
+        catalog_query = CatalogQueryFactory()
+        client = DiscoveryApiClient()
+        client.BACKOFF_FACTOR = 0
+
+        client.get_metadata_by_query(catalog_query)
+        assert mock_oauth_client.return_value.post.call_count == 5
 
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_metadata_by_query_with_error(self, mock_oauth_client):

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -901,8 +901,12 @@ def update_contentmetadata_from_discovery(catalog_query):
         list of str: Returns the content keys that were associated from the query results.
     """
 
-    # metadata will be an empty dict if unavailable from cache or API.
-    metadata = CatalogQueryMetadata(catalog_query).metadata
+    try:
+        # metadata will be an empty dict if unavailable from cache or API.
+        metadata = CatalogQueryMetadata(catalog_query).metadata
+    except Exception as exc:
+        LOGGER.exception('update_contentmetadata_from_discovery ran into an issue while talking to DiscoveryAPI.')
+        raise exc
 
     # associate content metadata with a catalog query only when we get valid results
     # back from the discovery service. if metadata is `None`, an error occurred while


### PR DESCRIPTION
## Description

Update catalog job often generates a bunch of json decode errors which lead us to believe we are overloading the service a bit, leading to non-json error messages (and then parse exceptions). This change adds basic backoff/retry and extra logging to the prime complainer method. It should make the error more recoverable, less likely to happen, and more obvious when it happens.

Cribbed off [prior art in edx-enterprise](https://github.com/edx/edx-enterprise/blob/master/integrated_channels/degreed2/client.py#L436). 
 
## Ticket Link

- [ENT-6546](https://2u-internal.atlassian.net/browse/ENT-6546)
