### PR TITLE
feat: programs ONLY inherit UUIDs for catalogs common to ALL content within.

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from celery import shared_task, states
 from celery.exceptions import Ignore
 from celery_utils.logged_task import LoggedTask
+from django.conf import settings
 from django.db import IntegrityError
 from django.db.models import Prefetch, Q
 from django.db.utils import OperationalError
@@ -676,6 +677,7 @@ def add_metadata_to_algolia_objects(
     _add_in_algolia_products_by_object_id(algolia_products_by_object_id, batched_metadata)
 
 
+# pylint: disable=too-many-statements
 def _get_algolia_products_for_batch(
     batch_num,
     content_keys_batch,
@@ -726,6 +728,9 @@ def _get_algolia_products_for_batch(
     catalog_uuids_by_key = defaultdict(set)
     customer_uuids_by_key = defaultdict(set)
     catalog_queries_by_key = defaultdict(set)
+
+    catalog_query_uuid_by_catalog_uuid = defaultdict(set)
+    customer_uuid_by_catalog_uuid = defaultdict(set)
 
     # Create a shared convenience queryset to prefetch catalogs for all metadata lookups below.
     all_catalog_queries = CatalogQuery.objects.prefetch_related('enterprise_catalogs')
@@ -789,18 +794,42 @@ def _get_algolia_products_for_batch(
             for catalog in associated_catalogs:
                 catalog_uuids_by_key[content_key].add(str(catalog.uuid))
                 customer_uuids_by_key[content_key].add(str(catalog.enterprise_uuid))
+                # Cache UUIDs related to each catalog.
+                catalog_query_uuid_by_catalog_uuid[str(catalog.uuid)] = (str(catalog_query.uuid), catalog_query.title)
+                customer_uuid_by_catalog_uuid[str(catalog.uuid)] = str(catalog.enterprise_uuid)
 
     # Second pass.  This time the goal is to capture indirect relationships on programs:
     #  * For each program:
     #    - Absorb all UUIDs associated with every associated course.
-    for metadata in content_metadata_to_process:
-        if metadata.content_type != PROGRAM:
-            continue
-        program_content_key = metadata.content_key
-        for metadata in program_to_courses_mapping[program_content_key]:
-            catalog_queries_by_key[program_content_key].update(catalog_queries_by_key[metadata.content_key])
-            catalog_uuids_by_key[program_content_key].update(catalog_uuids_by_key[metadata.content_key])
-            customer_uuids_by_key[program_content_key].update(customer_uuids_by_key[metadata.content_key])
+    if settings.ENABLE_ENT_7729_ONLY_SHOW_COMPLETE_PROGRAMS:
+        for program_metadata in content_metadata_to_process:
+            if program_metadata.content_type != PROGRAM:
+                continue
+            program_content_key = program_metadata.content_key
+            catalog_uuids_for_courses_of_program = [
+                catalog_uuids_by_key[course_metadata.content_key]
+                for course_metadata in program_to_courses_mapping[program_content_key]
+            ]
+            common_catalogs = set()
+            if catalog_uuids_for_courses_of_program:
+                common_catalogs = set.intersection(*catalog_uuids_for_courses_of_program)
+            for course_metadata in program_to_courses_mapping[program_content_key]:
+                catalog_queries_by_key[program_content_key].update(
+                    catalog_query_uuid_by_catalog_uuid[catalog_uuid] for catalog_uuid in common_catalogs
+                )
+                catalog_uuids_by_key[program_content_key].update(common_catalogs)
+                customer_uuids_by_key[program_content_key].update(
+                    customer_uuid_by_catalog_uuid[catalog_uuid] for catalog_uuid in common_catalogs
+                )
+    else:  # Old deprecated code in this else block. Remove as part of ENT-7729.
+        for metadata in content_metadata_to_process:
+            if metadata.content_type != PROGRAM:
+                continue
+            program_content_key = metadata.content_key
+            for metadata in program_to_courses_mapping[program_content_key]:
+                catalog_queries_by_key[program_content_key].update(catalog_queries_by_key[metadata.content_key])
+                catalog_uuids_by_key[program_content_key].update(catalog_uuids_by_key[metadata.content_key])
+                customer_uuids_by_key[program_content_key].update(customer_uuids_by_key[metadata.content_key])
 
     # Third pass.  This time the goal is to capture indirect relationships on pathways:
     #  * For each pathway:

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -429,3 +429,10 @@ SPECTACULAR_SETTINGS = {
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
 }
+
+# (ENT-7729) When indexing programs in Algolia, only attach catalog query/catalog/customer UUIDs common to all content
+# within the program.  This should have the outcome of only showing completely accessible programs in the catalog search
+# page: https://enterprise.edx.org/<customer>/search
+#
+# Enable this on stage first.
+ENABLE_ENT_7729_ONLY_SHOW_COMPLETE_PROGRAMS = False


### PR DESCRIPTION
ENT-7729

Companion PR to enable this feature in stage: https://github.com/edx/edx-internal/pull/9323

## Description

Description of changes made

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
