### PR TITLE
fix: limit exceeded errors should be 403

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -412,7 +412,7 @@ class HighlightSetViewSetTests(CurationAPITestBase):
             assert response.status_code == status.HTTP_201_CREATED
         # Create one more HighlightSet that should trigger an error.
         response = self.client.post(url, post_data)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_create_add_content(self):
         """
@@ -502,7 +502,7 @@ class HighlightSetViewSetTests(CurationAPITestBase):
             'content_keys': [last_content_metadata_to_request.content_key],
         }
         response = self.client.post(url, post_data)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
         # Finally, make sure the total count of content still does not exceed the max.
         detail_url = reverse('api:v1:highlight-sets-admin-detail', kwargs={'uuid': self.highlight_set_one.uuid})

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -369,7 +369,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
             return Response(
                 'Request exceeds the backend maximum highlight set per enterprise customer '
                 f'({HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT}).',
-                status=status.HTTP_400_BAD_REQUEST
+                status=status.HTTP_403_FORBIDDEN
             )
 
         response = super().create(request, *args, **kwargs)
@@ -401,7 +401,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         try:
             added_content_keys, ignored_content_keys, existing_content_keys = self._add_requested_content(highlight_set)
         except LimitExceeded as e:
-            return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
+            return Response(str(e), status=status.HTTP_403_FORBIDDEN)
         return Response(
             {
                 'ignored_content_keys': ignored_content_keys,


### PR DESCRIPTION
Examples given for 400 include things like malformed requests and invalid formatting, whereas 403 explicitly means that the request was fully understood by the server but the server still refuses to take action.  Therefore, 403 is a better fit for limit exceeded errors.

ENT-6556

Manually tested in devstack.