### PR TITLE
feat: normalize start/end/enroll_by dates across content types

### DIFF
--- a/enterprise_catalog/apps/api/constants.py
+++ b/enterprise_catalog/apps/api/constants.py
@@ -1,0 +1,23 @@
+"""
+Constants for api app.
+"""
+
+
+class CourseMode():
+    """
+    Content metadata course mode keys.
+
+    Copied from https://github.com/edx/edx-platform/blob/831a8bcc/common/djangoapps/course_modes/models.py#L164
+    """
+    HONOR = "honor"
+    PROFESSIONAL = "professional"
+    VERIFIED = "verified"
+    AUDIT = "audit"
+    NO_ID_PROFESSIONAL_MODE = "no-id-professional"
+    CREDIT_MODE = "credit"
+    MASTERS = "masters"
+    EXECUTIVE_EDUCATION = "executive-education"
+    PAID_EXECUTIVE_EDUCATION = "paid-executive-education"
+    UNPAID_EXECUTIVE_EDUCATION = "unpaid-executive-education"
+    PAID_BOOTCAMP = "paid-bootcamp"
+    UNPAID_BOOTCAMP = "unpaid-bootcamp"


### PR DESCRIPTION
ENT-7545

## Ticket Link

[[enterprise-catalog] Expose net-new fields on the existing `content-metadata` API](https://2u-internal.atlassian.net/browse/ENT-7545)

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
