### PR TITLE
Revert "chore: Updating Python Requirements"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -143,7 +143,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.in
 edx-django-release-util==1.3.0
     # via -r requirements/base.in
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   django-config-models
     #   edx-drf-extensions
@@ -255,7 +255,7 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   jsonschema
     #   referencing
@@ -304,7 +304,7 @@ uritemplate==4.1.1
     # via drf-spectacular
 urllib3==2.0.7
     # via requests
-vine==5.1.0
+vine==5.0.0
     # via
     #   amqp
     #   celery

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -274,7 +274,7 @@ edx-django-release-util==1.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -622,11 +622,11 @@ requests-oauthlib==1.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.23.3
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -719,6 +719,10 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/test.txt
+types-pyyaml==6.0.12.12
+    # via
+    #   -r requirements/test.txt
+    #   responses
 typing-extensions==4.8.0
     # via
     #   -r requirements/quality.txt
@@ -746,7 +750,7 @@ urllib3==2.0.7
     #   -r requirements/test.txt
     #   requests
     #   responses
-vine==5.1.0
+vine==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -222,7 +222,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/test.txt
 edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -495,11 +495,11 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.23.3
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -592,6 +592,10 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/test.txt
+types-pyyaml==6.0.12.12
+    # via
+    #   -r requirements/test.txt
+    #   responses
 typing-extensions==4.8.0
     # via
     #   -r requirements/test.txt
@@ -616,7 +620,7 @@ urllib3==2.0.7
     #   -r requirements/test.txt
     #   requests
     #   responses
-vine==5.1.0
+vine==5.0.0
     # via
     #   -r requirements/test.txt
     #   amqp

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -169,7 +169,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -342,7 +342,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -410,7 +410,7 @@ urllib3==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
-vine==5.1.0
+vine==5.0.0
     # via
     #   -r requirements/base.txt
     #   amqp

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -185,7 +185,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -382,7 +382,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -458,7 +458,7 @@ urllib3==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
-vine==5.1.0
+vine==5.0.0
     # via
     #   -r requirements/base.txt
     #   amqp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -195,7 +195,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -421,9 +421,9 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.23.3
     # via -r requirements/test.in
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -488,6 +488,8 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/test.in
+types-pyyaml==6.0.12.12
+    # via responses
 typing-extensions==4.8.0
     # via
     #   -r requirements/base.txt
@@ -511,7 +513,7 @@ urllib3==2.0.7
     #   -r requirements/base.txt
     #   requests
     #   responses
-vine==5.1.0
+vine==5.0.0
     # via
     #   -r requirements/base.txt
     #   amqp

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -258,7 +258,7 @@ edx-django-release-util==1.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -567,9 +567,9 @@ requests-oauthlib==1.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.23.3
     # via -r requirements/test.txt
-rpds-py==0.12.0
+rpds-py==0.10.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -656,6 +656,10 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/test.txt
+types-pyyaml==6.0.12.12
+    # via
+    #   -r requirements/test.txt
+    #   responses
 typing-extensions==4.8.0
     # via
     #   -r requirements/quality.txt
@@ -683,7 +687,7 @@ urllib3==2.0.7
     #   -r requirements/test.txt
     #   requests
     #   responses
-vine==5.1.0
+vine==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
This reverts commit 1512e9b2d886f4e7f3dbe9116541c07390acc909.

## Description

We're curious if vine 5.1.0 caused memory issues in our algolia task.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
