### PR TITLE
fix: set DJANGO_SETTINGS_MODULE in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+ENV DJANGO_SETTINGS_MODULE enterprise_access.settings.production
 
 # Prod ports
 EXPOSE 8160

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ENV DJANGO_SETTINGS_MODULE enterprise_access.settings.production
+ENV DJANGO_SETTINGS_MODULE enterprise_catalog.settings.production
 
 # Prod ports
 EXPOSE 8160


### PR DESCRIPTION
## Description

as seen here https://github.com/openedx/enterprise-access/blob/main/Dockerfile#L66

k8s deployment issue:

```
...
  File "/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 82, in _setup
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Requested settings, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```