### PR TITLE
chore: adding placeholder learning type facet to phase out non-human readable exec ed learning type

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -820,7 +820,7 @@ def fetch_missing_course_metadata_task(self, force=False):  # pylint: disable=un
 
 @shared_task(base=LoggedTaskWithRetry, bind=True)
 @expiring_task_semaphore()
-def fetch_missing_pathway_metadata_task(sel, force=False):  # pylint: disable=unused-argument
+def fetch_missing_pathway_metadata_task(self, force=False):  # pylint: disable=unused-argument
     """
     Creates ContentMetadata for Learner Pathways and all its associates.
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -11,6 +11,7 @@ from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     EXEC_ED_2U_COURSE_TYPE,
+    EXEC_ED_2U_READABLE_COURSE_TYPE,
     LEARNER_PATHWAY,
     PROGRAM,
     PROGRAM_TYPES_MAP,
@@ -1073,6 +1074,16 @@ def get_learning_type(content):
     return content.get('content_type')
 
 
+def get_learning_type_v2(content):
+    """
+    Placeholder learning type value used while switching exec ed learning type
+    to a readable value
+    """
+    if content.get('course_type') == EXEC_ED_2U_COURSE_TYPE:
+        return EXEC_ED_2U_READABLE_COURSE_TYPE
+    return content.get('content_type')
+
+
 def _algolia_object_from_product(product, algolia_fields):
     """
     Transforms a course or program into an Algolia object.
@@ -1105,6 +1116,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'outcome': get_course_outcome(searchable_product),
             'prerequisites': get_course_prerequisites(searchable_product),
             'learning_type': get_learning_type(searchable_product),
+            'learning_type_v2': get_learning_type_v2(searchable_product),
         })
     elif searchable_product.get('content_type') == PROGRAM:
         searchable_product.update({
@@ -1122,6 +1134,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'banner_image_url': get_program_banner_image_url(searchable_product),
             'course_details': get_program_course_details(searchable_product),
             'learning_type': get_learning_type(searchable_product),
+            'learning_type_v2': get_learning_type_v2(searchable_product),
         })
     elif searchable_product.get('content_type') == LEARNER_PATHWAY:
         searchable_product.update({
@@ -1133,6 +1146,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'subjects': get_pathway_subjects(searchable_product),
             'created': get_pathway_created_date(searchable_product),
             'learning_type': get_learning_type(searchable_product),
+            'learning_type_v2': get_learning_type_v2(searchable_product),
         })
 
     algolia_object = {}

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -19,6 +19,7 @@ CONTENT_TYPE_CHOICES = [
 ]
 
 EXEC_ED_2U_COURSE_TYPE = 'executive-education-2u'
+EXEC_ED_2U_READABLE_COURSE_TYPE = 'Executive Education'
 EXEC_ED_2U_ENTITLEMENT_MODE = 'paid-executive-education'
 
 # ContentMetadata allow/block lists


### PR DESCRIPTION

## Ticket Link

https://2u-internal.atlassian.net/browse/ENT-6675

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
