### PR TITLE
chore: upgrade dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic as app
-LABEL maintainer="devops@edx.org"
+LABEL maintainer="sre@edx.org"
 
 # Packages installed:
 # git
@@ -20,12 +20,18 @@ LABEL maintainer="devops@edx.org"
 #     MySQL-python for performance gains.
 
 # If you add a package here please include a comment above describing what it is used for
-RUN apt-get update && \
-apt-get install -y software-properties-common && \
-apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
-apt-get upgrade -qy && apt-get install language-pack-en locales git \
-libmysqlclient-dev libssl-dev build-essential python3.8-dev python3.8-venv -qy && \
-rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -qy install --no-install-recommends \
+ language-pack-en \
+ locales \
+ python3.8 \
+ python3-pip \
+ python3.8-venv \
+ python3.8-dev \
+ libmysqlclient-dev \
+ libssl-dev \
+ build-essential \
+ git \
+ wget
 
 ENV VIRTUAL_ENV=/venv
 RUN python3.8 -m venv $VIRTUAL_ENV


### PR DESCRIPTION
## Description

- upgrade base ubuntu
- fix docker build errors

```
Failing command: ['/venv/bin/python3.8', '-Im', 'ensurepip', '--upgrade', '--default-pip']

The command '/bin/sh -c python3.8 -m venv $VIRTUAL_ENV' returned a non-zero code: 1
Service 'app' failed to build : Build failed
Error: Process completed with exit code 1.
```

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
