### PR TITLE
fix: retry on POST verb too

### DIFF
--- a/enterprise_catalog/apps/api_client/base_oauth_with_retry.py
+++ b/enterprise_catalog/apps/api_client/base_oauth_with_retry.py
@@ -22,6 +22,7 @@ class BaseOAuthClientWithRetry(BaseOAuthClient):
             total=max_retries,
             backoff_factor=backoff_factor,
             backoff_jitter=backoff_jitter,
+            allowed_methods=None,
         )
         adapter = HTTPAdapter(max_retries=retry)
         self.client.mount('http://', adapter)

--- a/enterprise_catalog/apps/api_client/base_oauth_with_retry.py
+++ b/enterprise_catalog/apps/api_client/base_oauth_with_retry.py
@@ -15,6 +15,7 @@ class BaseOAuthClientWithRetry(BaseOAuthClient):
             backoff_factor=2,
             max_retries=3,
             backoff_jitter=1,
+            allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,
             **kwargs
     ):
         super().__init__(**kwargs)
@@ -22,7 +23,7 @@ class BaseOAuthClientWithRetry(BaseOAuthClient):
             total=max_retries,
             backoff_factor=backoff_factor,
             backoff_jitter=backoff_jitter,
-            allowed_methods=None,
+            allowed_methods=allowed_methods,
         )
         adapter = HTTPAdapter(max_retries=retry)
         self.client.mount('http://', adapter)

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -28,7 +28,12 @@ class DiscoveryApiClient(BaseOAuthClientWithRetry):
     def __init__(self):
         backoff_factor = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR", 2)
         max_retries = getattr(settings, "ENTERPRISE_DISCOVERY_CLIENT_MAX_RETRIES", 4)
-        super().__init__(backoff_factor=backoff_factor, max_retries=max_retries)
+        super().__init__(
+            backoff_factor=backoff_factor,
+            max_retries=max_retries,
+            # setting this to None ensures all verbs (including POST) are retried
+            allowed_methods=None,
+        )
 
     def _retrieve_metadata_for_content_filter(self, content_filter, page, request_params):
         """


### PR DESCRIPTION
## Description

- by default `Retry` only retries certain HTTP verbs: `{'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE'}`
- we need `POST` to be retried
- using `None` reties all verbs
- https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/retry.py#L125-L132

