### PR TITLE
fix: pin the pip-tools version to 6.6.2

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -403,7 +403,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.5.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
 platformdirs==2.4.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.5.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION

## Description

The pip-tools version currently used breaks with the error `ImportError: cannot import name 'BAR_TYPES' from 'pip._internal.cli.progress_bars'` during the deployment. This is fixed in the version 6.6.2 as reported in https://github.com/jazzband/pip-tools/issues/1617.

So, this commit pins the pip-tools version to 6.6.2 for the `open-release/nutmeg.master`

## Ticket Link

NA

### Similar fixes

* https://github.com/openedx/xblock-lti-consumer/pull/255
* https://github.com/openedx/edx-ora2/pull/1862
* https://github.com/openedx/super-csv/pull/105

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
