### PR TITLE
fix: blocking emeritus product source

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -44,6 +44,14 @@ CONTENT_COURSE_TYPE_ALLOW_LIST = {
     'credit-verified-honor',
 }
 
+# deliberate omissions:
+# 'emeritus'
+
+CONTENT_PRODUCT_SOURCE_ALLOW_LIST = {
+    '2u',
+    'edX',
+}
+
 # ContentFilter field types for validation.
 CONTENT_FILTER_FIELD_TYPES = {
     'key': {'type': list, 'subtype': str},

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -721,6 +721,14 @@ def _create_new_content_metadata(nonexisting_metadata_defaults):
     return metadata_list
 
 
+def _fetch_product_source(metadata_entry):
+    product_source = metadata_entry.get('product_source')
+    if isinstance(product_source, dict):
+        return product_source.get('slug')
+    else:
+        return product_source
+
+
 def _should_allow_metadata(metadata_entry, catalog_query=None):
     """
     Determines if an object from Discovery meets our criteria for indexing
@@ -731,11 +739,11 @@ def _should_allow_metadata(metadata_entry, catalog_query=None):
     Returns:
         bool: If we should save the metadata as a ContentMetaData object
     """
-    # make sure to exclude exec ed course runs
-    content_type = get_content_type(metadata_entry)
-    entry_product_source = metadata_entry.get('product_source')
+    entry_product_source = _fetch_product_source(metadata_entry)
     if entry_product_source not in CONTENT_PRODUCT_SOURCE_ALLOW_LIST and entry_product_source is not None:
         return False
+    # make sure to exclude exec ed course runs
+    content_type = get_content_type(metadata_entry)
     if not catalog_query or not catalog_query.include_exec_ed_2u_courses:
         if content_type == 'courserun':
             if seat_types := metadata_entry.get('seat_types'):

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -29,6 +29,7 @@ from enterprise_catalog.apps.api_client.enterprise_cache import (
 from enterprise_catalog.apps.catalog.constants import (
     ACCESS_TO_ALL_ENTERPRISES_TOKEN,
     CONTENT_COURSE_TYPE_ALLOW_LIST,
+    CONTENT_PRODUCT_SOURCE_ALLOW_LIST,
     CONTENT_TYPE_CHOICES,
     COURSE,
     COURSE_RUN,
@@ -732,13 +733,15 @@ def _should_allow_metadata(metadata_entry, catalog_query=None):
     """
     # make sure to exclude exec ed course runs
     content_type = get_content_type(metadata_entry)
+    entry_product_source = metadata_entry.get('product_source')
+    if entry_product_source not in CONTENT_PRODUCT_SOURCE_ALLOW_LIST and entry_product_source is not None:
+        return False
     if not catalog_query or not catalog_query.include_exec_ed_2u_courses:
         if content_type == 'courserun':
             if seat_types := metadata_entry.get('seat_types'):
                 for seat_type in seat_types:
                     if 'executive-education' in seat_type:
                         return False
-
     if content_type != 'course':
         return True
     entry_course_type = metadata_entry.get('course_type')

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -114,16 +114,23 @@ class TestModels(TestCase):
             ('title', 'test course 3'),
             ('product_source', 'emeritus'),
         ])
+        null_source_course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+nullSourceX'),
+            ('key', 'edX+nullSourceX'),
+            ('title', 'test course 4'),
+            ('product_source', None),
+        ])
         mock_client.return_value.get_metadata_by_query.return_value = [
             edx_course_metadata,
             twou_course_metadata,
             emeritus_course_metadata,
+            null_source_course_metadata,
         ]
         catalog = factories.EnterpriseCatalogFactory()
         self.assertEqual(ContentMetadata.objects.count(), 0)
         update_contentmetadata_from_discovery(catalog.catalog_query)
         mock_client.assert_called_once()
-        self.assertEqual(ContentMetadata.objects.count(), 2)
+        self.assertEqual(ContentMetadata.objects.count(), 3)
 
     @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
     @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient')

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -87,6 +87,42 @@ class TestModels(TestCase):
 
     @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
     @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient')
+    def test_product_source_content_inclusion_logic(self, mock_client):
+        """
+        Test that we exclude 2u exec ed courses from the create content metadata task unless the query provided allows
+        for it
+        """
+        edx_course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+edxSourceX'),
+            ('key', 'edX+edxSourceX'),
+            ('title', 'test course'),
+            ('product_source', 'edX'),
+        ])
+        twou_course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+2uSourceX'),
+            ('key', 'edX+2uSourceX'),
+            ('title', 'test course 2'),
+            ('product_source', '2u'),
+        ])
+        emeritus_course_metadata = OrderedDict([
+            ('aggregation_key', 'course:edX+emeritusSourceX'),
+            ('key', 'edX+emeritusSourceX'),
+            ('title', 'test course 3'),
+            ('product_source', 'emeritus'),
+        ])
+        mock_client.return_value.get_metadata_by_query.return_value = [
+            edx_course_metadata,
+            twou_course_metadata,
+            emeritus_course_metadata,
+        ]
+        catalog = factories.EnterpriseCatalogFactory()
+        self.assertEqual(ContentMetadata.objects.count(), 0)
+        update_contentmetadata_from_discovery(catalog.catalog_query)
+        mock_client.assert_called_once()
+        self.assertEqual(ContentMetadata.objects.count(), 2)
+
+    @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
+    @mock.patch('enterprise_catalog.apps.api_client.discovery_cache.DiscoveryApiClient')
     def test_contentmetadata_update_from_discovery(self, mock_client):
         """
         update_contentmetadata_from_discovery should update or create ContentMetadata

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -102,7 +102,11 @@ class TestModels(TestCase):
             ('aggregation_key', 'course:edX+2uSourceX'),
             ('key', 'edX+2uSourceX'),
             ('title', 'test course 2'),
-            ('product_source', '2u'),
+            ('product_source', OrderedDict(
+                [('name', '2u'),
+                 ('slug', '2u'),
+                 ('description', '2U, Trilogy, Getsmarter -- external source for 2u courses and programs')]
+            )),
         ])
         emeritus_course_metadata = OrderedDict([
             ('aggregation_key', 'course:edX+emeritusSourceX'),


### PR DESCRIPTION
## Description

Adding in the allowed values for the new `product_source` field, purposefully excluding Emeritus courses. 

## Ticket Link

Link to the associated ticket
[ENT-6785](https://2u-internal.atlassian.net/browse/ENT-6785)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
