### PR TITLE
fix: make correct part of string a format string

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -367,8 +367,8 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         existing_highlightset_count = len(HighlightSet.objects.filter(enterprise_curation=curation_config))
         if existing_highlightset_count == HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT:
             return Response(
-                f'Request exceeds the backend maximum highlight set per enterprise customer '
-                '({HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT}).',
+                'Request exceeds the backend maximum highlight set per enterprise customer '
+                f'({HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT}).',
                 status=status.HTTP_400_BAD_REQUEST
             )
 


### PR DESCRIPTION
commit a3ecbfac attempted to make a variable render correctly into a string, however that still failed due to the wrong half of the string being marked as a format string.

Yes, this time I actually tested in devstack first:
![image](https://user-images.githubusercontent.com/85151/206264331-6216babb-6fd1-4ce7-9a79-cb0c9edb176b.png)
