### PR TITLE
feat: add django-clearcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,12 @@ dev.up: dev.up.redis # Starts all containers
 dev.up.build: # Runs docker-compose -up -d --build
 	docker-compose up -d --build
 
+dev.up.build-no-cache: dev.up.redis
+	docker-compose build --no-cache
+	docker-compose up -d
+	docker exec -u 0 -it enterprise-catalog.app pip install -r requirements/pip-tools.txt
+	docker exec -u 0 -it enterprise-catalog.app pip-sync -q requirements/dev.txt requirements/private.* requirements/test.txt
+
 dev.up.redis:
 	docker-compose -f $(DEVSTACK_WORKSPACE)/devstack/docker-compose.yml up -d redis
 

--- a/docs/how_to/clear_cache.rst
+++ b/docs/how_to/clear_cache.rst
@@ -1,0 +1,33 @@
+Manually clear Django cache 
+===========================
+
+At times, it is helpful to clear the cache for the application to enable more efficient QA in local/stage/production environments 
+when working with APIs that cache data from external sources. For instance, enterprise-catalog makes an API request to the LMS to
+retrieve metadata about the enterprise customer and caches it for 1 hour. If you then update that enterprise customer's config (e.g.,
+disable the learner portal), the metadata about the enterprise customer is still cached by enterprise-catalog, so it won't be aware of
+the config change on the enterprise customer.
+
+In order to get around this, `django-clearcache` (https://github.com/timonweb/django-clearcache) is installed and configured, which allows you to clear the cache for the application via
+Django and via a manage.py command.
+
+Via Django admin
+----------------
+
+1. Go to /admin/clearcache/, you should see a form with cache selector
+2. Pick a cache. Usually there's one default cache, but can be more.
+3. Click the button, you're done!
+
+Via manage.py command
+---------------------
+
+1. Run the following command to clear the default cache
+
+.. code-block:: bash
+
+    $ python manage.py clearcache
+
+2. Run the command above with an additional parameter to clear non-default cache (if exists):
+
+.. code-block:: bash
+
+    $ python manage.py clearcache cache_name

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -38,6 +38,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = (
+    'clearcache',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -35,6 +35,7 @@ api_info = make_api_info(
 urlpatterns = [
     path('', include(oauth2_urlpatterns)),
     path('', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
+    path('admin/clearcache/', include('clearcache.urls')),
     path('admin/', admin.site.urls),
     path('api/', include(api_urls), name='api'),
     # Use the same auth views for all logins, including those originating from the browseable API.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -34,3 +34,4 @@ zipp<2.0
 algoliasearch
 social-auth-app-django
 xlsxwriter
+django-clearcache

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -67,6 +67,7 @@ django==3.2.19
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -87,6 +88,8 @@ django==3.2.19
     #   jsonfield2
     #   social-auth-app-django
 django-celery-results==2.5.1
+    # via -r requirements/base.in
+django-clearcache==1.2.1
     # via -r requirements/base.in
 django-config-models==2.3.0
     # via -r requirements/base.in
@@ -152,7 +155,7 @@ edx-opaque-keys==2.3.0
     # via edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via -r requirements/base.in
 edx-toggles==5.0.0
     # via -r requirements/base.in
@@ -282,7 +285,7 @@ social-auth-core==4.4.2
     #   social-auth-app-django
 sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -165,6 +165,7 @@ django==3.2.19
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -190,6 +191,10 @@ django-celery-results==2.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+django-clearcache==1.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-config-models==2.3.0
     # via
     #   -r requirements/quality.txt
@@ -205,7 +210,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
@@ -311,7 +316,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -536,7 +541,7 @@ pylint-django==2.5.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -699,7 +704,7 @@ sqlparse==0.4.4
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -133,6 +133,7 @@ django==3.2.19
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -153,6 +154,8 @@ django==3.2.19
     #   jsonfield2
     #   social-auth-app-django
 django-celery-results==2.5.1
+    # via -r requirements/test.txt
+django-clearcache==1.2.1
     # via -r requirements/test.txt
 django-config-models==2.3.0
     # via -r requirements/test.txt
@@ -241,7 +244,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/test.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via -r requirements/test.txt
 edx-toggles==5.0.0
     # via -r requirements/test.txt
@@ -414,7 +417,7 @@ pylint-django==2.5.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   -r requirements/test.txt
     #   pylint-celery
@@ -561,7 +564,7 @@ sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/test.txt
     #   code-annotations

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -91,6 +91,7 @@ django==3.2.19
     # via
     #   -r requirements/base.txt
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -111,6 +112,8 @@ django==3.2.19
     #   jsonfield2
     #   social-auth-app-django
 django-celery-results==2.5.1
+    # via -r requirements/base.txt
+django-clearcache==1.2.1
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
@@ -182,7 +185,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via -r requirements/base.txt
 edx-toggles==5.0.0
     # via -r requirements/base.txt
@@ -381,7 +384,7 @@ sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -106,6 +106,7 @@ django==3.2.19
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -126,6 +127,8 @@ django==3.2.19
     #   jsonfield2
     #   social-auth-app-django
 django-celery-results==2.5.1
+    # via -r requirements/base.txt
+django-clearcache==1.2.1
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
@@ -203,7 +206,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via -r requirements/base.txt
 edx-toggles==5.0.0
     # via -r requirements/base.txt
@@ -322,7 +325,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   pylint-celery
     #   pylint-django
@@ -427,7 +430,7 @@ sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -114,6 +114,7 @@ distlib==0.3.6
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -134,6 +135,8 @@ distlib==0.3.6
     #   jsonfield2
     #   social-auth-app-django
 django-celery-results==2.5.1
+    # via -r requirements/base.txt
+django-clearcache==1.2.1
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
@@ -213,7 +216,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via -r requirements/base.txt
 edx-toggles==5.0.0
     # via -r requirements/base.txt
@@ -348,7 +351,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   pylint-celery
     #   pylint-django
@@ -462,7 +465,7 @@ sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -146,6 +146,7 @@ django==3.2.19
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-celery-results
+    #   django-clearcache
     #   django-config-models
     #   django-cors-headers
     #   django-crum
@@ -166,6 +167,10 @@ django==3.2.19
     #   jsonfield2
     #   social-auth-app-django
 django-celery-results==2.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-clearcache==1.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -278,7 +283,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -474,7 +479,7 @@ pylint-django==2.5.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -617,7 +622,7 @@ sqlparse==0.4.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description

Installs and configures https://github.com/timonweb/django-clearcache to add a route like http://localhost:18160/admin/clearcache/

<img width="623" alt="image" src="https://github.com/openedx/enterprise-catalog/assets/2828721/3d4d0ea5-6db1-4098-ab55-b707f8f07e5b">


## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
