### PR TITLE
feat: use learner portal as enrollment url for all subsidy and content types behind Waffle flag

### DIFF
--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -55,7 +55,7 @@ class EnterpriseCustomerDetails:
     @property
     def active_catalogs(self):
         """
-        Return catalogs associated with active subisides for the enterprise customer.
+        Return catalogs associated with active coupon code and subscription catalogs for the enterprise customer.
         """
         catalogs = self.customer_data.get('coupons_catalogs', []) + self.customer_data.get('subscriptions_catalogs', [])
         return list(set(catalogs))

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -461,7 +461,7 @@ class EnterpriseCatalog(TimeStampedModel):
                 f"executive-education-2u/course/{content_metadata.content_key}",
                 None
             )
-        
+
         entitlement_sku = None
         for entitlement in content_metadata.json_metadata.get('entitlements', []):
             if entitlement['mode'] == EXEC_ED_2U_ENTITLEMENT_MODE:

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -455,17 +455,17 @@ class EnterpriseCatalog(TimeStampedModel):
         return update_query_parameters(url, params)
 
     def _get_exec_ed_2u_enrollment_url(self, content_metadata, enterprise_slug, use_learner_portal):
-        entitlement_sku = None
-        for entitlement in content_metadata.json_metadata.get('entitlements', []):
-            if entitlement['mode'] == EXEC_ED_2U_ENTITLEMENT_MODE:
-                entitlement_sku = entitlement.get('sku')
-
         if use_learner_portal:
             return (
                 f"{settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/{enterprise_slug}/"
                 f"executive-education-2u/course/{content_metadata.content_key}",
                 None
             )
+        
+        entitlement_sku = None
+        for entitlement in content_metadata.json_metadata.get('entitlements', []):
+            if entitlement['mode'] == EXEC_ED_2U_ENTITLEMENT_MODE:
+                entitlement_sku = entitlement.get('sku')
 
         return (
             f"{settings.ECOMMERCE_BASE_URL}/executive-education-2u/checkout",

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -349,24 +349,35 @@ class TestModels(TestCase):
             'is_course_in_subscriptions_catalog': True,
             'is_course_in_coupons_catalog': True,
             'should_direct_to_lp': True,
+            'has_learner_portal_enrollment_flag_enabled': False,
         },
         {
             'is_integrated_customer_with_subsidies_and_offer': True,
             'is_course_in_subscriptions_catalog': False,
             'is_course_in_coupons_catalog': False,
             'should_direct_to_lp': False,
+            'has_learner_portal_enrollment_flag_enabled': False,
+        },
+        {
+            'is_integrated_customer_with_subsidies_and_offer': True,
+            'is_course_in_subscriptions_catalog': False,
+            'is_course_in_coupons_catalog': False,
+            'should_direct_to_lp': True,
+            'has_learner_portal_enrollment_flag_enabled': True,
         },
         {
             'is_integrated_customer_with_subsidies_and_offer': True,
             'is_course_in_subscriptions_catalog': True,
             'is_course_in_coupons_catalog': False,
             'should_direct_to_lp': True,
+            'has_learner_portal_enrollment_flag_enabled': False,
         },
         {
             'is_integrated_customer_with_subsidies_and_offer': True,
             'is_course_in_subscriptions_catalog': False,
             'is_course_in_coupons_catalog': True,
             'should_direct_to_lp': True,
+            'has_learner_portal_enrollment_flag_enabled': False,
         }
     )
     @ddt.unpack
@@ -375,7 +386,8 @@ class TestModels(TestCase):
         is_integrated_customer_with_subsidies_and_offer,
         is_course_in_subscriptions_catalog,
         is_course_in_coupons_catalog,
-        should_direct_to_lp
+        should_direct_to_lp,
+        has_learner_portal_enrollment_flag_enabled,
     ):
         enterprise_uuid = uuid4()
         enterprise_slug = 'sluggy'
