### PR TITLE
fix: replace memcache in devstack settings

### DIFF
--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -81,7 +81,7 @@ CORS_ORIGIN_WHITELIST = [
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': 'enterprise.catalog.memcached:11211',
     }
 }


### PR DESCRIPTION
## Description

Replaces devstack Django settings to use correct memcached to be able to run enterprise-catalog locally.

## Ticket Link

N/A

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
