### PR TITLE
fix: making update_content_metadata task honor the force kwarg

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -776,7 +776,7 @@ def update_catalog_metadata_task(self, catalog_query_id, force=False):  # pylint
 
 @shared_task(base=LoggedTaskWithRetry, bind=True)
 @expiring_task_semaphore()
-def fetch_missing_course_metadata_task(self):  # pylint: disable=unused-argument
+def fetch_missing_course_metadata_task(self, force=False):  # pylint: disable=unused-argument
     """
     Creates a CatalogQuery for all the courses that do not have ContentMetadata instance.
 
@@ -820,7 +820,7 @@ def fetch_missing_course_metadata_task(self):  # pylint: disable=unused-argument
 
 @shared_task(base=LoggedTaskWithRetry, bind=True)
 @expiring_task_semaphore()
-def fetch_missing_pathway_metadata_task(self):  # pylint: disable=unused-argument
+def fetch_missing_pathway_metadata_task(sel, force=False):  # pylint: disable=unused-argument
     """
     Creates ContentMetadata for Learner Pathways and all its associates.
 

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -32,19 +32,19 @@ class Command(BaseCommand):
         logger.info(message, catalog_query)
         return update_catalog_metadata_task.s(catalog_query.id, force=force)
 
-    def _fetch_missing_course_metadata_task(self):
+    def _fetch_missing_course_metadata_task(self, force=False):
         logger.info(
             'Spinning off fetch_missing_course_metadata_task from update_content_metadata command'
             ' to update content_metadata of missing courses.'
         )
-        return fetch_missing_course_metadata_task.si()
+        return fetch_missing_course_metadata_task.si(force=force)
 
-    def _fetch_missing_pathway_metadata_task(self):
+    def _fetch_missing_pathway_metadata_task(self, force=False):
         logger.info(
             'Spinning off fetch_missing_pathway_metadata_task from update_content_metadata command'
             ' to update content_metadata of missing pathways.'
         )
-        return fetch_missing_pathway_metadata_task.si()
+        return fetch_missing_pathway_metadata_task.si(force=force)
 
     def _update_full_content_metadata_task(self, *args, **kwargs):
         """
@@ -83,13 +83,13 @@ class Command(BaseCommand):
         options.update(CatalogUpdateCommandConfig.current_options())
 
         # Fetch program metadata for the programs that are missing.
-        self._fetch_missing_pathway_metadata_task().apply_async().get(
+        self._fetch_missing_pathway_metadata_task(force=options['force']).apply_async().get(
             timeout=TASK_TIMEOUT,
             propagate=True,
         )
 
         # Fetch course metadata for the courses that are missing.
-        self._fetch_missing_course_metadata_task().apply_async().get(
+        self._fetch_missing_course_metadata_task(force=options['force']).apply_async().get(
             timeout=TASK_TIMEOUT,
             propagate=True,
         )


### PR DESCRIPTION
## Description

the force kwarg supplied by the admin config is not being applied to all asynchronous tasks being invoked by update_content_metadata management command.