### PR TITLE
fix: filter for content metadata contined in any customer's catalog better

### DIFF
--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -1,0 +1,13 @@
+# This makes it easier to get coverage reports for only specific modules
+# when running pytest locally, for example:
+# pytest -x enterprise_access/apps/events/  --cov=enterprise_access.apps.events -c pytest.local.ini
+[pytest]
+DJANGO_SETTINGS_MODULE = enterprise_access.settings.test
+addopts = --cov-report term-missing --cov-report xml -W ignore
+norecursedirs = .* docs requirements site-packages
+
+# Filter depr warnings coming from packages that we can't control.
+filterwarnings =
+	ignore:.*urlresolvers is deprecated in favor of.*:DeprecationWarning:auth_backends.views:5
+	ignore:.*invalid escape sequence.*:DeprecationWarning:.*(newrelic|uritemplate|psutil).*
+	ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*distutils.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,6 @@ filterwarnings =
 	ignore:.*urlresolvers is deprecated in favor of.*:DeprecationWarning:auth_backends.views:5
 	ignore:.*invalid escape sequence.*:DeprecationWarning:.*(newrelic|uritemplate|psutil).*
 	ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*distutils.*
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
# Handle cases where we search for course runs in a customer, but the customer's catalog(s) contain only `course` metadata proper.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
