### PR TITLE
feat: adding a more standard retry system

### DIFF
--- a/enterprise_catalog/apps/api_client/base_oauth_with_retry.py
+++ b/enterprise_catalog/apps/api_client/base_oauth_with_retry.py
@@ -1,0 +1,19 @@
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from .base_oauth import BaseOAuthClient
+
+
+class BaseOAuthClientWithRetry(BaseOAuthClient):
+    """
+    Base class for OAuth API clients wrapped in Retry.
+    """
+    def __init__(self, backoff_factor=2, max_retries=3, **kwargs):
+        super().__init__(**kwargs)
+        retry = Retry(
+            total=max_retries,
+            backoff_factor=backoff_factor,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.client.mount('http://', adapter)
+        self.client.mount('https://', adapter)

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -2,12 +2,11 @@
 Discovery service api client code.
 """
 import logging
-import time
 
 from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
 
-from .base_oauth import BaseOAuthClient
+from .base_oauth_with_retry import BaseOAuthClientWithRetry
 from .constants import (
     DISCOVERY_COURSES_ENDPOINT,
     DISCOVERY_OFFSET_SIZE,
@@ -19,46 +18,29 @@ from .constants import (
 LOGGER = logging.getLogger(__name__)
 
 
-class DiscoveryApiClient(BaseOAuthClient):
+class DiscoveryApiClient(BaseOAuthClientWithRetry):
     """
     Object builds an API client to make calls to the Discovery Service.
     """
 
-    # the maximum number of retries to attempt a call
-    MAX_RETRIES = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_MAX_RETRIES", 4)
-    # the number of seconds to sleep beteween tries, which is doubled every attempt
-    BACKOFF_FACTOR = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR", 2)
-
-    def _calculate_backoff(self, attempt_count):
-        """
-        Calculate the seconds to sleep based on attempt_count
-        """
-        return (self.BACKOFF_FACTOR * (2 ** (attempt_count - 1)))
+    def __init__(self):
+        backoff_factor = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR", 2)
+        max_retries = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_MAX_RETRIES", 4)
+        super().__init__(backoff_factor=backoff_factor, max_retries=max_retries)
 
     def _retrieve_metadata_for_content_filter(self, content_filter, page, request_params):
         """
         Makes a request to discovery's /search/all/ endpoint with the specified
         content_filter, page, and request_params
         """
-        LOGGER.info('Retrieving results from course-discovery for page %s...', page)
-        attempts = 0
-        while True:
-            attempts = attempts + 1
-            response = self.client.post(
-                DISCOVERY_SEARCH_ALL_ENDPOINT,
-                json=content_filter,
-                params=request_params,
-            )
-            if attempts <= self.MAX_RETRIES and response.status_code >= 400:
-                sleep_seconds = self._calculate_backoff(attempts)
-                LOGGER.warning(
-                    f'failed request detected from {DISCOVERY_SEARCH_ALL_ENDPOINT}, '
-                    'backing-off before retrying, '
-                    f'sleeping {sleep_seconds} seconds...'
-                )
-                time.sleep(sleep_seconds)
-            else:
-                break
+        LOGGER.info(f'Retrieving results from course-discovery for page {page}...')
+        response = self.client.post(
+            DISCOVERY_SEARCH_ALL_ENDPOINT,
+            json=content_filter,
+            params=request_params,
+        )
+        elabsed_seconds = response.elapsed.total_seconds()
+        LOGGER.info(f'Retrieved results from course-discovery for page {page} in {elabsed_seconds} seconds.')
         return response.json()
 
     def get_metadata_by_query(self, catalog_query):

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -33,25 +33,6 @@ class TestDiscoveryApiClient(TestCase):
         self.assertEqual(actual_response, expected_response)
 
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
-    def test_get_metadata_by_query_with_retry_and_error(self, mock_oauth_client):
-        """
-        get_metadata_by_query should call discovery endpoint, but not call
-        traverse_pagination if traverse_pagination is false.
-        """
-
-        mock_oauth_client.return_value.post.return_value.status_code = 400
-        mock_oauth_client.return_value.post.return_value.json.return_value = {}
-
-        catalog_query = CatalogQueryFactory()
-        client = DiscoveryApiClient()
-        # setting this to 0 means we wont wait between retries
-        client.BACKOFF_FACTOR = 0
-
-        client.get_metadata_by_query(catalog_query)
-        # the retry logic will end up calling this 5 times
-        assert mock_oauth_client.return_value.post.call_count == 5
-
-    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_metadata_by_query_with_error(self, mock_oauth_client):
         """
         get_metadata_by_query should return None when a call to discovery endpoint fails.


### PR DESCRIPTION
## Description

- investigating the performance and reliability of the update_catalog task
- use a [built-in](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry) retry/back-off functionality
- remove old code from our bespoke retry functionality
- add logging for request duration
- https://2u-internal.atlassian.net/browse/ENT-7253