@@ -387,6 +399,9 @@ class TestModels(TestCase):
 
         with self.settings(
             INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS=INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS
+        ), override_waffle_flag(
+            LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES_FLAG,
+            active=has_learner_portal_enrollment_flag_enabled
         ):
             enterprise_catalog = factories.EnterpriseCatalogFactory(enterprise_uuid=enterprise_uuid)
             content_metadata = factories.ContentMetadataFactory(

--- a/enterprise_catalog/apps/catalog/waffle.py
+++ b/enterprise_catalog/apps/catalog/waffle.py
@@ -3,11 +3,14 @@ This module contains various configuration settings via
 waffle switches for the catalog app.
 """
 
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import WaffleFlag, WaffleSwitch
 
 
 WAFFLE_NAMESPACE = 'catalog'
+
 DISABLE_MODEL_ADMIN_CHANGES = 'disable_model_admin_changes'
+LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES = 'learner_portal_enrollment_all_subsidies_and_content_types'
+
 # .. toggle_name: catalog.disable_model_admin_changes
 # .. toggle_implementation: WaffleSwitch
 # .. toggle_default: False
@@ -18,3 +21,22 @@ DISABLE_MODEL_ADMIN_CHANGES_SWITCH = WaffleSwitch(
     f'{WAFFLE_NAMESPACE}.{DISABLE_MODEL_ADMIN_CHANGES}',
     module_name=__name__,
 )
+
+# .. toggle_name: catalog.learner_portal_enrollment_all_subsidies_and_content_types
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Indicates whether enrollment urls should point to learner portal for all customers, subsidies, and content types for customers with learner portal enabled.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2023-05-15
+LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES_FLAG = WaffleFlag(
+    f'{WAFFLE_NAMESPACE}.{LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES}',
+    module_name=__name__,
+)
+
+
+def use_learner_portal_for_all_subsidies_content_types():
+    """
+    Returns whether enrollments url should point to learner portal for all customers,
+    subsidies, and content types for customers with learner portal enabled.
+    """
+    return LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES_FLAG.is_enabled()


### PR DESCRIPTION
## Description

If a waffle flag `catalog.learner_portal_enrollment_all_subsidies_and_content_types` is enabled, use the learner portal for Executive Education (2U) courses as well as OCM courses that would otherwise be reverted back to legacy enrollment pages via `settings.INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS`.

### Test Cases

- [x] Enrollment URL for OCM course when enterprise customer does not have learner portal enabled: http://edx.devstack.lms:18000/enterprise/a067aacd-667d-4bd6-81e2-e332ef5ca1cd/course/edX+DemoX/enroll/?catalog=4a4681e4-0369-4ace-8bd3-892f7c5984fb&utm_medium=enterprise&utm_source=test-enterprise 
- [x] Enrollment URL for Exec Ed course when enterprise customer does not have learner portal enabled: http://edx.devstack.lms:18000/enterprise/proxy-login/?enterprise_slug=test-enterprise&next=http://edx.devstack.ecommerce:18130/executive-education-2u/checkout?sku=BCC3328&utm_medium=enterprise&utm_source=test-enterprise
- [x] Enrollment URL for OCM course where customer has learner portal enabled, but has an incompatible enterprise offer so is excluded by `settings.INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS`: http://edx.devstack.lms:18000/enterprise/a067aacd-667d-4bd6-81e2-e332ef5ca1cd/course/edX+DemoX/enroll/?catalog=4a4681e4-0369-4ace-8bd3-892f7c5984fb&utm_medium=enterprise&utm_source=test-enterprise
- [x] Enrollment URL for OCM course where customer has learner portal enabled and does not have an incompatible enterprise offer: http://localhost:8734/test-enterprise/course/edX+DemoX?utm_medium=enterprise&utm_source=test-enterprise
- [x] Enrollment URL for Exec Ed course where customer has learner portal enabled but has the `catalog.learner_portal_enrollment_all_subsidies_and_content_types` Waffle flag is disabled: http://edx.devstack.lms:18000/enterprise/proxy-login/?enterprise_slug=test-enterprise&next=http://edx.devstack.ecommerce:18130/executive-education-2u/checkout?sku=BCC3328&utm_medium=enterprise&utm_source=test-enterprise
- [x] Enrollment URL for Exec Ed course where customer has learner portal enabled but has the `catalog.learner_portal_enrollment_all_subsidies_and_content_types` Waffle flag is enabled: http://localhost:8734/test-enterprise/executive-education-2u/course/edX+DM?utm_medium=enterprise&utm_source=test-enterprise 

## Ticket Link

[ENT-6896](https://openedx.atlassian.net/browse/ENT-6896)

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
