### PR TITLE
fix: changing default catalog results view to work with learning types

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
+++ b/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
@@ -70,18 +70,14 @@ class DefaultCatalogResultsView(GenericAPIView):
         facets = querydict_to_dict(request.query_params)
         invalid_facets = validate_query_facets(facets)
 
-        content_type = facets.get("content_type", ['course'])[0]
+        learning_type = facets.get("learning_type", ['course'])[0]
         if invalid_facets:
             return Response({'Error': f'invalid facet(s): {invalid_facets} provided.'}, status=HTTP_400_BAD_REQUEST)
 
         catalog_filter = [
             f'enterprise_catalog_query_titles:{facets.get("enterprise_catalog_query_titles")[0]}',
-            f'content_type:{content_type}'
+            f'learning_type:{learning_type}'
         ]
-
-        if content_type == 'course':
-            if course_types := facets.get("course_type"):
-                catalog_filter.append([f'course_type:{type}' for type in course_types])
 
         search_options = {
             'facetFilters': catalog_filter,


### PR DESCRIPTION
related PR: https://github.com/openedx/frontend-app-enterprise-public-catalog/pull/268

## Description

default catalog results view is going to be deprecated in a fast follow to the exec ed introduction to the public catalog epic. However until then, we need to make sure this view works with the newly minted `learning_type` facet.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
