### PR TITLE
feat: catch broader exception when fetching external data.

### DIFF
--- a/enterprise_catalog/apps/api_client/enterprise_cache.py
+++ b/enterprise_catalog/apps/api_client/enterprise_cache.py
@@ -98,7 +98,7 @@ def _get_enterprise_customer_data(uuid):
             ecommerce_client = EcommerceApiClient()
             coupons_overview = ecommerce_client.get_coupons_overview(uuid)
             coupons_catalogs = [coupon['enterprise_catalog_uuid'] for coupon in coupons_overview]
-        except requests.exceptions.HTTPError as exc:
+        except requests.exceptions.RequestException as exc:
             logger.error(
                 'Failed to fetch coupons overview for %r because %r',
                 uuid,
@@ -115,7 +115,7 @@ def _get_enterprise_customer_data(uuid):
                 ]
             else:
                 subscriptions_catalogs = []
-        except requests.exceptions.HTTPError as exc:
+        except requests.exceptions.RequestException as exc:
             logger.error(
                 'Failed to fetch customer agreement for %r because %r',
                 uuid,


### PR DESCRIPTION
When fetching data from ecommerce or license-manager, we now catch the broadest possible requests exception, so that calls to _get_enterprise_customer_data() don't fail if we're e.g. unable to connect to one of these services.

This should help us locally, so we don't hard fail certain requests to enterprise-access or directly to enterprise-catalog if these other services (which are not directly related to content metadata) are not online.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
