### PR TITLE
feat: ENT-7554 Added academies in Algolia index

### DIFF
--- a/enterprise_catalog/apps/academy/tests/factories.py
+++ b/enterprise_catalog/apps/academy/tests/factories.py
@@ -1,0 +1,38 @@
+from uuid import uuid4
+
+import factory
+from factory.fuzzy import FuzzyText
+
+from enterprise_catalog.apps.academy.models import Academy, Tag
+from enterprise_catalog.apps.catalog.tests.factories import (
+    EnterpriseCatalogFactory,
+)
+
+
+class TagFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `Tag` model
+    """
+    class Meta:
+        model = Tag
+
+
+class AcademyFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `Academy` model
+    """
+    class Meta:
+        model = Academy
+
+    uuid = factory.LazyFunction(uuid4)
+    title = FuzzyText(length=32)
+    short_description = FuzzyText(length=32)
+    long_description = FuzzyText(length=255)
+    enterprise_catalogs = factory.RelatedFactoryList(
+        EnterpriseCatalogFactory,
+        size=4,
+    )
+    tags = factory.RelatedFactoryList(
+        TagFactory,
+        size=4,
+    )

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -632,6 +632,7 @@ def add_metadata_to_algolia_objects(
     catalog_uuids,
     customer_uuids,
     catalog_queries,
+    academy_uuids,
 ):
     """
     Convert ContentMetadata objects into Algolia products and accumulate results into `algolia_products_by_object_id`.
@@ -673,6 +674,16 @@ def add_metadata_to_algolia_objects(
         customer_uuids,
         'enterprise_customer_uuids',
         '{}-customer-uuids-{}',
+    )
+    _add_in_algolia_products_by_object_id(algolia_products_by_object_id, batched_metadata)
+
+    # academy uuids
+    academy_uuids = sorted(list(academy_uuids))
+    batched_metadata = _batched_metadata(
+        json_metadata,
+        academy_uuids,
+        'academy_uuids',
+        '{}-academy-uuids-{}',
     )
     _add_in_algolia_products_by_object_id(algolia_products_by_object_id, batched_metadata)
 
@@ -737,9 +748,11 @@ def _get_algolia_products_for_batch(
     catalog_uuids_by_key = defaultdict(set)
     customer_uuids_by_key = defaultdict(set)
     catalog_queries_by_key = defaultdict(set)
+    academy_uuids_by_key = defaultdict(set)
 
     catalog_query_uuid_by_catalog_uuid = defaultdict(set)
     customer_uuid_by_catalog_uuid = defaultdict(set)
+    academy_uuids_by_catalog_uuid = defaultdict(set)
 
     # Create a shared convenience queryset to prefetch catalogs for all metadata lookups below.
     all_catalog_queries = CatalogQuery.objects.prefetch_related('enterprise_catalogs')
@@ -806,6 +819,10 @@ def _get_algolia_products_for_batch(
                 # Cache UUIDs related to each catalog.
                 catalog_query_uuid_by_catalog_uuid[str(catalog.uuid)] = (str(catalog_query.uuid), catalog_query.title)
                 customer_uuid_by_catalog_uuid[str(catalog.uuid)] = str(catalog.enterprise_uuid)
+                associated_academies = catalog.academies.all()
+                for academy in associated_academies:
+                    academy_uuids_by_key[content_key].add(str(academy.uuid))
+                    academy_uuids_by_catalog_uuid[str(catalog.uuid)].add(str(academy.uuid))
 
     # Second pass.  This time the goal is to capture indirect relationships on programs:
     #  * For each program:
@@ -833,6 +850,10 @@ def _get_algolia_products_for_batch(
             customer_uuids_by_key[program_content_key].update(
                 customer_uuid_by_catalog_uuid[catalog_uuid] for catalog_uuid in common_catalogs
             )
+            for catalog_uuid in common_catalogs:
+                academy_uuids_by_key[program_content_key].update(
+                    academy_uuids_by_catalog_uuid[catalog_uuid]
+                )
 
     # Third pass.  This time the goal is to capture indirect relationships on pathways:
     #  * For each pathway:
@@ -847,6 +868,7 @@ def _get_algolia_products_for_batch(
             catalog_queries_by_key[pathway_content_key].update(catalog_queries_by_key[metadata.content_key])
             catalog_uuids_by_key[pathway_content_key].update(catalog_uuids_by_key[metadata.content_key])
             customer_uuids_by_key[pathway_content_key].update(customer_uuids_by_key[metadata.content_key])
+            academy_uuids_by_key[pathway_content_key].update(academy_uuids_by_key[metadata.content_key])
 
             # Extra disabled logic to additionally absorb UUIDs from courses linked to this pathway indirectly via a
             # program (chain of association is course -> program -> pathway).  This doesn't work because
@@ -881,6 +903,7 @@ def _get_algolia_products_for_batch(
             catalog_uuids_by_key[metadata.content_key],
             customer_uuids_by_key[metadata.content_key],
             catalog_queries_by_key[metadata.content_key],
+            academy_uuids_by_key[metadata.content_key],
         )
 
         num_content_metadata_indexed += 1

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -12,6 +12,7 @@ from celery import states
 from django.test import TestCase
 from django_celery_results.models import TaskResult
 
+from enterprise_catalog.apps.academy.tests.factories import AcademyFactory
 from enterprise_catalog.apps.api import tasks
 from enterprise_catalog.apps.api.constants import CourseMode
 from enterprise_catalog.apps.api_client.discovery import CatalogQueryMetadata
@@ -661,6 +662,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
     ALGOLIA_FIELDS = [
         'key',
         'objectID',
+        'academy_uuids',
         'enterprise_customer_uuids',
         'enterprise_catalog_uuids',
         'enterprise_catalog_query_uuids',
@@ -671,8 +673,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         super().setUp()
 
         # Set up a catalog, query, and metadata for a course and course associated program
+        self.academy = AcademyFactory()
         self.enterprise_catalog_query = CatalogQueryFactory(uuid=SORTED_QUERY_UUID_LIST[0])
         self.enterprise_catalog_courses = EnterpriseCatalogFactory(catalog_query=self.enterprise_catalog_query)
+        self.enterprise_catalog_courses.academies.add(self.academy)
         self.course_metadata_published = ContentMetadataFactory(content_type=COURSE, content_key='course-1')
         self.course_metadata_published.catalog_queries.set([self.enterprise_catalog_query])
         self.course_metadata_unpublished = ContentMetadataFactory(content_type=COURSE, content_key='course-2')
@@ -711,6 +715,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             str(self.enterprise_catalog_courses.enterprise_uuid),
             str(self.enterprise_catalog_course_runs.enterprise_uuid),
         ])
+        expected_academy_uuids = [str(self.academy.uuid)]
         expected_queries = sorted([(
             str(self.enterprise_catalog_courses.catalog_query.uuid),
             self.enterprise_catalog_courses.catalog_query.title,
@@ -723,6 +728,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         return {
             'catalog_uuids': expected_catalog_uuids,
             'customer_uuids': expected_customer_uuids,
+            'academy_uuids': expected_academy_uuids,
             'query_uuids': query_uuids,
             'query_titles': query_titles,
             'course_metadata_published': self.course_metadata_published,
@@ -792,7 +798,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 15 products found.' in products_found_log_records[0]
+        assert ' 16 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_program_1_objects_to_index = []
@@ -884,7 +890,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 12 products found.' in products_found_log_records[0]
+        assert ' 13 products found.' in products_found_log_records[0]
 
         # assert the program was not indexed.
         program_uuid = program_1.json_metadata.get('uuid')
@@ -982,7 +988,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 6 products found.' in products_found_log_records[0]
+        assert ' 8 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_course_1_objects_to_index = []
@@ -996,6 +1002,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_course_1_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_course_1_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1013,6 +1024,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         expected_program_1_objects_to_index.append({
             'objectID': f'program-{program_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_program_1_objects_to_index.append({
+            'objectID': f'program-{program_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_program_1_objects_to_index.append({
             'objectID': f'program-{program_uuid}-catalog-query-uuids-0',
@@ -1078,7 +1093,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 6 products found.' in products_found_log_records[0]
+        assert ' 8 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_course_1_objects_to_index = []
@@ -1092,6 +1107,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_course_1_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_course_1_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1109,6 +1129,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         expected_program_1_objects_to_index.append({
             'objectID': f'program-{program_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': [str(self.enterprise_catalog_courses.enterprise_uuid)],
+        })
+        expected_program_1_objects_to_index.append({
+            'objectID': f'program-{program_uuid}-academy-uuids-0',
+            'academy_uuids': [str(self.enterprise_catalog_courses.academies.first().uuid)],
         })
         expected_program_1_objects_to_index.append({
             'objectID': f'program-{program_uuid}-catalog-query-uuids-0',
@@ -1162,7 +1186,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 6 products found.' in products_found_log_records[0]
+        assert ' 8 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_course_1_objects_to_index = []
@@ -1176,6 +1200,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_course_1_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_course_1_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1195,6 +1224,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': pathway_1.content_key,
             'objectID': f'learnerpathway-{pathway_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_pathway_1_objects_to_index.append({
+            'key': pathway_1.content_key,
+            'objectID': f'learnerpathway-{pathway_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_pathway_1_objects_to_index.append({
             'key': pathway_1.content_key,
@@ -1253,7 +1287,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 6 products found.' in products_found_log_records[0]
+        assert ' 8 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_course_1_objects_to_index = []
@@ -1267,6 +1301,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_course_1_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_course_1_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1286,6 +1325,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': pathway_1.content_key,
             'objectID': f'learnerpathway-{pathway_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': [str(self.enterprise_catalog_courses.enterprise_uuid)],
+        })
+        expected_pathway_1_objects_to_index.append({
+            'key': pathway_1.content_key,
+            'objectID': f'learnerpathway-{pathway_uuid}-academy-uuids-0',
+            'academy_uuids': [str(self.enterprise_catalog_courses.academies.first().uuid)],
         })
         expected_pathway_1_objects_to_index.append({
             'key': pathway_1.content_key,
@@ -1354,7 +1398,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 9 products found.' in products_found_log_records[0]
+        assert ' 12 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_course_1_objects_to_index = []
@@ -1368,6 +1412,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_course_1_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_course_1_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1387,6 +1436,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'enterprise_customer_uuids': [str(self.enterprise_catalog_courses.enterprise_uuid)],
         })
         expected_program_1_objects_to_index.append({
+            'objectID': f'program-{program_uuid}-academy-uuids-0',
+            'academy_uuids': [str(self.enterprise_catalog_courses.academies.first().uuid)],
+        })
+        expected_program_1_objects_to_index.append({
             'objectID': f'program-{program_uuid}-catalog-query-uuids-0',
             'enterprise_catalog_query_uuids': [str(self.enterprise_catalog_courses.catalog_query.uuid)],
             'enterprise_catalog_query_titles': [self.enterprise_catalog_courses.catalog_query.title],
@@ -1403,6 +1456,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': pathway_1.content_key,
             'objectID': f'learnerpathway-{pathway_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': [str(self.enterprise_catalog_courses.enterprise_uuid)],
+        })
+        expected_pathway_1_objects_to_index.append({
+            'key': pathway_1.content_key,
+            'objectID': f'learnerpathway-{pathway_uuid}-academy-uuids-0',
+            'academy_uuids': [str(self.enterprise_catalog_courses.academies.first().uuid)],
         })
         expected_pathway_1_objects_to_index.append({
             'key': pathway_1.content_key,
@@ -1507,7 +1565,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
         products_found_log_records = [record for record in info_logs.output if ' products found.' in record]
-        assert ' 15 products found.' in products_found_log_records[0]
+        assert ' 20 products found.' in products_found_log_records[0]
 
         # create expected data to be added/updated in the Algolia index.
         expected_algolia_objects_to_index = []
@@ -1521,6 +1579,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_algolia_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1540,6 +1603,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'enterprise_customer_uuids': [str(self.enterprise_catalog_courses.enterprise_uuid)],
         })
         expected_algolia_program_objects3.append({
+            'objectID': f'program-{program_uuid}-academy-uuids-0',
+            'academy_uuids': [str(self.enterprise_catalog_courses.academies.first().uuid)],
+        })
+        expected_algolia_program_objects3.append({
             'objectID': f'program-{program_uuid}-catalog-query-uuids-0',
             'enterprise_catalog_query_uuids': [str(self.enterprise_catalog_courses.catalog_query.uuid)],
             'enterprise_catalog_query_titles': [self.enterprise_catalog_courses.catalog_query.title],
@@ -1556,6 +1623,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': pathway_for_course.content_key,
             'objectID': f'learnerpathway-{pathway_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_algolia_pathway_objects.append({
+            'key': pathway_for_course.content_key,
+            'objectID': f'learnerpathway-{pathway_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_algolia_pathway_objects.append({
             'key': pathway_for_course.content_key,
@@ -1578,6 +1650,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         })
         expected_algolia_pathway_objects2.append({
             'key': pathway_for_courserun.content_key,
+            'objectID': f'learnerpathway-{pathway_uuid}-academy-uuids-0',
+            'academy_uuids': [str(self.enterprise_catalog_courses.academies.first().uuid)],
+        })
+        expected_algolia_pathway_objects2.append({
+            'key': pathway_for_courserun.content_key,
             'objectID': f'learnerpathway-{pathway_uuid}-catalog-query-uuids-0',
             'enterprise_catalog_query_uuids': [str(self.enterprise_catalog_courses.catalog_query.uuid)],
             'enterprise_catalog_query_titles': [self.enterprise_catalog_courses.catalog_query.title],
@@ -1595,6 +1672,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': pathway_key,
             'objectID': f'learnerpathway-{pathway_uuid}-customer-uuids-0',
             'enterprise_customer_uuids': algolia_data['customer_uuids'],
+        })
+        expected_algolia_pathway_objects3.append({
+            'key': pathway_key,
+            'objectID': f'learnerpathway-{pathway_uuid}-academy-uuids-0',
+            'academy_uuids': algolia_data['academy_uuids'],
         })
         expected_algolia_pathway_objects3.append({
             'key': pathway_key,
@@ -1640,7 +1722,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             with self.assertLogs(level='INFO') as info_logs:
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
-        assert ' 6 products found.' in info_logs.output[-1]
+        assert ' 7 products found.' in info_logs.output[-1]
 
         # create expected data to be added/updated in the Algolia index.
         expected_algolia_objects_to_index = []
@@ -1664,6 +1746,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-1',
             'enterprise_customer_uuids': [algolia_data['customer_uuids'][1]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': [algolia_data['academy_uuids'][0]],
         })
         expected_algolia_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1706,7 +1793,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             with self.assertLogs(level='INFO') as info_logs:
                 tasks.index_enterprise_catalog_in_algolia_task()  # pylint: disable=no-value-for-parameter
 
-        assert ' 6 products found.' in info_logs.output[-1]
+        assert ' 7 products found.' in info_logs.output[-1]
 
         # create expected data to be added/updated in the Algolia index.
         expected_algolia_objects_to_index = []
@@ -1730,6 +1817,11 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             'key': algolia_data['course_metadata_published'].content_key,
             'objectID': f'course-{published_course_uuid}-customer-uuids-1',
             'enterprise_customer_uuids': [algolia_data['customer_uuids'][1]],
+        })
+        expected_algolia_objects_to_index.append({
+            'key': algolia_data['course_metadata_published'].content_key,
+            'objectID': f'course-{published_course_uuid}-academy-uuids-0',
+            'academy_uuids': [algolia_data['academy_uuids'][0]],
         })
         expected_algolia_objects_to_index.append({
             'key': algolia_data['course_metadata_published'].content_key,
@@ -1802,7 +1894,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 tasks.index_enterprise_catalog_in_algolia_task(force, dry_run)
 
         mock_search_client().replace_all_objects.assert_not_called()
-        assert '[ENTERPRISE_CATALOG_ALGOLIA_REINDEX] [DRY RUN] 6 products found.' in info_logs.output[-1]
+        assert '[ENTERPRISE_CATALOG_ALGOLIA_REINDEX] [DRY RUN] 7 products found.' in info_logs.output[-1]
         assert any(
             '[ENTERPRISE_CATALOG_ALGOLIA_REINDEX] [DRY RUN] skipping algolia_client.replace_all_objects().' in record
             for record in info_logs.output

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -37,6 +37,7 @@ ALGOLIA_FIELDS = [
     'enterprise_catalog_uuids',
     'enterprise_catalog_query_uuids',
     'enterprise_customer_uuids',
+    'academy_uuids',
     'full_description',
     'key',  # for links to Course about pages from the Learner Portal search page
     'uuid',
@@ -103,6 +104,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'enterprise_catalog_uuids',
         'enterprise_catalog_query_uuids',
         'enterprise_customer_uuids',
+        'academy_uuids',
         'language',
         'level_type',
         'program_type',
@@ -126,6 +128,7 @@ ALGOLIA_INDEX_SETTINGS = {
     'unretrievableAttributes': [
         'enterprise_catalog_uuids',
         'enterprise_customer_uuids',
+        'academy_uuids',
     ],
     'customRanking': [
         'asc(visible_via_association)',


### PR DESCRIPTION
## Description

This PR adds the new academies to the Algolia index

## Ticket Link

[ENT-7554](https://2u-internal.atlassian.net/browse/ENT-7554)

## Sample Index

https://user-images.githubusercontent.com/34648393/281024016-f7098118-db42-40ec-857a-e9aa51a786f7.png

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
