### PR TITLE
build: add pyememcache to dependencies

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -13,4 +13,5 @@ gunicorn                  # For running the application locally
 inflect
 ddt
 python-memcached
+pymemcache
 responses

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -526,6 +526,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/dev.in
 pymongo==3.13.0
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
## Description
Under the issue https://github.com/edx/edx-arch-experiments/issues/454, adding the pymemcache dependency in the requirements for cache backend migration.