### PR TITLE
feat: fix reindex-algolia task dict bug and add dry_run

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -17,11 +17,18 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser):
-        # Argument to force execution of celery task, ignoring time since last execution
         parser.add_argument(
             '--force',
             default=False,
             action='store_true',
+            help='Force execution of celery task, ignoring time since last execution.',
+        )
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            action='store_true',
+            default=False,
+            help='Generate algolia products to index, but do not actually send them to algolia for indexing.',
         )
 
     def handle(self, *args, **options):
@@ -31,11 +38,13 @@ class Command(BaseCommand):
         options.update(CatalogUpdateCommandConfig.current_options())
         try:
             force_task_execution = options.get('force', False)
+            dry_run = options.get('dry_run', False)
             if options.get('no_async'):
-                index_enterprise_catalog_in_algolia_task()
+                # For some reason in order to call a celery task in-memory you must pass kwargs as args.
+                index_enterprise_catalog_in_algolia_task(force_task_execution, dry_run)
             else:
                 index_enterprise_catalog_in_algolia_task.apply_async(
-                    kwargs={'force': force_task_execution}
+                    kwargs={'force': force_task_execution, 'dry_run': dry_run}
                 ).get()
             logger.info(
                 'index_enterprise_catalog_in_algolia_task from command reindex_algolia finished successfully.'

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -20,21 +20,8 @@ class ReindexAlgoliaCommandTests(TestCase):
         super().setUpTestData()
         cls.content_metadata = ContentMetadataFactory.create_batch(3, content_type=COURSE)
 
-    def setUp(self):
-        super().setUp()
-        self.command_config_mock = mock.patch('enterprise_catalog.apps.catalog.models.CatalogUpdateCommandConfig')
-        mock_config = self.command_config_mock.start()
-        mock_config.current_config.return_value = {
-            'force': False,
-            'no_async': False,
-        }
-
-    def tearDown(self):
-        super().tearDown()
-        self.command_config_mock.stop()
-
     @mock.patch(PATH_PREFIX + 'index_enterprise_catalog_in_algolia_task')
-    @mock.patch('enterprise_catalog.apps.catalog.models.CatalogUpdateCommandConfig')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.reindex_algolia.CatalogUpdateCommandConfig')
     def test_reindex_algolia(self, mock_command_config, mock_task):
         """
         Verify that the job spins off the correct number of index_enterprise_catalog_in_algolia_task
@@ -44,4 +31,33 @@ class ReindexAlgoliaCommandTests(TestCase):
             'no_async': False,
         }
         call_command(self.command_name)
+        mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': False})
+        mock_task.apply_async.return_value.get.assert_called_once_with()
+
+    @mock.patch(PATH_PREFIX + 'index_enterprise_catalog_in_algolia_task')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.reindex_algolia.CatalogUpdateCommandConfig')
+    def test_reindex_algolia_no_async(self, mock_command_config, mock_task):
+        """
+        Verify that the job spins off the correct number of index_enterprise_catalog_in_algolia_task
+        """
+        mock_command_config.current_options.return_value = {
+            'force': False,
+            'no_async': True,
+        }
+        call_command(self.command_name)
+        mock_task.assert_called_once_with(False, False)  # force=False, dry_run=False
+        mock_task.apply_async.assert_not_called()
+
+    @mock.patch(PATH_PREFIX + 'index_enterprise_catalog_in_algolia_task')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.reindex_algolia.CatalogUpdateCommandConfig')
+    def test_reindex_algolia_dry_run(self, mock_command_config, mock_task):
+        """
+        Verify that the job spins off the correct number of index_enterprise_catalog_in_algolia_task
+        """
+        mock_command_config.current_options.return_value = {
+            'force': False,
+            'no_async': False,
+        }
+        call_command(self.command_name, dry_run=True)
+        mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': True})
         mock_task.apply_async.return_value.get.assert_called_once_with()

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -75,6 +75,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
 
     # model fields
     content_key = factory.Sequence(lambda n: f'{str(n).zfill(5)}_metadata_item')
+    content_uuid = factory.LazyFunction(uuid4)
     content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM, LEARNER_PATHWAY])
     parent_content_key = None
 
@@ -83,7 +84,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
         json_metadata = {
             'key': self.content_key,
             'aggregation_key': f'{self.content_type}:{self.content_key}',
-            'uuid': str(uuid4()),
+            'uuid': str(self.content_uuid),
             'title': self.title,
         }
         if self.content_type == COURSE:


### PR DESCRIPTION
Sadly, the last attempt to add logging resulted in a dict iteration bug:
```
...
File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 689, in _get_algolia_products_for_batch
    for algolia_object_id in algolia_products_by_object_id.keys():
RuntimeError: dictionary changed size during iteration
```

This PR fixes this bug, adds a unit test to cover it, and also implements --dry-run for the associated management command.