### PR TITLE
feat: standardizing product source format across serialized metadata

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -229,6 +229,12 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
         marketing_url = json_metadata.get('marketing_url')
         content_key = json_metadata.get('key')
 
+        # Currently (3/17/23) product source can potentially be two different formats, string and dict.
+        # For the purposes of the metadata serializer, we will standardize and default to the dict format.
+        if product_source := json_metadata.get('product_source'):
+            if isinstance(product_source, str):
+                json_metadata['product_source'] = {'name': product_source, 'slug': None, 'description': None}
+
         # The enrollment URL field of content metadata is generated on request and is determined by the status of the
         # enterprise customer as well as the catalog. So, in order to detect when content metadata has last been
         # modified, we have to also check the customer and the catalog's modified times.

--- a/enterprise_catalog/apps/api/v1/tests/test_serializers.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_serializers.py
@@ -5,10 +5,40 @@ from django.test import TestCase
 from rest_framework import serializers
 
 from enterprise_catalog.apps.api.v1.serializers import (
+    ContentMetadataSerializer,
     find_and_modify_catalog_query,
 )
 from enterprise_catalog.apps.catalog.models import CatalogQuery
+from enterprise_catalog.apps.catalog.tests.factories import (
+    ContentMetadataFactory,
+)
 from enterprise_catalog.apps.catalog.utils import get_content_filter_hash
+
+
+class ContentMetadataSerializerTests(TestCase):
+    """
+    Tests for the content metadata serializer and how it formats data
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.content_metadata_item = ContentMetadataFactory()
+
+    def test_product_source_formatting(self):
+        """
+        Test that the content metadata serializer will transform product source data within the json metadata field
+        from a string to a dict.
+        """
+        json_metadata = self.content_metadata_item.json_metadata
+        json_metadata['product_source'] = '2u'
+        self.content_metadata_item.json_metadata = json_metadata
+        self.content_metadata_item.save()
+        serialized_data = ContentMetadataSerializer(self.content_metadata_item)
+        assert serialized_data.data.get('product_source') == {
+            'name': self.content_metadata_item.json_metadata.get('product_source'),
+            'slug': None,
+            'description': None
+        }
 
 
 class FindCatalogQueryTest(TestCase):


### PR DESCRIPTION
## Description

Content metadata serializer will ensure product source is a singular format.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
