### PR TITLE
fix: allow update job to proceed past individual failures

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -777,6 +777,7 @@ def update_catalog_metadata_task(self, catalog_query_id, force=False):  # pylint
     except CatalogQuery.DoesNotExist:
         logger.error('Could not find a CatalogQuery with id %s', catalog_query_id)
 
+    associated_content_keys = []
     try:
         associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
     except Exception as e:
@@ -784,7 +785,8 @@ def update_catalog_metadata_task(self, catalog_query_id, force=False):  # pylint
             f'Something went wrong while updating content metadata from discovery using catalog: {catalog_query_id}. ',
             exc_info=e,
         )
-        raise e
+        # johnnagro removing this to allow the entire job to proceed past individual task failures
+        # raise e
     logger.info('Finished update_catalog_metadata_task with {} associated content keys for catalog {}'.format(
         len(associated_content_keys), catalog_query_id
     ))


### PR DESCRIPTION
## Description

Allow our update content metadata job to proceed past individual failures.

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
