### PR TITLE
fix: handle None type numbers

### DIFF
--- a/enterprise_catalog/apps/catalog/filters.py
+++ b/enterprise_catalog/apps/catalog/filters.py
@@ -71,22 +71,26 @@ def field_comparison(query_value, content_value, comparison_kind):
     compre the fields based on the comparison kind
     python 3.10 has match (like switch)
     """
-    if comparison_kind == 'exact':
-        return content_value == query_value
-    elif comparison_kind == 'not':
-        return content_value != query_value
-    elif comparison_kind == 'exclude':
-        return content_value != query_value
-    elif comparison_kind == 'gt':
-        return float(content_value) > float(query_value)
-    elif comparison_kind == 'gte':
-        return float(content_value) >= float(query_value)
-    elif comparison_kind == 'lt':
-        return float(content_value) < float(query_value)
-    elif comparison_kind == 'lte':
-        return float(content_value) <= float(query_value)
-    else:
-        raise QueryFilterException(f'invalid comparison kind "{comparison_kind}"')
+    try:
+        if comparison_kind == 'exact':
+            return content_value == query_value
+        elif comparison_kind == 'not':
+            return content_value != query_value
+        elif comparison_kind == 'exclude':
+            return content_value != query_value
+        elif comparison_kind == 'gt':
+            return float(content_value) > float(query_value)
+        elif comparison_kind == 'gte':
+            return float(content_value) >= float(query_value)
+        elif comparison_kind == 'lt':
+            return float(content_value) < float(query_value)
+        elif comparison_kind == 'lte':
+            return float(content_value) <= float(query_value)
+        else:
+            raise QueryFilterException(f'invalid comparison kind "{comparison_kind}"')
+    except TypeError:
+        # if content_value or query_value are None float() cannot parse
+        return False
 
 
 def does_query_match_content(query_dict, content_metadata_dict):

--- a/enterprise_catalog/apps/catalog/tests/test_filters.py
+++ b/enterprise_catalog/apps/catalog/tests/test_filters.py
@@ -384,6 +384,27 @@ class QueryFilterTests(TestCase):
         content_metadata = json.loads(content_metadata_json)
         assert not filters.does_query_match_content(query_data, content_metadata)
 
+    def test_exceptional_gt_key(self):
+        """
+        A non-matching query using an gt key.
+        """
+        query_json = """
+        {
+            "content_type":"course",
+            "first_enrollable_paid_seat_price__gt":"301"
+        }
+        """
+
+        content_metadata_json = """
+        {
+            "content_type": "course"
+        }
+        """
+
+        query_data = json.loads(query_json)
+        content_metadata = json.loads(content_metadata_json)
+        assert not filters.does_query_match_content(query_data, content_metadata)
+
     def test_exact_list(self):
         """
         A matching query using a list exact key (aka include)


### PR DESCRIPTION
## Description

- when query or content are `None` they cannot be parsed into floats and should not match with queries

```
2023-10-03 19:11:36,548 ERROR 1136 [request_id None] [celery.app.trace] trace.py:270 - Task enterprise_catalog.apps.catalog.tasks.compare_catalog_queries_to_filters_task[e34c769c-0e9c-45b6-9c87-7007a48672c8] raised unexpected: TypeError("float() argument must be a string or a number, not 'NoneType'")
Traceback (most recent call last):
  File "/edx/app/enterprise_catalog/venvs/enterprise_catalog/lib/python3.8/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/enterprise_catalog/venvs/enterprise_catalog/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 99, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/enterprise_catalog/venvs/enterprise_catalog/lib/python3.8/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/tasks.py", line 24, in compare_catalog_queries_to_filters_task
    match = filters.does_query_match_content(
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/filters.py", line 129, in does_query_match_content
    field_result = field_comparison(query_value, content_value, comparison_kind)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/filters.py", line 83, in field_comparison
    return float(content_value) >= float(query_value)
TypeError: float() argument must be a string or a number, not 'NoneType'
```
