### PR TITLE
fix: use drf-spec for docs, remove edx_api_doc_tools

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -1,6 +1,4 @@
 import os
-import platform
-from logging.handlers import SysLogHandler
 from os.path import abspath, dirname, join
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
@@ -14,7 +12,7 @@ from enterprise_catalog.apps.catalog.constants import (
     SYSTEM_ENTERPRISE_LEARNER_ROLE,
     SYSTEM_ENTERPRISE_OPERATOR_ROLE,
 )
-from enterprise_catalog.settings.utils import get_env_setting, get_logger_config
+from enterprise_catalog.settings.utils import get_logger_config
 
 
 # PATH vars
@@ -49,9 +47,7 @@ INSTALLED_APPS = (
 
 THIRD_PARTY_APPS = (
     # API Documentation
-    'drf_yasg',
-    'edx_api_doc_tools',
-
+    'drf_spectacular',
     'corsheaders',
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
     'django_celery_results',  # Enables a Django model as the celery result backend
@@ -144,7 +140,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'PAGE_SIZE': 10,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
@@ -425,3 +421,11 @@ USE_DEPRECATED_PYTZ = True
 
 # (ENT-5968) This is temporary until offers are implemented in the learner portal
 INTEGRATED_CUSTOMERS_WITH_SUBSIDIES_AND_OFFERS = ['731b28ee-09d1-4b89-8f7b-2c8fd0939746']
+
+# DRF Spectacular settings
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Enterprise Catalog API',
+    'DESCRIPTION': 'API for querying and commanding about enterprise catalog records.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}

--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -19,7 +19,11 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-from edx_api_doc_tools import make_api_info, make_docs_urls
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 from enterprise_catalog.apps.api import urls as api_urls
 from enterprise_catalog.apps.core import views as core_views
@@ -27,9 +31,16 @@ from enterprise_catalog.apps.core import views as core_views
 
 admin.autodiscover()
 
-api_info = make_api_info(
-    title='Enterprise Catalog API',
-    version="v1",
+spectacular_view = SpectacularAPIView(
+    api_version='v1',
+    title='enterprise-access spectacular view',
+)
+
+spec_swagger_view = SpectacularSwaggerView()
+
+spec_redoc_view = SpectacularRedocView(
+    title='Redoc view for the enterprise-access API.',
+    url_name='schema',
 )
 
 urlpatterns = [
@@ -41,9 +52,12 @@ urlpatterns = [
     # Use the same auth views for all logins, including those originating from the browseable API.
     path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
     path('health/', core_views.health, name='health'),
+    # All the API docs
+    path('api-docs/', spec_swagger_view.as_view(), name='api-docs'),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/redoc/', spec_redoc_view.as_view(url_name='schema'), name='redoc'),
+    path('api/schema/swagger-ui/', spec_swagger_view.as_view(url_name='schema'), name='swaggger-ui'),
 ]
-
-urlpatterns += make_docs_urls(api_info)
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
     import debug_toolbar

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,6 @@ django-cors-headers
 django-crum
 django-extensions
 django-model-utils
-edx-api-doc-tools
 django-simple-history
 djangorestframework
 djangorestframework-xml

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -80,8 +80,6 @@ django==3.2.20
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -132,18 +130,12 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-spectacular==0.26.4
-    # via -r requirements/base.in
-drf-yasg==1.21.7
-    # via edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via -r requirements/base.in
 edx-auth-backends==4.1.0
     # via -r requirements/base.in
@@ -176,9 +168,7 @@ importlib-resources==5.1.3
     #   jsonschema
     #   jsonschema-specifications
 inflection==0.5.1
-    # via
-    #   drf-spectacular
-    #   drf-yasg
+    # via drf-spectacular
 jinja2==3.1.2
     # via code-annotations
 jsonfield==3.1.0
@@ -203,8 +193,6 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-packaging==23.1
-    # via drf-yasg
 pbr==5.11.1
     # via stevedore
 pkgutil-resolve-name==1.3.10
@@ -242,12 +230,10 @@ pytz==2023.3
     #   -r requirements/base.in
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via
@@ -314,9 +300,7 @@ tzdata==2023.3
     #   backports-zoneinfo
     #   celery
 uritemplate==4.1.1
-    # via
-    #   drf-spectacular
-    #   drf-yasg
+    # via drf-spectacular
 urllib3==2.0.4
     # via requests
 vine==5.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -171,8 +171,6 @@ django==3.2.20
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -248,8 +246,6 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
@@ -261,15 +257,6 @@ drf-jwt==1.19.2
     #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-spectacular==0.26.4
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-drf-yasg==1.21.7
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -362,7 +349,6 @@ inflection==0.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   drf-spectacular
-    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -443,10 +429,8 @@ oauthlib==3.2.2
 packaging==23.1
     # via
     #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   build
-    #   drf-yasg
     #   gunicorn
     #   pytest
     #   tox
@@ -591,14 +575,12 @@ pytz==2023.3
     #   -r requirements/test.txt
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
     #   edx-i18n-tools
     #   responses
@@ -630,7 +612,7 @@ requests-oauthlib==1.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.23.2
+responses==0.23.3
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt
@@ -753,7 +735,6 @@ uritemplate==4.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   drf-spectacular
-    #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -145,8 +145,6 @@ django==3.2.20
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -200,8 +198,6 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/test.txt
@@ -219,12 +215,6 @@ drf-jwt==1.19.2
     #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-spectacular==0.26.4
-    # via -r requirements/test.txt
-drf-yasg==1.21.7
-    # via
-    #   -r requirements/test.txt
-    #   edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
@@ -289,7 +279,6 @@ inflection==0.5.1
     # via
     #   -r requirements/test.txt
     #   drf-spectacular
-    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -351,7 +340,6 @@ oauthlib==3.2.2
 packaging==23.1
     # via
     #   -r requirements/test.txt
-    #   drf-yasg
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
@@ -470,13 +458,11 @@ pytz==2023.3
     #   babel
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
     #   responses
 readme-renderer==40.0
@@ -506,7 +492,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.23.2
+responses==0.23.3
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
@@ -628,7 +614,6 @@ uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   drf-spectacular
-    #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -103,8 +103,6 @@ django==3.2.20
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -154,8 +152,6 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/base.txt
@@ -164,12 +160,6 @@ drf-jwt==1.19.2
     #   -r requirements/base.txt
     #   edx-drf-extensions
 drf-spectacular==0.26.4
-    # via -r requirements/base.txt
-drf-yasg==1.21.7
-    # via
-    #   -r requirements/base.txt
-    #   edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
@@ -217,7 +207,6 @@ inflection==0.5.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-    #   drf-yasg
 jinja2==3.1.2
     # via
     #   -r requirements/base.txt
@@ -260,10 +249,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
     #   social-auth-core
 packaging==23.1
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-    #   gunicorn
+    # via gunicorn
 pbr==5.11.1
     # via
     #   -r requirements/base.txt
@@ -325,14 +311,12 @@ pytz==2023.3
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via -r requirements/base.txt
@@ -419,7 +403,6 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-    #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -118,8 +118,6 @@ django==3.2.20
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -171,8 +169,6 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/base.txt
@@ -181,12 +177,6 @@ drf-jwt==1.19.2
     #   -r requirements/base.txt
     #   edx-drf-extensions
 drf-spectacular==0.26.4
-    # via -r requirements/base.txt
-drf-yasg==1.21.7
-    # via
-    #   -r requirements/base.txt
-    #   edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
@@ -232,7 +222,6 @@ inflection==0.5.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-    #   drf-yasg
 isort==5.12.0
     # via
     #   -r requirements/quality.in
@@ -282,10 +271,6 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==23.1
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
 pbr==5.11.1
     # via
     #   -r requirements/base.txt
@@ -366,13 +351,11 @@ pytz==2023.3
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
 redis==3.5.3
     # via
@@ -469,7 +452,6 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-    #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -126,8 +126,6 @@ distlib==0.3.7
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -181,8 +179,6 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/base.txt
@@ -191,12 +187,6 @@ drf-jwt==1.19.2
     #   -r requirements/base.txt
     #   edx-drf-extensions
 drf-spectacular==0.26.4
-    # via -r requirements/base.txt
-drf-yasg==1.21.7
-    # via
-    #   -r requirements/base.txt
-    #   edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
@@ -252,7 +242,6 @@ inflection==0.5.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-    #   drf-yasg
 iniconfig==2.0.0
     # via pytest
 isort==5.12.0
@@ -304,8 +293,6 @@ oauthlib==3.2.2
     #   social-auth-core
 packaging==23.1
     # via
-    #   -r requirements/base.txt
-    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.11.1
@@ -401,13 +388,11 @@ pytz==2023.3
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
     #   responses
 redis==3.5.3
@@ -434,7 +419,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-responses==0.23.2
+responses==0.23.3
     # via -r requirements/test.in
 rpds-py==0.9.2
     # via
@@ -522,7 +507,6 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-    #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -158,8 +158,6 @@ django==3.2.20
     #   djangorestframework
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-celeryutils
     #   edx-django-release-util
@@ -232,8 +230,6 @@ djangorestframework==3.14.0
     #   django-config-models
     #   drf-jwt
     #   drf-spectacular
-    #   drf-yasg
-    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
@@ -245,15 +241,6 @@ drf-jwt==1.19.2
     #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-spectacular==0.26.4
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-drf-yasg==1.21.7
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   edx-api-doc-tools
-edx-api-doc-tools==1.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -335,7 +322,6 @@ inflection==0.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   drf-spectacular
-    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -411,9 +397,7 @@ oauthlib==3.2.2
     #   social-auth-core
 packaging==23.1
     # via
-    #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.11.1
@@ -542,14 +526,12 @@ pytz==2023.3
     #   -r requirements/test.txt
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   drf-spectacular
-    #   drf-yasg
     #   edx-django-release-util
     #   responses
 redis==3.5.3
@@ -580,7 +562,7 @@ requests-oauthlib==1.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.23.2
+responses==0.23.3
     # via -r requirements/test.txt
 rpds-py==0.9.2
     # via
@@ -695,7 +677,6 @@ uritemplate==4.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   drf-spectacular
-    #   drf-yasg
 urllib3==2.0.4
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
## Description

http://localhost:18160/api-docs/ is now backed by drf-spec.  The same view lives at this route, too: http://localhost:18160/api/schema/swagger-ui/
Also, redoc: http://localhost:18160/api/schema/redoc/'

This also removes the now unused `edx_api_doc_tools`

https://openedx.atlassian.net/browse/ENT-7395

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
