### PR TITLE
Update yaml loader for safe loading opsgenie alert: #48774

### DIFF
--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -23,7 +23,7 @@ FILE_STORAGE_BACKEND = {}
 
 CONFIG_FILE = get_env_setting('ENTERPRISE_CATALOG_CFG')
 with open(CONFIG_FILE, encoding='utf-8') as f:
-    config_from_yaml = yaml.load(f)
+    config_from_yaml = yaml.load(f, Loader=yaml.SafeLoader)
 
     # Remove the items that should be used to update dicts, and apply them separately rather
     # than pumping them into the local vars.


### PR DESCRIPTION
## Description

Jenkins job prod-edx-reindex-algolia failed with:
13:59:57 2023-04-10 13:14:59,106 INFO 836648 [celery_utils.logged_task] logged_task.py:25 - Task enterprise_catalog.apps.api.tasks.index_enterprise_catalog_in_algolia_task[a4d67e4f-49de-478e-9c88-0294f399419c] submitted with arguments None, {'force': False}/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/settings/production.py:26: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
13:59:57   config_from_yaml = yaml.load(f)

## Ticket Link
https://2u-internal.app.opsgenie.com/alert/detail/37058f45-41f4-4f01-b460-e2b4f9e84b6c-1681135220785/details

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
