### PR TITLE
test: reindex-algolia tests now cover NOT including associated courses

### DIFF
--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -131,7 +131,6 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'uuid': self.content_key,
                 'content_type': PROGRAM,
                 'type': 'MicroMasters',
-                'hidden': True,
                 'marketing_url': f'https://marketing.url/{self.content_key}',
                 'authoring_organizations': authoring_organizations,
                 'card_image_url': self.card_image_url,


### PR DESCRIPTION
This bulks up the unit tests to cover the following cases:

* If a program is to be indexed, but not one of its associated courses, make sure we do not index the course.
* If a learner pathway is to be indexed, but not one of its associated courses, make sure we do not index the course.

Meanwhile, I made sure to retain the following association tests:

* If a program is NOT to be indexed, but it is associated with an indexable course, index the program.
* If a program is NOT to be indexed, but it is associated with a pathway, index the program.

Note: This does not change any logic in the active code path.  It is merely updating unit tests to improve coverage, help prevent future regressions, and offered as a way of verifing the existing behavior.

ENT-7311