### PR TITLE
chore: Add pip constraints to ensure we stay on an LTS Django version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ upgrade: $(COMMON_CONSTRAINTS_TXT) piptools ## update the requirements/*.txt fil
 	# Make sure to compile files after any other files they include!
 	sed 's/Django<4.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed -i.'' 's/django-simple-history==//g' requirements/common_constraints.txt
 	pip-compile --allow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -11,10 +11,6 @@
 # Note: Changes to this file will automatically be used by other repos, referencing
 #  this file from Github directly. It does not require packaging in edx-lint.
 
-
-# using LTS django version
-
-
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,14 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+# Pull in the common constraints file
+-c common_constraints.txt
+
+# using LTS django version
+Django>=4.2,<4.3
+
+# At least version 3.4.0 of django simple history
+django-simple-history>=3.4.0
 
 # As it is not clarified what exact breaking changes will be introduced as per
 # the next major release, ensure the installed version is within boundaries.


### PR DESCRIPTION
## Description

Lock Django to the 4.2 family of releases.
