### PR TITLE
fix: preserving request authentication by passing drf request object 

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -35,10 +35,6 @@ from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     EnterpriseCatalogRoleAssignment,
 )
-from enterprise_catalog.apps.catalog.rules import (
-    enterprises_with_admin_access,
-    has_access_to_all_enterprises,
-)
 from enterprise_catalog.apps.curation.models import (
     EnterpriseCurationConfig,
     HighlightedContent,

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
@@ -35,7 +35,7 @@ class EnterpriseCatalogCRUDViewSet(BaseViewSet, viewsets.ModelViewSet):
         """
         Cached set of enterprise identifiers the requesting user has admin access to.
         """
-        return enterprises_with_admin_access(self.request.user)
+        return enterprises_with_admin_access(self.request)
 
     def get_serializer_class(self):
         request_action = getattr(self, 'action', None)


### PR DESCRIPTION
## Description

the catalog crud view auth validation helper method was using crum to retrieve the request object which lacked the necessary attrs for the `edx_rest_framework_extensions` library to verify the request's authentication. I've opted instead to pass the request object directly to the helper method from the django view.

## Ticket Link

Link to the associated ticket
https://2u-internal.atlassian.net/browse/ENT-3995
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
