### PR TITLE
fix: make product_source check case insensitive

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -49,7 +49,7 @@ CONTENT_COURSE_TYPE_ALLOW_LIST = {
 
 CONTENT_PRODUCT_SOURCE_ALLOW_LIST = {
     '2u',
-    'edX',
+    'edx',
 }
 
 # ContentFilter field types for validation.

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -755,7 +755,7 @@ def _should_allow_metadata(metadata_entry, catalog_query=None):
         bool: If we should save the metadata as a ContentMetaData object
     """
     entry_product_source = _fetch_product_source(metadata_entry)
-    if entry_product_source not in CONTENT_PRODUCT_SOURCE_ALLOW_LIST and entry_product_source is not None:
+    if entry_product_source is not None and entry_product_source.lower() not in CONTENT_PRODUCT_SOURCE_ALLOW_LIST:
         return False
     # make sure to exclude exec ed course runs
     content_type = get_content_type(metadata_entry)


### PR DESCRIPTION
## Description

Making the product_source check to include/exclude courses case-insensitive, as the data in discovery appears to vary between mixed case and lowercase.

## Ticket Link

https://2u-internal.atlassian.net/browse/ENT-6918

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
