### PR TITLE
feat: Remove api calls for content enrollment url

### DIFF
--- a/enterprise_catalog/apps/catalog/waffle.py
+++ b/enterprise_catalog/apps/catalog/waffle.py
@@ -3,7 +3,7 @@ This module contains various configuration settings via
 waffle switches for the catalog app.
 """
 
-from edx_toggles.toggles import WaffleFlag, WaffleSwitch
+from edx_toggles.toggles import WaffleSwitch
 
 
 WAFFLE_NAMESPACE = 'catalog'
@@ -21,22 +21,3 @@ DISABLE_MODEL_ADMIN_CHANGES_SWITCH = WaffleSwitch(
     f'{WAFFLE_NAMESPACE}.{DISABLE_MODEL_ADMIN_CHANGES}',
     module_name=__name__,
 )
-
-# .. toggle_name: catalog.learner_portal_enrollment_all_subsidies_and_content_types
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Indicates whether enrollment urls should point to learner portal for all customers, subsidies, and content types for customers with learner portal enabled.
-# .. toggle_use_cases: opt_in
-# .. toggle_creation_date: 2023-05-15
-LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES_FLAG = WaffleFlag(
-    f'{WAFFLE_NAMESPACE}.{LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES}',
-    module_name=__name__,
-)
-
-
-def use_learner_portal_for_all_subsidies_content_types():
-    """
-    Returns whether enrollments url should point to learner portal for all customers,
-    subsidies, and content types for customers with learner portal enabled.
-    """
-    return LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES_FLAG.is_enabled()


### PR DESCRIPTION
Removes API calls and `active_catalogs` property from the `EnterpriseCustomerDetails` class.
Will now return `True` for `_can_enroll_via_learner_portal` method when the learner portal is enabled for all subsidy content types.

Note: In this PR, we remove the `LEARNER_PORTAL_ENROLLMENT_ALL_SUBSIDIES_AND_CONTENT_TYPES_FLAG` Waffle flag (not breakfast related), but still requires manual removal from the Enterprise Catalog Django Admin page once merged in stage, then prod.

## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
