### PR TITLE
feat: ENT-7553 Added Academies api for MFEs

### DIFF
--- a/enterprise_catalog/apps/academy/tests/factories.py
+++ b/enterprise_catalog/apps/academy/tests/factories.py
@@ -1,0 +1,50 @@
+from uuid import uuid4
+
+import factory
+from factory.fuzzy import FuzzyText
+
+from enterprise_catalog.apps.academy.models import Academy, Tag
+from enterprise_catalog.apps.catalog.tests.factories import (
+    EnterpriseCatalogFactory,
+)
+
+
+class TagFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `Tag` model
+    """
+    class Meta:
+        model = Tag
+
+
+class AcademyFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `Academy` model
+    """
+    class Meta:
+        model = Academy
+
+    uuid = factory.LazyFunction(uuid4)
+    title = FuzzyText(length=32)
+    short_description = FuzzyText(length=32)
+    long_description = FuzzyText(length=255)
+
+    @factory.post_generation
+    def enterprise_catalogs(self, create, extracted, **kwargs):  # pylint: disable=unused-argument
+        if extracted:
+            for enterprise_catalog in extracted:
+                self.enterprise_catalogs.add(enterprise_catalog)  # pylint: disable=no-member
+        else:
+            enterprise_catalog1 = EnterpriseCatalogFactory()
+            enterprise_catalog2 = EnterpriseCatalogFactory()
+            self.enterprise_catalogs.set([enterprise_catalog1, enterprise_catalog2])  # pylint: disable=no-member
+
+    @factory.post_generation
+    def tags(self, create, extracted, **kwargs):  # pylint: disable=unused-argument
+        if extracted:
+            for tag in extracted:
+                self.tags.add(tag)  # pylint: disable=no-member
+        else:
+            tag1 = TagFactory()
+            tag2 = TagFactory()
+            self.tags.set([tag1, tag2])  # pylint: disable=no-member

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -4,6 +4,7 @@ from re import search
 from django.db import IntegrityError, models
 from rest_framework import serializers, status
 
+from enterprise_catalog.apps.academy.models import Academy, Tag
 from enterprise_catalog.apps.api.v1.utils import (
     get_enterprise_utm_context,
     get_most_recent_modified_time,
@@ -392,3 +393,25 @@ class EnterpriseCurationConfigSerializer(serializers.ModelSerializer):
             }
             for highlight_set in catalog_highlight_sets
         ]
+
+
+class TagsSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `Tag` model.
+    """
+    class Meta:
+        model = Tag
+        fields = '__all__'
+
+
+class AcademySerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `Academy` model.
+    """
+    enterprise_catalogs = EnterpriseCatalogSerializer(many=True)
+    tags = TagsSerializer(many=True)
+
+    class Meta:
+        model = Academy
+        fields = '__all__'
+        lookup_field = 'uuid'

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -4,6 +4,9 @@ URL definitions for enterprise catalog API version 1.
 from django.urls import path, re_path
 from rest_framework.routers import DefaultRouter
 
+from enterprise_catalog.apps.api.v1.views.academies import (
+    AcademiesReadOnlyViewSet,
+)
 from enterprise_catalog.apps.api.v1.views.catalog_csv import CatalogCsvView
 from enterprise_catalog.apps.api.v1.views.catalog_csv_data import (
     CatalogCsvDataView,
@@ -53,6 +56,7 @@ router.register(r'enterprise-curations', EnterpriseCurationConfigReadOnlyViewSet
 router.register(r'enterprise-curations-admin', EnterpriseCurationConfigViewSet, basename='enterprise-curations-admin')
 router.register(r'highlight-sets', HighlightSetReadOnlyViewSet, basename='highlight-sets')
 router.register(r'highlight-sets-admin', HighlightSetViewSet, basename='highlight-sets-admin')
+router.register(r'academies', AcademiesReadOnlyViewSet, basename='academies')
 
 urlpatterns = [
     path('enterprise-catalogs/catalog_csv_data', CatalogCsvDataView.as_view(),
@@ -66,6 +70,12 @@ urlpatterns = [
          ),
     path('enterprise-catalogs/catalog_workbook', CatalogWorkbookView.as_view(),
          name='catalog-workbook'
+         ),
+    path('academies', AcademiesReadOnlyViewSet.as_view({'get': 'list'}),
+         name='academies-list'
+         ),
+    path('academies/<uuid:uuid>/', AcademiesReadOnlyViewSet.as_view({'get': 'retrieve'}),
+         name='academies-detail'
          ),
     re_path(
         r'^enterprise-catalogs/(?P<uuid>[\S]+)/get_content_metadata',

--- a/enterprise_catalog/apps/api/v1/views/academies.py
+++ b/enterprise_catalog/apps/api/v1/views/academies.py
@@ -1,0 +1,46 @@
+from django.utils.functional import cached_property
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
+from rest_framework import permissions, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.renderers import JSONRenderer
+from rest_framework_xml.renderers import XMLRenderer
+
+from enterprise_catalog.apps.academy.models import Academy
+from enterprise_catalog.apps.api.v1.serializers import AcademySerializer
+
+
+class AcademiesReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
+    """ Viewset for Read Only operations on Academies """
+    authentication_classes = [JwtAuthentication, SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+    renderer_classes = [JSONRenderer, XMLRenderer]
+    serializer_class = AcademySerializer
+    lookup_field = 'uuid'
+
+    @cached_property
+    def request_action(self):
+        return getattr(self, 'action', None)
+
+    def get_queryset(self):
+        """
+        Returns the queryset corresponding to all academies the requesting user has access to.
+        """
+        enterprise_customer = self.request.GET.get('enterprise_customer', False)
+        all_academies = Academy.objects.all()
+        if self.request_action == 'list':
+            if enterprise_customer:
+                user_accessible_academy_uuids = []
+                for academy in all_academies:
+                    academy_associated_catalogs = academy.enterprise_catalogs.all()
+                    enterprise_associated_catalogs = academy_associated_catalogs.filter(
+                        enterprise_uuid=enterprise_customer
+                    )
+                    if enterprise_associated_catalogs:
+                        user_accessible_academy_uuids.append(academy.uuid)
+                return all_academies.filter(uuid__in=user_accessible_academy_uuids)
+            else:
+                return Academy.objects.none()
+
+        return Academy.objects.all()


### PR DESCRIPTION
## Description

This PR adds an API for accessing the Academy model via MFEs

## Ticket Link

[ENT-7553](https://2u-internal.atlassian.net/browse/ENT-7553)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
