### PR TITLE
fix: only index active programs

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -264,7 +264,8 @@ def _should_index_program(program_metadata):
 
     return program_json_metadata.get('marketing_url')\
         and program_json_metadata.get('type')\
-        and not program_json_metadata.get('hidden')
+        and not program_json_metadata.get('hidden')\
+        and program_json_metadata.get('status') == 'active'
 
 
 def partition_program_keys_for_indexing(programs_content_metadata):

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -135,6 +135,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'marketing_url': f'https://marketing.url/{self.content_key}',
                 'authoring_organizations': authoring_organizations,
                 'card_image_url': self.card_image_url,
+                'status': 'active',
             })
         elif self.content_type == LEARNER_PATHWAY:
             json_metadata.update({


### PR DESCRIPTION
## Description

Our catalog indexing job has a method which determines if a program should be included in the index or not, this method was based on a corresponding method in course discovery. Our version of the method had fallen out of of date with what was in use on the discovery side. This code change updates this method to account for program status, which is the main discrepancy at this point.
