### PR TITLE
build: uninstall docker-compose, install drf-spectacular

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,6 +16,7 @@ django-simple-history
 djangorestframework
 djangorestframework-xml
 djangoql
+drf-spectacular
 edx-auth-backends
 edx-celeryutils
 edx-django-release-util

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,10 @@ analytics-python==1.4.post1
     # via -r requirements/base.in
 asgiref==3.7.2
     # via django
+attrs==23.1.0
+    # via
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via analytics-python
 backports-zoneinfo[tzdata]==0.2.1
@@ -75,6 +79,7 @@ django==3.2.20
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -126,6 +131,7 @@ djangorestframework==3.14.0
     #   -r requirements/base.in
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -133,6 +139,8 @@ djangorestframework-xml==2.0.0
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
+drf-spectacular==0.26.4
+    # via -r requirements/base.in
 drf-yasg==1.21.7
     # via edx-api-doc-tools
 edx-api-doc-tools==1.7.0
@@ -163,14 +171,24 @@ edx-toggles==5.0.0
     # via -r requirements/base.in
 idna==3.4
     # via requests
+importlib-resources==5.1.3
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 inflection==0.5.1
-    # via drf-yasg
+    # via
+    #   drf-spectacular
+    #   drf-yasg
 jinja2==3.1.2
     # via code-annotations
 jsonfield==3.1.0
     # via edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
+jsonschema==4.18.4
+    # via drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 kombu==5.3.1
     # via celery
 markupsafe==2.1.3
@@ -189,6 +207,8 @@ packaging==23.1
     # via drf-yasg
 pbr==5.11.1
     # via stevedore
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 ply==3.11
     # via djangoql
 prompt-toolkit==3.0.39
@@ -223,16 +243,20 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
-    #   -c requirements/constraints.txt
     #   code-annotations
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+referencing==0.30.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   algoliasearch
@@ -244,6 +268,10 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via -r requirements/base.in
 semantic-version==2.10.0
@@ -286,7 +314,9 @@ tzdata==2023.3
     #   backports-zoneinfo
     #   celery
 uritemplate==4.1.1
-    # via drf-yasg
+    # via
+    #   drf-spectacular
+    #   drf-yasg
 urllib3==2.0.4
     # via requests
 vine==5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,9 +26,6 @@ inflect<4.0.0
 # Using the same version of diff-cover which is being used currently in edx-platform to avoid this conflict.
 diff-cover==4.0.0
 
-# docker-compose wants pyyaml<6
-pyyaml<6
-
 # redis 4 client won't work with redis 3 server
 redis<4
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,7 +7,6 @@
 -r test.txt
 
 diff-cover                # Changeset diff test coverage
-docker-compose            # Tool for orchestrating docker containers; used for devstack
 edx-i18n-tools            # For i18n_tool dummy
 django-debug-toolbar      # For debugging Django
 gunicorn                  # For running the application locally

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,11 @@ astroid==2.11.7
     #   pylint
     #   pylint-celery
 attrs==23.1.0
-    # via jsonschema
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via
     #   -r requirements/quality.txt
@@ -42,8 +46,6 @@ backports-zoneinfo[tzdata]==0.2.1
     #   -r requirements/test.txt
     #   celery
     #   kombu
-bcrypt==4.0.1
-    # via paramiko
 billiard==4.1.0
     # via
     #   -r requirements/quality.txt
@@ -124,7 +126,6 @@ cryptography==41.0.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   paramiko
     #   pyjwt
     #   social-auth-core
 ddt==1.6.0
@@ -151,8 +152,6 @@ distlib==0.3.7
     # via
     #   -r requirements/test.txt
     #   virtualenv
-distro==1.8.0
-    # via docker-compose
 django==3.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -171,6 +170,7 @@ django==3.2.20
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -247,6 +247,7 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -254,19 +255,15 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-docker[ssh]==6.1.3
-    # via docker-compose
-docker-compose==1.29.2
-    # via -r requirements/dev.in
-dockerpty==0.4.1
-    # via docker-compose
-docopt==0.6.2
-    # via docker-compose
 drf-jwt==1.19.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-spectacular==0.26.4
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 drf-yasg==1.21.7
     # via
     #   -r requirements/quality.txt
@@ -349,6 +346,12 @@ idna==3.4
     #   requests
 importlib-metadata==6.8.0
     # via inflect
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   jsonschema-specifications
 inflect==3.0.2
     # via
     #   -c requirements/constraints.txt
@@ -358,6 +361,7 @@ inflection==0.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -386,8 +390,16 @@ jsonfield2==4.0.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-jsonschema==3.2.0
-    # via docker-compose
+jsonschema==4.18.4
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
 kombu==5.3.1
     # via
     #   -r requirements/quality.txt
