### PR TITLE
chore: remove deprecated code for indexing catalogs for programs

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -433,11 +433,3 @@ SPECTACULAR_SETTINGS = {
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
 }
-
-# (ENT-7729) When indexing programs in Algolia, only attach catalog query/catalog/customer UUIDs common to all content
-# within the program.  This should have the outcome of only showing completely accessible programs in the catalog search
-# page: https://enterprise.edx.org/<customer>/search
-#
-# Enable this on stage first.
-ENABLE_ENT_7729_ONLY_SHOW_COMPLETE_PROGRAMS = False
-


### PR DESCRIPTION
This is the last cleanup step of ENT-7729 to remove deprecated code which improperly included catalogs in program algolia objects that did not necessarily provide all content within the program.

ENT-7729