### PR TITLE
fix: Added proxy login with executive education course enrollment url

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -40,6 +40,7 @@ from enterprise_catalog.apps.catalog.constants import (
 )
 from enterprise_catalog.apps.catalog.utils import (
     batch,
+    enterprise_proxy_login_url,
     get_content_filter_hash,
     get_content_key,
     get_content_type,
@@ -403,6 +404,12 @@ class EnterpriseCatalog(TimeStampedModel):
                 LOGGER.warning(warning, content_metadata.content_key, self.uuid)
                 return None
             params['sku'] = entitlement_sku
+            exec_ed_enrollment_url = update_query_parameters(url, params)
+            enterprise_proxy_exec_ed_enrollment_url = enterprise_proxy_login_url(
+                self.enterprise_customer.slug,
+                next_url=exec_ed_enrollment_url
+            )
+            return enterprise_proxy_exec_ed_enrollment_url
         elif self._can_enroll_via_learner_portal(content_key):
             course_key = content_key
             if parent_content_key:

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -5,7 +5,9 @@ import hashlib
 import json
 from datetime import datetime
 from logging import getLogger
+from urllib.parse import urljoin
 
+from django.conf import settings
 from edx_rbac.utils import feature_roles_from_jwt
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     get_decoded_jwt_from_auth,
@@ -105,3 +107,10 @@ def batch(iterable, batch_size=1):
 def localized_utcnow():
     """Helper function to return localized utcnow()."""
     return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter
+
+
+def enterprise_proxy_login_url(slug, next_url=None):
+    url = urljoin(settings.LMS_BASE_URL, f'/enterprise/proxy-login/?enterprise_slug={slug}')
+    if next_url:
+        url += f'&next={next_url}'
+    return url


### PR DESCRIPTION
## Description

 Added proxy login with executive education course enrollment URL

## Ticket Link

Link to the associated ticket
[ENT-7071](https://2u-internal.atlassian.net/browse/ENT-7071)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
