### PR TITLE
feat: adding ability to fetch all catalogs that contain a piece of content

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_content_indexing.py
+++ b/enterprise_catalog/apps/catalog/algolia_content_indexing.py
@@ -1,0 +1,26 @@
+from enterprise_catalog.apps.catalog.filters import does_query_match_content
+from enterprise_catalog.apps.catalog.models import (
+    ContentMetadata,
+    EnterpriseCatalog,
+)
+
+
+def get_catalogs_for_content(course_key, catalog_filter=None):
+    """
+    Retrieve all catalogs that contain the given course_key.
+
+    Arguments:
+        course_key (str): Course key to lookup the content metadata object for comparison against the catalog query
+            filters
+
+        catalog_filter (dict): Optional filter to apply to the catalogs queryset
+    """
+    content_object = ContentMetadata.objects.get(content_key=course_key)
+    if catalog_filter is None:
+        catalog_filter = {}
+    included_catalogs = []
+    for catalog in EnterpriseCatalog.objects.filter(**catalog_filter):
+        if does_query_match_content(catalog.catalog_query.content_filter, content_object.json_metadata):
+            included_catalogs.append(catalog)
+
+    return included_catalogs

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_content_indexing.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_content_indexing.py
@@ -1,0 +1,44 @@
+""" Tests for catalog query filtering. """
+import logging
+
+import ddt
+from django.test import TestCase
+
+from enterprise_catalog.apps.catalog.algolia_content_indexing import (
+    get_catalogs_for_content,
+)
+from enterprise_catalog.apps.catalog.tests.factories import (
+    CatalogQueryFactory,
+    ContentMetadataFactory,
+    EnterpriseCatalogFactory,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@ddt.ddt
+class AlgoliaContentIndexingTests(TestCase):
+    """ Tests for catalog query filtering. """
+
+    def test_does_content_belong_in_catalog(self):
+        """ Test that `get_catalogs_for_content_metadata` matches content to correct catalog. """
+        content_metadata = ContentMetadataFactory(content_type='course')
+        content_key = content_metadata.json_metadata.get('key')
+        status = content_metadata.json_metadata.get('status')
+
+        included_query = CatalogQueryFactory(
+            content_filter={'content_type': 'course', 'status': status, 'key': content_key}
+        )
+        excluded_query = CatalogQueryFactory(
+            content_filter={'content_type': 'course', 'status': status, 'key__exclude': [content_key]}
+        )
+        included_catalog = EnterpriseCatalogFactory(
+            catalog_query=included_query
+        )
+        EnterpriseCatalogFactory(
+            catalog_query=excluded_query
+        )
+        found_catalogs = get_catalogs_for_content(content_key)
+        assert len(found_catalogs) == 1
+        assert found_catalogs[0] == included_catalog


### PR DESCRIPTION
## Description

added ability to find all catalogs that have a filter for a piece of provided content

## Ticket Link

TBD

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