@@ -434,13 +446,10 @@ packaging==23.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   build
-    #   docker
     #   drf-yasg
     #   gunicorn
     #   pytest
     #   tox
-paramiko==3.3.1
-    # via docker
 path==16.7.1
     # via edx-i18n-tools
 pbr==5.11.1
@@ -450,6 +459,11 @@ pbr==5.11.1
     #   stevedore
 pip-tools==7.1.0
     # via -r requirements/pip-tools.txt
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
 platformdirs==3.10.0
     # via
     #   -r requirements/quality.txt
@@ -538,13 +552,10 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-    #   paramiko
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pyrsistent==0.19.3
-    # via jsonschema
 pytest==7.4.0
     # via
     #   -r requirements/test.txt
@@ -562,8 +573,6 @@ python-dateutil==2.8.2
     #   celery
     #   edx-drf-extensions
     #   faker
-python-dotenv==0.21.1
-    # via docker-compose
 python-memcached==1.59
     # via -r requirements/dev.in
 python-slugify==8.0.1
@@ -583,13 +592,12 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
-    #   docker-compose
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
     #   edx-i18n-tools
@@ -599,14 +607,18 @@ redis==3.5.3
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+referencing==0.30.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   algoliasearch
     #   analytics-python
-    #   docker
-    #   docker-compose
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -622,6 +634,12 @@ responses==0.23.2
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt
+rpds-py==0.9.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via
     #   -r requirements/quality.txt
@@ -641,17 +659,14 @@ six==1.16.0
     #   -r requirements/test.txt
     #   analytics-python
     #   django-dynamic-fixture
-    #   dockerpty
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
-    #   jsonschema
     #   python-dateutil
     #   python-memcached
     #   tox
-    #   websocket-client
 slumber==0.7.1
     # via
     #   -r requirements/quality.txt
@@ -690,8 +705,6 @@ text-unidecode==1.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   python-slugify
-texttable==1.6.7
-    # via docker-compose
 tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
@@ -739,12 +752,12 @@ uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   docker
     #   requests
     #   responses
 vine==5.0.0
@@ -763,10 +776,6 @@ wcwidth==0.2.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   prompt-toolkit
-websocket-client==0.59.0
-    # via
-    #   docker
-    #   docker-compose
 wheel==0.41.0
     # via
     #   -r requirements/pip-tools.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,6 +26,11 @@ astroid==2.11.7
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+attrs==23.1.0
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   referencing
 babel==2.12.1
     # via
     #   pydata-sphinx-theme
@@ -139,6 +144,7 @@ django==3.2.20
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -193,6 +199,7 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -211,6 +218,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-spectacular==0.26.4
+    # via -r requirements/test.txt
 drf-yasg==1.21.7
     # via
     #   -r requirements/test.txt
@@ -271,9 +280,15 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.8.0
     # via sphinx
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   jsonschema-specifications
 inflection==0.5.1
     # via
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -294,6 +309,14 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
+jsonschema==4.18.4
+    # via
+    #   -r requirements/test.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 kombu==5.3.1
     # via
     #   -r requirements/test.txt
@@ -337,6 +360,10 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 platformdirs==3.10.0
     # via
     #   -r requirements/test.txt
@@ -444,11 +471,11 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
     #   responses
@@ -458,6 +485,11 @@ redis==3.5.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
+referencing==0.30.0
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/test.txt
@@ -478,6 +510,11 @@ responses==0.23.2
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
+rpds-py==0.9.2
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via -r requirements/test.txt
 semantic-version==2.10.0
@@ -590,6 +627,7 @@ tzdata==2023.3
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 urllib3==2.0.4
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,6 +16,11 @@ asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
+attrs==23.1.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -97,6 +102,7 @@ django==3.2.20
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -147,6 +153,7 @@ djangorestframework==3.14.0
     #   -r requirements/base.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -156,6 +163,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-spectacular==0.26.4
+    # via -r requirements/base.txt
 drf-yasg==1.21.7
     # via
     #   -r requirements/base.txt
@@ -199,9 +208,15 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 jinja2==3.1.2
     # via
@@ -213,6 +228,14 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
+jsonschema==4.18.4
+    # via
+    #   -r requirements/base.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 kombu==5.3.1
     # via
     #   -r requirements/base.txt
@@ -245,6 +268,10 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 ply==3.11
     # via
     #   -r requirements/base.txt
@@ -299,15 +326,21 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   code-annotations
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via -r requirements/base.txt
+referencing==0.30.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/base.txt
@@ -322,6 +355,11 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
+rpds-py==0.9.2
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via -r requirements/base.txt
 semantic-version==2.10.0
