### PR TITLE
fix: improve retry visibilty

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -5,6 +5,7 @@ import logging
 
 from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
+from requests.adapters import Retry
 
 from .base_oauth_with_retry import BaseOAuthClientWithRetry
 from .constants import (
@@ -31,8 +32,8 @@ class DiscoveryApiClient(BaseOAuthClientWithRetry):
         super().__init__(
             backoff_factor=backoff_factor,
             max_retries=max_retries,
-            # setting this to None ensures all verbs (including POST) are retried
-            allowed_methods=None,
+            allowed_methods={'POST'}.union(Retry.DEFAULT_ALLOWED_METHODS),
+            status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,
         )
 
     def _retrieve_metadata_for_content_filter(self, content_filter, page, request_params):

--- a/enterprise_catalog/apps/api_client/tests/test_retry.py
+++ b/enterprise_catalog/apps/api_client/tests/test_retry.py
@@ -1,9 +1,15 @@
 """ Tests for EnterpriseRery and BaseOAuthClientWithRetry """
-from django.test import TestCase
-from requests.exceptions import ChunkedEncodingError
-from urllib3.exceptions import ProtocolError
+from unittest import mock
 
-from ..base_oauth_with_retry import EnterpriseRetry
+import requests
+import responses
+from django.test import TestCase, override_settings
+from requests.adapters import Retry
+from requests.exceptions import ChunkedEncodingError
+from urllib3.exceptions import ConnectTimeoutError
+
+from ..base_oauth_with_retry import BaseOAuthClientWithRetry, EnterpriseRetry
+from ..discovery import DiscoveryApiClient
 
 
 class TestEnterpriseRetry(TestCase):
@@ -14,18 +20,94 @@ class TestEnterpriseRetry(TestCase):
         Ensure the parent class logic still works
         """
         # pylint: disable=protected-access
-        assert EnterpriseRetry()._is_read_error(ProtocolError())
+        assert EnterpriseRetry()._is_connection_error(ConnectTimeoutError())
 
     def test_existing_negative_case(self):
         """
         Ensure the parent class logic still works
         """
         # pylint: disable=protected-access
-        assert EnterpriseRetry()._is_read_error(Exception()) is False
+        assert EnterpriseRetry()._is_connection_error(Exception()) is False
 
     def test_requests_chuncked_error(self):
         """
         Ensure the added Exception(s) are working
         """
         # pylint: disable=protected-access
-        assert EnterpriseRetry()._is_read_error(ChunkedEncodingError())
+        assert EnterpriseRetry()._is_connection_error(ChunkedEncodingError())
+
+
+class TestBaseOAuthClientWithRetry(TestCase):
+    """BaseOAuthClientWithRetry tests. """
+
+    # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+    @responses.activate(registry=responses.registries.OrderedRegistry)
+    def test_plain_base_with_retry(self):
+        rsp1 = responses.post(url="https://example.com/", status=429)
+        responses.add(rsp1)
+        rsp2 = responses.post(url="https://example.com/", status=429)
+        responses.add(rsp2)
+        rsp3 = responses.post(url="https://example.com/", status=200)
+        responses.add(rsp3)
+        base_client = BaseOAuthClientWithRetry(
+            max_retries=4,
+            backoff_factor=0.1,
+            allowed_methods={'POST'}.union(Retry.DEFAULT_ALLOWED_METHODS),
+            status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,
+        )
+        with mock.patch('edx_rest_api_client.client.OAuthAPIClient._ensure_authentication', return_value=True):
+            base_client.client.post('https://example.com/')
+        assert rsp1.call_count == 1
+        assert rsp2.call_count == 1
+        assert rsp3.call_count == 1
+
+    def test_plain_base_with_mock_exception(self):
+        base_client = BaseOAuthClientWithRetry(
+            max_retries=1,
+            backoff_factor=0.1,
+            allowed_methods={'POST'}.union(Retry.DEFAULT_ALLOWED_METHODS),
+            status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,
+        )
+        with self.assertRaises(requests.exceptions.ConnectionError) as excinfo:
+            with mock.patch(
+                'edx_rest_api_client.client.OAuthAPIClient._ensure_authentication',
+                return_value=True,
+            ):
+                with mock.patch(
+                    'urllib3.connectionpool.HTTPConnectionPool._make_request',
+                    side_effect=ChunkedEncodingError(),
+                ):
+                    base_client.client.post('https://example.com/')
+        assert "Max retries exceeded" in str(excinfo.exception)
+
+    # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+    @responses.activate(registry=responses.registries.OrderedRegistry)
+    @override_settings(ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR=0.1)
+    def test_discovery_client(self):
+        rsp1 = responses.post(url="https://example.com/", status=429)
+        responses.add(rsp1)
+        rsp2 = responses.post(url="https://example.com/", status=429)
+        responses.add(rsp2)
+        rsp3 = responses.post(url="https://example.com/", status=200)
+        responses.add(rsp3)
+        disco_client = DiscoveryApiClient()
+        with mock.patch('edx_rest_api_client.client.OAuthAPIClient._ensure_authentication', return_value=True):
+            disco_client.client.post('https://example.com/')
+        assert rsp1.call_count == 1
+        assert rsp2.call_count == 1
+        assert rsp3.call_count == 1
+
+    @override_settings(ENTERPRISE_DISCOVERY_CLIENT_BACKOFF_FACTOR=0.1)
+    def test_discovery_client_with_exception(self):
+        disco_client = DiscoveryApiClient()
+        with self.assertRaises(requests.exceptions.ConnectionError) as excinfo:
+            with mock.patch(
+                'edx_rest_api_client.client.OAuthAPIClient._ensure_authentication',
+                return_value=True,
+            ):
+                with mock.patch(
+                    'urllib3.connectionpool.HTTPConnectionPool._make_request',
+                    side_effect=ChunkedEncodingError(),
+                ):
+                    disco_client.client.post('https://example.com/')
+        assert "Max retries exceeded" in str(excinfo.exception)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,13 +10,17 @@ amqp==5.1.1
     # via kombu
 analytics-python==1.4.post1
     # via -r requirements/base.in
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 backoff==1.10.0
     # via analytics-python
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   celery
+    #   kombu
+billiard==4.1.0
     # via celery
-celery==5.2.7
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -42,17 +46,11 @@ click-didyoumean==0.3.0
     # via celery
 click-plugins==1.1.1
     # via celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via celery
 code-annotations==1.3.0
     # via edx-toggles
-coreapi==2.3.3
-    # via drf-yasg
-coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -94,7 +92,7 @@ django-clearcache==1.2.1
     # via -r requirements/base.in
 django-config-models==2.3.0
     # via -r requirements/base.in
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -102,7 +100,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.in
 django-log-request-id==2.1.0
     # via -r requirements/base.in
@@ -134,7 +132,7 @@ djangorestframework-xml==2.0.0
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via edx-api-doc-tools
 edx-api-doc-tools==1.6.0
     # via -r requirements/base.in
@@ -144,7 +142,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   django-config-models
     #   edx-drf-extensions
@@ -166,25 +164,21 @@ idna==3.4
     # via requests
 inflection==0.5.1
     # via drf-yasg
-itypes==1.2.0
-    # via coreapi
 jinja2==3.1.2
-    # via
-    #   code-annotations
-    #   coreschema
+    # via code-annotations
 jsonfield==3.1.0
     # via edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-kombu==5.2.4
+kombu==5.3.1
     # via celery
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 monotonic==1.6
     # via analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/base.in
-newrelic==8.8.0
+newrelic==8.8.1
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -216,6 +210,7 @@ pynacl==1.5.0
 python-dateutil==2.8.2
     # via
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
 python-slugify==8.0.1
     # via code-annotations
@@ -224,7 +219,6 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   -r requirements/base.in
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -232,6 +226,7 @@ pyyaml==5.4.1
     # via
     #   -c requirements/constraints.txt
     #   code-annotations
+    #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via
@@ -241,7 +236,6 @@ requests==2.31.0
     # via
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -249,10 +243,6 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-ruamel-yaml==0.17.26
-    # via drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via ruamel-yaml
 rules==3.3
     # via -r requirements/base.in
 semantic-version==2.10.0
@@ -262,7 +252,6 @@ simplejson==3.19.1
 six==1.16.0
     # via
     #   analytics-python
-    #   click-repl
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
@@ -287,13 +276,17 @@ stevedore==5.1.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.6.1
-    # via asgiref
-uritemplate==4.1.1
+typing-extensions==4.6.3
     # via
-    #   coreapi
-    #   drf-yasg
-urllib3==2.0.2
+    #   asgiref
+    #   kombu
+tzdata==2023.3
+    # via
+    #   backports-zoneinfo
+    #   celery
+uritemplate==4.1.1
+    # via drf-yasg
+urllib3==2.0.3
     # via requests
 vine==5.0.0
     # via
@@ -302,7 +295,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via -r requirements/base.in
 zipp==1.2.0
     # via -r requirements/base.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,3 +14,4 @@ gunicorn                  # For running the application locally
 inflect
 ddt
 python-memcached
+responses

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ analytics-python==1.4.post1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -36,9 +36,15 @@ backoff==1.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   celery
+    #   kombu
 bcrypt==4.0.1
     # via paramiko
-billiard==3.6.4.0
+billiard==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -47,7 +53,7 @@ build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-celery==5.2.7
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
@@ -99,7 +105,7 @@ click-plugins==1.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -110,22 +116,11 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   coreapi
-    #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -200,7 +195,7 @@ django-config-models==2.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -215,7 +210,7 @@ django-debug-toolbar==4.1.0
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -258,7 +253,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-docker[ssh]==6.1.2
+docker[ssh]==6.1.3
     # via docker-compose
 docker-compose==1.29.2
     # via -r requirements/dev.in
@@ -271,7 +266,7 @@ drf-jwt==1.19.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -292,7 +287,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -335,11 +330,11 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.9.0
+faker==18.11.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -351,7 +346,7 @@ idna==3.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via inflect
 inflect==3.0.2
     # via
@@ -372,17 +367,11 @@ isort==5.12.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
-    #   coreschema
     #   diff-cover
     #   jinja2-pluralize
 jinja2-pluralize==0.3.0
@@ -398,7 +387,7 @@ jsonfield2==4.0.0.post0
     #   -r requirements/test.txt
 jsonschema==3.2.0
     # via docker-compose
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -408,7 +397,7 @@ lazy-object-proxy==1.9.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -423,11 +412,11 @@ monotonic==1.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==8.8.0
+newrelic==8.8.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -448,7 +437,7 @@ packaging==23.1
     #   drf-yasg
     #   pytest
     #   tox
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
 path==16.6.0
     # via edx-i18n-tools
@@ -459,13 +448,13 @@ pbr==5.11.1
     #   stevedore
 pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.5.1
+platformdirs==3.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -r requirements/test.txt
     #   diff-cover
@@ -554,12 +543,12 @@ pyproject-hooks==1.0.0
     #   build
 pyrsistent==0.19.3
     # via jsonschema
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -568,6 +557,7 @@ python-dateutil==2.8.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
     #   faker
 python-dotenv==0.21.1
@@ -588,7 +578,6 @@ pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -599,8 +588,10 @@ pyyaml==5.4.1
     #   -r requirements/test.txt
     #   code-annotations
     #   docker-compose
+    #   drf-yasg
     #   edx-django-release-util
     #   edx-i18n-tools
+    #   responses
 redis==3.5.3
     # via
     #   -c requirements/constraints.txt
@@ -612,12 +603,12 @@ requests==2.31.0
     #   -r requirements/test.txt
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   docker
     #   docker-compose
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
+    #   responses
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
@@ -625,16 +616,10 @@ requests-oauthlib==1.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
+responses==0.23.1
     # via
-    #   -r requirements/quality.txt
+    #   -r requirements/dev.in
     #   -r requirements/test.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/quality.txt
@@ -653,7 +638,6 @@ six==1.16.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
-    #   click-repl
     #   django-dynamic-fixture
     #   dockerpty
     #   edx-auth-backends
@@ -729,25 +713,36 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/test.txt
-typing-extensions==4.6.1
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/test.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
+    #   celery
 uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   coreapi
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   docker
     #   requests
+    #   responses
 vine==5.0.0
     # via
     #   -r requirements/quality.txt
@@ -755,7 +750,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.23.0
+virtualenv==20.23.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -777,7 +772,7 @@ wrapt==1.15.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,7 +16,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/test.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -34,15 +34,20 @@ backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+    #   kombu
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-billiard==3.6.4.0
+billiard==4.1.0
     # via
     #   -r requirements/test.txt
     #   celery
 bleach==6.0.0
     # via readme-renderer
-celery==5.2.7
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -84,7 +89,7 @@ click-plugins==1.1.1
     # via
     #   -r requirements/test.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
@@ -93,20 +98,11 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/test.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements/test.txt
-    #   coreapi
-    #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -160,7 +156,7 @@ django-clearcache==1.2.1
     # via -r requirements/test.txt
 django-config-models==2.3.0
     # via -r requirements/test.txt
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -170,7 +166,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/test.txt
 django-log-request-id==2.1.0
     # via -r requirements/test.txt
@@ -214,7 +210,7 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
@@ -226,7 +222,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -257,11 +253,11 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.9.0
+faker==18.11.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -272,7 +268,7 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via sphinx
 inflection==0.5.1
     # via
@@ -286,15 +282,10 @@ isort==5.12.0
     # via
     #   -r requirements/test.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/test.txt
-    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-    #   coreschema
     #   sphinx
 jsonfield==3.1.0
     # via
@@ -302,7 +293,7 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -310,7 +301,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -322,9 +313,9 @@ monotonic==1.6
     # via
     #   -r requirements/test.txt
     #   analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/test.txt
-newrelic==8.8.0
+newrelic==8.8.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -345,12 +336,12 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.5.1
+platformdirs==3.8.0
     # via
     #   -r requirements/test.txt
     #   pylint
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -421,12 +412,12 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -434,6 +425,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/test.txt
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
     #   faker
 python-slugify==8.0.1
@@ -448,7 +440,6 @@ pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -457,8 +448,10 @@ pyyaml==5.4.1
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-yasg
     #   edx-django-release-util
-readme-renderer==37.3
+    #   responses
+readme-renderer==40.0
     # via -r requirements/doc.in
 redis==3.5.3
     # via
@@ -469,10 +462,10 @@ requests==2.31.0
     #   -r requirements/test.txt
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
+    #   responses
     #   slumber
     #   social-auth-core
     #   sphinx
@@ -480,16 +473,10 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
+responses==0.23.1
+    # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/test.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/test.txt
-    #   ruamel-yaml
 rules==3.3
     # via -r requirements/test.txt
 semantic-version==2.10.0
@@ -503,7 +490,6 @@ six==1.16.0
     #   -r requirements/test.txt
     #   analytics-python
     #   bleach
-    #   click-repl
     #   django-dynamic-fixture
     #   edx-auth-backends
     #   edx-django-release-util
@@ -529,9 +515,8 @@ social-auth-core==4.4.2
     #   social-auth-app-django
 soupsieve==2.4.1
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==6.2.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
@@ -583,29 +568,39 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/test.txt
-typing-extensions==4.6.1
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/test.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pydata-sphinx-theme
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
+    #   celery
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
-    #   coreapi
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/test.txt
     #   requests
+    #   responses
 vine==5.0.0
     # via
     #   -r requirements/test.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.23.0
+virtualenv==20.23.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -619,7 +614,7 @@ wrapt==1.15.0
     # via
     #   -r requirements/test.txt
     #   astroid
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via -r requirements/test.txt
 zipp==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.8.0
+setuptools==68.0.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,7 +12,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/base.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -20,11 +20,16 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.2.7
+    #   kombu
+billiard==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==5.3.1
     # via
     #   -r requirements/base.txt
     #   django-celery-results
@@ -59,7 +64,7 @@ click-plugins==1.1.1
     # via
     #   -r requirements/base.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
@@ -67,16 +72,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
-    #   drf-yasg
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -118,7 +114,7 @@ django-clearcache==1.2.1
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -126,7 +122,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
@@ -159,7 +155,7 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
@@ -171,7 +167,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -206,26 +202,21 @@ inflection==0.5.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
-itypes==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   code-annotations
-    #   coreschema
 jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/base.txt
     #   celery
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -233,9 +224,9 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/base.txt
-newrelic==8.8.0
+newrelic==8.8.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -288,6 +279,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
 python-memcached==1.59
     # via -r requirements/production.in
@@ -302,7 +294,6 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   -r requirements/base.txt
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -311,6 +302,7 @@ pyyaml==5.4.1
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   code-annotations
+    #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via -r requirements/base.txt
@@ -319,7 +311,6 @@ requests==2.31.0
     #   -r requirements/base.txt
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -329,14 +320,6 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/base.txt
-    #   ruamel-yaml
 rules==3.3
     # via -r requirements/base.txt
 semantic-version==2.10.0
@@ -349,7 +332,6 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-    #   click-repl
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
@@ -383,16 +365,21 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.6.1
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
+    #   kombu
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -406,11 +393,11 @@ wcwidth==0.2.6
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via -r requirements/base.txt
 zipp==1.2.0
     # via -r requirements/base.txt
-zope-event==4.6
+zope-event==5.0
     # via gevent
 zope-interface==6.0
     # via gevent

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/base.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -25,11 +25,16 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.2.7
+    #   kombu
+billiard==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -69,7 +74,7 @@ click-plugins==1.1.1
     # via
     #   -r requirements/base.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
@@ -78,16 +83,7 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   edx-lint
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
-    #   drf-yasg
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -133,7 +129,7 @@ django-clearcache==1.2.1
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -141,7 +137,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
@@ -176,7 +172,7 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
@@ -188,7 +184,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -225,28 +221,23 @@ isort==5.12.0
     # via
     #   -r requirements/quality.in
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   code-annotations
-    #   coreschema
 jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/base.txt
     #   celery
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -256,9 +247,9 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/base.txt
-newrelic==8.8.0
+newrelic==8.8.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -275,7 +266,7 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.5.1
+platformdirs==3.8.0
     # via pylint
 ply==3.11
     # via
@@ -332,6 +323,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
 python-slugify==8.0.1
     # via
@@ -344,7 +336,6 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   -r requirements/base.txt
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -353,6 +344,7 @@ pyyaml==5.4.1
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
+    #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via
@@ -363,7 +355,6 @@ requests==2.31.0
     #   -r requirements/base.txt
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -373,14 +364,6 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/base.txt
-    #   ruamel-yaml
 rules==3.3
     # via -r requirements/base.txt
 semantic-version==2.10.0
@@ -393,7 +376,6 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-    #   click-repl
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
@@ -433,18 +415,23 @@ tomli==2.0.1
     # via pylint
 tomlkit==0.11.8
     # via pylint
-typing-extensions==4.6.1
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -460,7 +447,7 @@ wcwidth==0.2.6
     #   prompt-toolkit
 wrapt==1.15.0
     # via astroid
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via -r requirements/base.txt
 zipp==1.2.0
     # via -r requirements/base.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,3 +13,4 @@ pytest-cov
 pytest-django
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
+responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/base.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -25,11 +25,16 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.2.7
+    #   kombu
+billiard==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -69,7 +74,7 @@ click-plugins==1.1.1
     # via
     #   -r requirements/base.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
@@ -79,20 +84,11 @@ code-annotations==1.3.0
     #   -r requirements/test.in
     #   edx-lint
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
-    #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -141,7 +137,7 @@ django-clearcache==1.2.1
     # via -r requirements/base.txt
 django-config-models==2.3.0
     # via -r requirements/base.txt
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -151,7 +147,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
@@ -186,7 +182,7 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
@@ -198,7 +194,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -227,9 +223,9 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.9.0
+faker==18.11.2
     # via factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
@@ -245,28 +241,23 @@ iniconfig==2.0.0
     # via pytest
 isort==5.12.0
     # via pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   code-annotations
-    #   coreschema
 jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/base.txt
     #   celery
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -276,9 +267,9 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/base.txt
-newrelic==8.8.0
+newrelic==8.8.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -297,11 +288,11 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.5.1
+platformdirs==3.8.0
     # via
     #   pylint
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   pytest
     #   tox
@@ -354,11 +345,11 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -366,6 +357,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
     #   faker
 python-slugify==8.0.1
@@ -379,7 +371,6 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   -r requirements/base.txt
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -388,7 +379,9 @@ pyyaml==5.4.1
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
+    #   drf-yasg
     #   edx-django-release-util
+    #   responses
 redis==3.5.3
     # via
     #   -c requirements/constraints.txt
@@ -398,24 +391,18 @@ requests==2.31.0
     #   -r requirements/base.txt
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
+    #   responses
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/base.txt
-    #   ruamel-yaml
+responses==0.23.1
+    # via -r requirements/test.in
 rules==3.3
     # via -r requirements/base.txt
 semantic-version==2.10.0
@@ -428,7 +415,6 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-    #   click-repl
     #   django-dynamic-fixture
     #   edx-auth-backends
     #   edx-django-release-util
@@ -479,28 +465,36 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/test.in
-typing-extensions==4.6.1
+types-pyyaml==6.0.12.10
+    # via responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/base.txt
     #   requests
+    #   responses
 vine==5.0.0
     # via
     #   -r requirements/base.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.23.0
+virtualenv==20.23.1
     # via tox
 wcwidth==0.2.6
     # via
@@ -508,7 +502,7 @@ wcwidth==0.2.6
     #   prompt-toolkit
 wrapt==1.15.0
     # via astroid
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via -r requirements/base.txt
 zipp==1.2.0
     # via -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -17,7 +17,7 @@ analytics-python==1.4.post1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -34,12 +34,18 @@ backoff==1.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-celery==5.2.7
+    #   kombu
+billiard==4.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   celery
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
@@ -89,7 +95,7 @@ click-plugins==1.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -100,22 +106,11 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   coreapi
-    #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -179,7 +174,7 @@ django-config-models==2.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -192,7 +187,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -240,7 +235,7 @@ drf-jwt==1.19.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -261,7 +256,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -302,11 +297,11 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.9.0
+faker==18.11.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -330,17 +325,11 @@ isort==5.12.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
-    #   coreschema
 jsonfield==3.1.0
     # via
     #   -r requirements/quality.txt
@@ -350,7 +339,7 @@ jsonfield2==4.0.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -360,7 +349,7 @@ lazy-object-proxy==1.9.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -375,11 +364,11 @@ monotonic==1.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==8.8.0
+newrelic==8.8.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -402,13 +391,13 @@ pbr==5.11.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.5.1
+platformdirs==3.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -485,12 +474,12 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -499,6 +488,7 @@ python-dateutil==2.8.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
+    #   celery
     #   edx-drf-extensions
     #   faker
 python-slugify==8.0.1
@@ -515,7 +505,6 @@ pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   celery
     #   django
     #   djangorestframework
     #   drf-yasg
@@ -525,7 +514,9 @@ pyyaml==5.4.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-yasg
     #   edx-django-release-util
+    #   responses
 redis==3.5.3
     # via
     #   -c requirements/constraints.txt
@@ -537,10 +528,10 @@ requests==2.31.0
     #   -r requirements/test.txt
     #   algoliasearch
     #   analytics-python
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
+    #   responses
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
@@ -548,16 +539,8 @@ requests-oauthlib==1.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   ruamel-yaml
+responses==0.23.1
+    # via -r requirements/test.txt
 rules==3.3
     # via
     #   -r requirements/quality.txt
@@ -576,7 +559,6 @@ six==1.16.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
-    #   click-repl
     #   django-dynamic-fixture
     #   edx-auth-backends
     #   edx-django-release-util
@@ -642,24 +624,35 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/test.txt
-typing-extensions==4.6.1
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/test.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
+    #   celery
 uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   coreapi
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
+    #   responses
 vine==5.0.0
     # via
     #   -r requirements/quality.txt
@@ -667,7 +660,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.23.0
+virtualenv==20.23.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -681,7 +674,7 @@ wrapt==1.15.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description

I am not getting the behavior i expect. This makes several changes: 

- It modifies a different error handler. I had modified the read error handler, where perhaps i should be doing the connection error handler because they treat the error state differently. The read error one also looks at the verb and status code and the exceptions i am interested in do not have a status.
- It adds a log line when retries are exhausted
- It explicitly sets the read and connect retry counts. The docs say the total takes precedence but I cannot find where the read and connect counts are set if not in the init.

https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/retry.py#L460-L472

