### PR TITLE
fix: minimize error rate

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_decorators.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_decorators.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from rest_framework.exceptions import ValidationError
+from enterprise_catalog.apps.api.v1.decorators import require_at_least_one_query_parameter
+
+
+class DecoratorTests(TestCase):
+    """
+    Tests for the existence of at least one of the specified query in the decorator
+    """
+
+    def test_require_at_least_one_query_parameter(self):
+        """
+        Tests that at least one of the specified query parameters are included in the request
+        """
+        query_parameter_names = 'enterprise_catalog_query_titles'
+
+        @require_at_least_one_query_parameter(query_parameter_names)
+        def my_view(request):
+            return HttpResponse('a response for request {}'.format(request))
+        request = RequestFactory().get('/')
+        request.query_params = request.GET
+
+        with self.assertRaisesMessage(ValidationError,
+                                      'You must provide at least one of the following '
+                                      'query parameters: enterprise_catalog_query_titles.'):
+            my_view(request)

--- a/enterprise_catalog/apps/api/v1/tests/test_decorators.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_decorators.py
@@ -1,9 +1,10 @@
-from django.test import TestCase
 from django.http import HttpResponse
-from django.test import RequestFactory
-
+from django.test import RequestFactory, TestCase
 from rest_framework.exceptions import ValidationError
-from enterprise_catalog.apps.api.v1.decorators import require_at_least_one_query_parameter
+
+from enterprise_catalog.apps.api.v1.decorators import (
+    require_at_least_one_query_parameter,
+)
 
 
 class DecoratorTests(TestCase):

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -133,18 +133,6 @@ class EnterpriseCatalogDefaultCatalogResultsTests(APITestMixin):
         response = self.client.get(f'{url}?{facets}')
         assert response.status_code == 200
 
-    def test_required_param_validation(self):
-        """
-        Tests that the view requires a provided catalog
-        """
-        url = self._get_contains_content_base_url()
-        invalid_facets = 'bad=ayylmao'
-        response = self.client.get(f'{url}?{invalid_facets}')
-        assert response.status_code == 400
-        assert response.json() == [
-            'You must provide at least one of the following query parameters: enterprise_catalog_query_titles.'
-        ]
-
     @mock.patch('enterprise_catalog.apps.api.v1.views.default_catalog_results.get_initialized_algolia_client')
     def test_default_catalog_results_view_works_with_one_and_many_course_types(self, mock_algolia_client):
         """

--- a/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
+++ b/enterprise_catalog/apps/api/v1/views/default_catalog_results.py
@@ -1,12 +1,8 @@
-from django.utils.decorators import method_decorator
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
-from enterprise_catalog.apps.api.v1.decorators import (
-    require_at_least_one_query_parameter,
-)
 from enterprise_catalog.apps.api.v1.export_utils import (
     querydict_to_dict,
     validate_query_facets,
@@ -65,7 +61,6 @@ class DefaultCatalogResultsView(GenericAPIView):
         # Since this view does not hit any models, override the serializer
         pass
 
-    @method_decorator(require_at_least_one_query_parameter('enterprise_catalog_query_titles'))
     @action(detail=True)
     def get(self, request, **kwargs):
         """


### PR DESCRIPTION
## Description

**Problem**: At the endpoint of https://explore-catalog.edx.org/ the page automatically gets redirected to
[https://explore-catalog.edx.org/?enterprise_catalog_query_titles=A la carte&availability=Available Now&availability=Starting Soon&availability=Upcoming](https://explore-catalog.edx.org/?enterprise_catalog_query_titles=A%20la%20carte&availability=Available%20Now&availability=Starting%20Soon&availability=Upcoming) 
by default. On-call reported seeing the error https://onenr.io/0qwLXOdKzw5 that is caused by the URL https://explore-catalog.edx.org/ not having query parameters.

**Solution**: On the client, there are existing checks in place to verify that the query parameters are loaded before making the API request. The fix is implemented on the API by removing the method decorator that validates the query parameters because that same validation is already done on the client.

_Note:_ This error could not be reproduced locally. The changes will be closely monitored after being deployed. 

## Ticket Link

Link to the associated ticket
[[enterprise-catalog] You must provide at least one of the following query parameters: enterprise_catalog_query_titles](https://2u-internal.atlassian.net/browse/ENT-7003)

## Post-review

* [x] Squash commits into discrete sets of changes
* [x] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