@@ -380,6 +418,7 @@ tzdata==2023.3
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 urllib3==2.0.4
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -21,6 +21,11 @@ astroid==2.11.7
     #   -c requirements/constraints.txt
     #   pylint
     #   pylint-celery
+attrs==23.1.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -112,6 +117,7 @@ django==3.2.20
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -164,6 +170,7 @@ djangorestframework==3.14.0
     #   -r requirements/base.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -173,6 +180,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-spectacular==0.26.4
+    # via -r requirements/base.txt
 drf-yasg==1.21.7
     # via
     #   -r requirements/base.txt
@@ -214,9 +223,15 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 isort==5.12.0
     # via
@@ -232,6 +247,14 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
+jsonschema==4.18.4
+    # via
+    #   -r requirements/base.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 kombu==5.3.1
     # via
     #   -r requirements/base.txt
@@ -267,6 +290,10 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 platformdirs==3.10.0
     # via pylint
 ply==3.11
@@ -340,17 +367,22 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+referencing==0.30.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/base.txt
@@ -365,6 +397,11 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
+rpds-py==0.9.2
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via -r requirements/base.txt
 semantic-version==2.10.0
@@ -431,6 +468,7 @@ tzdata==2023.3
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 urllib3==2.0.4
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,6 +21,11 @@ astroid==2.11.7
     #   -c requirements/constraints.txt
     #   pylint
     #   pylint-celery
+attrs==23.1.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -120,6 +125,7 @@ distlib==0.3.7
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -174,6 +180,7 @@ djangorestframework==3.14.0
     #   -r requirements/base.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -183,6 +190,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-spectacular==0.26.4
+    # via -r requirements/base.txt
 drf-yasg==1.21.7
     # via
     #   -r requirements/base.txt
@@ -234,9 +243,15 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
@@ -252,6 +267,14 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
+jsonschema==4.18.4
+    # via
+    #   -r requirements/base.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 kombu==5.3.1
     # via
     #   -r requirements/base.txt
@@ -289,6 +312,10 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 platformdirs==3.10.0
     # via
     #   pylint
@@ -375,11 +402,11 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
     #   responses
@@ -387,6 +414,11 @@ redis==3.5.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+referencing==0.30.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/base.txt
@@ -404,6 +436,11 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 responses==0.23.2
     # via -r requirements/test.in
+rpds-py==0.9.2
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via -r requirements/base.txt
 semantic-version==2.10.0
@@ -484,6 +521,7 @@ tzdata==2023.3
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 urllib3==2.0.4
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -29,6 +29,12 @@ astroid==2.11.7
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+attrs==23.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via
     #   -r requirements/quality.txt
@@ -151,6 +157,7 @@ django==3.2.20
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -224,6 +231,7 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -236,6 +244,10 @@ drf-jwt==1.19.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-spectacular==0.26.4
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 drf-yasg==1.21.7
     # via
     #   -r requirements/quality.txt
@@ -312,10 +324,17 @@ idna==3.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
+importlib-resources==5.1.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   jsonschema-specifications
 inflection==0.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -340,6 +359,16 @@ jsonfield2==4.0.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+jsonschema==4.18.4
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
 kombu==5.3.1
     # via
     #   -r requirements/quality.txt
@@ -392,6 +421,11 @@ pbr==5.11.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
 platformdirs==3.10.0
     # via
     #   -r requirements/quality.txt
@@ -509,12 +543,12 @@ pytz==2023.3
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
     #   responses
@@ -523,6 +557,12 @@ redis==3.5.3
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+referencing==0.30.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/quality.txt
@@ -542,6 +582,12 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 responses==0.23.2
     # via -r requirements/test.txt
+rpds-py==0.9.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   referencing
 rules==3.3
     # via
     #   -r requirements/quality.txt
@@ -648,6 +694,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 urllib3==2.0.4
     # via


### PR DESCRIPTION
## Description
Uninstalls `docker-compose` python package from `dev.in`, which I'm  not sure why that had to be installed *inside* the container? https://github.com/docker/compose/issues/10836
The issue with docker-compose is that it requires pyyaml < 6, but another dependency that we need, drf-spectacular, requires pyyaml>=6 via `jsonschema` to work around a pyyaml short-coming.  Annoyingly, jsonschema needs pyyaml only to build its docs.  Dependency hell, thy name is this PR.
https://github.com/yaml/pyyaml/issues/724
https://github.com/python-jsonschema/jsonschema/issues/1139

https://openedx.atlassian.net/browse/ENT-7395

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
