### PR TITLE
fix: track app was not being initialized

### DIFF
--- a/enterprise_catalog/apps/track/apps.py
+++ b/enterprise_catalog/apps/track/apps.py
@@ -15,8 +15,7 @@ class TrackConfig(AppConfig):
     """
     Application Configuration for the track app.
     """
-    name = 'track'
-    default = False
+    name = 'enterprise_catalog.apps.track'
 
     def ready(self):
         """


### PR DESCRIPTION
The track app was not being initialized due to the `default` AppConfig parameter being set to `False`.  Unsetting the `default` parameter fixes the problem.  There is only one AppConfig subclass in this apps.py file, so the parameter serves no purpose, AFAIK.

more info:
https://docs.djangoproject.com/en/4.1/ref/applications/#django.apps.AppConfig.default

Bug discovered on Stage, reproduced in devstack, then the fix tested in devstack.  Unfortunately, there's no way to unit test this case because the app initialization code paths live outside of the django unit test framework.