### PR TITLE
fix: formatting registration date in the csv download endpoint

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
@@ -15,3 +15,16 @@ class ExportUtilsTests(TestCase):
         """
         # assert that ALGOLIA_ATTRIBUTES_TO_RETRIEVE is a SUBSET of ALGOLIA_FIELDS
         assert set(export_utils.ALGOLIA_ATTRIBUTES_TO_RETRIEVE) <= set(algolia_utils.ALGOLIA_FIELDS)
+
+    def test_fetch_and_format_registration_date(self):
+        """
+        Test the export properly fetches executive education registration dates
+        """
+        # expected hit format from algolia, porperly reformatted for csv download
+        assert export_utils.fetch_and_format_registration_date(
+            {'registration_deadline': '2002-02-15T12:12:200'}
+        ) == '02-15-2002'
+        # some other format from algolia, should return None
+        assert export_utils.fetch_and_format_registration_date(
+            {'registration_deadline': '02-15-2015T12:12:200'}
+        ) is None


### PR DESCRIPTION

## Description

registration date needs to be formatted m-d-y and placed after end date

## Ticket Link

Link to the associated ticket
https://2u-internal.atlassian.net/browse/ENT-6676

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
