### PR TITLE
feat: better string print out for catalog queries

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -61,8 +61,16 @@ class ContentMetadataAdmin(UnchangeableMixin):
     )
     readonly_fields = (
         'associated_content_metadata',
-        'catalog_queries'
+        'catalog_queries',
+        'get_catalog',
     )
+
+    @admin.display(description='Enterprise Catalogs')
+    def get_catalog(self, obj):
+        catalogs = EnterpriseCatalog.objects.filter(
+            catalog_query_id__in=obj.catalog_queries.all().values_list('id')
+        )
+        return f"{list(catalogs)}"
 
 
 @admin.register(CatalogQuery)

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -125,11 +125,8 @@ class CatalogQuery(TimeStampedModel):
         Return human-readable string representation.
         """
         return (
-            "CatalogQuery with content_filter_hash '{content_filter_hash}' "
-            "and content_filter '{content_filter}'>".format(
-                content_filter_hash=self.content_filter_hash,
-                content_filter=self.pretty_print_content_filter(),
-            )
+            f"<CatalogQuery: ({self.id}) with content_filter_hash '{self.content_filter_hash}' "
+            f"and content_filter '{self.pretty_print_content_filter()}'>"
         )
 
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/67655836/218774362-6811d4ff-83df-44eb-96e0-8df4faead046.png)

context- it's hard to look at and determine what queries and catalogs are attached to which content metadata items in django admin. While this information is available via a few api endpoints I figured it would be helpful to see in the admin view so I added ID to the model's str method and added the list of associated catalogs. Now it's possible to quickly find if a piece of content belongs to both a query or a catalog. 

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
