### PR TITLE
feat: Add new catalog type column

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -34,6 +34,7 @@ CSV_COURSE_HEADERS = [
     'Length',
     'What You’ll Learn',
     'Pre-requisites',
+    'Associated Catalogs',
 ]
 
 CSV_PROGRAM_HEADERS = [
@@ -42,6 +43,7 @@ CSV_PROGRAM_HEADERS = [
     'Partner',
     'Short Description',
     'Number of courses',
+    'Associated Catalogs',
 ]
 
 CSV_COURSE_RUN_HEADERS = [
@@ -61,6 +63,7 @@ CSV_COURSE_RUN_HEADERS = [
     'Skills',
     'Subjects',
     'Language',
+    'Associated Catalogs'
 ]
 
 CSV_EXEC_ED_COURSE_HEADERS = [
@@ -93,6 +96,7 @@ ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
     'course_runs',
     'course_type',
     'entitlements',
+    'enterprise_catalog_query_titles',
     'first_enrollable_paid_seat_price',
     'full_description',
     'key',
@@ -124,6 +128,19 @@ def write_headers_to_sheet(worksheet, headers, cell_format):
         worksheet.write(0, col_num, cell_data, cell_format)
 
 
+def fetch_catalog_types(hit):
+    """
+    Helper function to extract only the three needed catalog types.
+    """
+    CATALOG_TYPES = [
+        'A la carte',
+        'Business',
+        'Education'
+    ]
+
+    return [catalog for catalog in CATALOG_TYPES if catalog in hit.get('enterprise_catalog_query_titles')]
+
+
 def program_hit_to_row(hit):
     """
     Helper function to construct a CSV row according to a single Algolia result program hit.
@@ -138,6 +155,9 @@ def program_hit_to_row(hit):
     csv_row.append(hit.get('subtitle'))
 
     csv_row.append(len(hit.get('course_keys', [])))
+
+    catalogs = fetch_catalog_types(hit)
+    csv_row.append(', '.join(catalogs))
 
     return csv_row
 
@@ -207,6 +227,9 @@ def course_hit_to_row(hit):
     csv_row.append(strip_tags(hit.get('outcome', '')))  # What You’ll Learn
 
     csv_row.append(strip_tags(hit.get('prerequisites_raw', '')))  # Pre-requisites
+
+    catalogs = fetch_catalog_types(hit)  # Catalog types
+    csv_row.append(', '.join(catalogs))
 
     return csv_row
 
@@ -338,6 +361,10 @@ def course_run_to_row(hit, course_run):
 
     # Language
     csv_row.append(hit.get('language'))
+
+    # Course Catalogs
+    catalogs = fetch_catalog_types(hit)
+    csv_row.append(', '.join(catalogs))
 
     return csv_row
 

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -620,6 +620,7 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
         'language': 'English',
         'level_type': 'Intermediate',
         'content_type': 'course',
+        'enterprise_catalog_query_titles': ['A la carte', 'Business', 'DemoX'],
         'partners': [
             {'name': 'Massachusetts Institute of Technology',
              'logo_image_url': 'https://edx.org/image.png'}
@@ -669,12 +670,12 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
 
     expected_result_data = 'Title,Partner Name,Start,End,Verified Upgrade Deadline,Program Type,Program Name,Pacing,' \
                            'Level,Price,Language,URL,Short Description,Subjects,Key,Short Key,Skills,Min Effort,' \
-                           'Max Effort,Length,What You’ll Learn,Pre-requisites\r\nCalculus 1B: ' \
+                           'Max Effort,Length,What You’ll Learn,Pre-requisites,Associated Catalogs\r\nCalculus 1B: ' \
                            'Integration,Massachusetts Institute of Technology,2015-09-08,' \
                            '2015-09-08,3000-01-01,Professional Certificate,Totally ' \
                            'Awesome Program,instructor_paced,Intermediate,100,English,edx.org/foo-bar,description,' \
                            'Math,MITx/18.01.2x/3T2015,course:MITx+18.01.2x,"Probability And Statistics, ' \
-                           'Engineering Design Process",1,10,1,learn,interest\r\n'
+                           'Engineering Design Process",1,10,1,learn,interest,"A la carte, Business"\r\n'
 
     def setUp(self):
         super().setUp()
@@ -733,12 +734,12 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
         assert response.status_code == 200
         excpected_csv_data = 'Title,Partner Name,Start,End,Verified Upgrade Deadline,Program Type,Program Name,' \
                              'Pacing,Level,Price,Language,URL,Short Description,Subjects,Key,Short Key,Skills,' \
-                             'Min Effort,Max Effort,Length,What You’ll Learn,Pre-requisites\r\n' \
+                             'Min Effort,Max Effort,Length,What You’ll Learn,Pre-requisites,Associated Catalogs\r\n' \
                              'Calculus 1B: Integration,Massachusetts Institute of Technology,2015-09-08,' \
                              ',,Professional Certificate,Totally Awesome ' \
                              'Program,instructor_paced,Intermediate,,English,,description,' \
                              'Math,MITx/18.01.2x/3T2015,course:MITx+18.01.2x,"Probability And Statistics, ' \
-                             'Engineering Design Process",1,10,1,learn,interest\r\n'
+                             'Engineering Design Process",1,10,1,learn,interest,"A la carte, Business"\r\n'
         expected_response = {
             'csv_data': excpected_csv_data
         }
@@ -757,6 +758,7 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
                 "language": "English",
                 "level_type": "Intermediate",
                 "content_type": "course",
+                "enterprise_catalog_query_titles": ["A la carte", "Business", "DemoX"],
                 "partners": [
                     {
                         "name": "Massachusetts Institute of Technology",

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -942,8 +942,10 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
                 "content_type": "program",
                 "enterprise_catalog_query_titles": ["A la carte", "Business", "DemoX"],
                 "partners": [
-                    {"name": "Harvard University",
-                    "logo_image_url": "https://edx.org/image.png"}
+                    {
+                        "name": "Harvard University",
+                        "logo_image_url": "https://edx.org/image.png"
+                    }
                 ],
                 "title": "Calculus 1B: Integration",
                 "subtitle": "this is a subtitle",

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -935,6 +935,19 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
                 "language": "English",
                 "level_type": "Intermediate",
                 "objectID": "course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf7-catalog-query-uuids-0"
+            },
+            {
+                "aggregation_key": "course:MITx+18.01.2x",
+                "course_keys": ['MITx+18.01.2x'],
+                "content_type": "program",
+                "enterprise_catalog_query_titles": ["A la carte", "Business", "DemoX"],
+                "partners": [
+                    {"name": "Harvard University",
+                    "logo_image_url": "https://edx.org/image.png"}
+                ],
+                "title": "Calculus 1B: Integration",
+                "subtitle": "this is a subtitle",
+                "program_type": "Professional Certificate"
             }
         ]
     }


### PR DESCRIPTION
## Description

**Problem**: The explore catalog tool displays on the screen displays very well which courses are included in the catalog categories: A la carte, business subscription, and education. However, the CSV download file does not present that information.

**Solution**: Add a column with the header "Associated Catalogs" in the tabs - Programs, Courses, and Course Runs to include the catalog categories. 

![Screenshot 2023-05-23 at 3 32 51 PM](https://github.com/openedx/enterprise-catalog/assets/71999631/a79d0e03-9947-4bec-8dd8-8c3b17dcf560)

## Ticket Link

Link to the associated ticket
[Catalog Explore Download results include Associated catalogs](https://2u-internal.atlassian.net/browse/ENT-6963)

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed