### PR TITLE
feat: Add manufacture_data django command

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/manufacture_data.py
+++ b/enterprise_catalog/apps/catalog/management/commands/manufacture_data.py
@@ -1,0 +1,20 @@
+"""
+Management command for making instances of models with test factories.
+"""
+
+from edx_django_utils.data_generation.management.commands.manufacture_data import \
+    Command as BaseCommand
+
+from enterprise_catalog.apps.academy.tests.factories import *
+from enterprise_catalog.apps.catalog.tests.factories import *
+from enterprise_catalog.apps.curation.tests.factories import *
+
+
+class Command(BaseCommand):
+    """
+    Management command for generating Django records from factories with custom attributes
+
+    Example usage:
+        $ ./manage.py manufacture_data --model enterprise_catalog.apps.catalog.models.EnterpriseCatalog /
+            -title "Test Catalog"
+    """

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -74,7 +74,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
     title = factory.Faker('lexify', text=f'{FAKE_CONTENT_TITLE_PREFIX} ??????????')
 
     # model fields
-    content_key = factory.Sequence(lambda n: f'{str(n).zfill(5)}_metadata_item')
+    content_key = factory.Faker('bothify', text='??????????+####')
     content_uuid = factory.LazyFunction(uuid4)
     content_type = factory.Iterator([COURSE_RUN, COURSE, PROGRAM, LEARNER_PATHWAY])
     parent_content_key = None

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,6 +19,7 @@ drf-spectacular
 edx-auth-backends
 edx-celeryutils
 edx-django-release-util
+edx-django-utils
 edx-drf-extensions
 edx_rbac
 edx-rest-api-client

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -145,8 +145,9 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.in
 edx-django-release-util==1.3.0
     # via -r requirements/base.in
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
+    #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -177,7 +178,7 @@ jsonfield==3.1.0
     # via edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via drf-spectacular
 jsonschema-specifications==2023.12.1
     # via jsonschema

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -287,7 +287,7 @@ edx-django-release-util==1.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -394,7 +394,7 @@ jsonfield2==4.0.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -726,7 +726,7 @@ tomlkit==0.12.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-tox==4.12.0
+tox==4.12.1
     # via -r requirements/test.txt
 typing-extensions==4.9.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -47,7 +47,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   celery
     #   django
     #   kombu
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 billiard==4.2.0
     # via
@@ -235,7 +235,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/test.txt
 edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -311,7 +311,7 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/test.txt
     #   drf-spectacular
@@ -600,7 +600,7 @@ tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.12.0
+tox==4.12.1
     # via -r requirements/test.txt
 typing-extensions==4.9.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -170,7 +170,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -220,7 +220,7 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -186,7 +186,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -238,7 +238,7 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -202,7 +202,7 @@ edx-celeryutils==1.2.3
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -264,7 +264,7 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
@@ -490,7 +490,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.12.3
     # via pylint
-tox==4.12.0
+tox==4.12.1
     # via -r requirements/test.in
 typing-extensions==4.9.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -271,7 +271,7 @@ edx-django-release-util==1.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -360,7 +360,7 @@ jsonfield2==4.0.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -664,7 +664,7 @@ tomlkit==0.12.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-tox==4.12.0
+tox==4.12.1
     # via -r requirements/test.txt
 typing-extensions==4.9.0
     # via


### PR DESCRIPTION
## Description

Adding support for the manufacture_data command from https://github.com/openedx/edx-django-utils/pull/369

## Ticket Link
[ENT-7510](https://2u-internal.atlassian.net/browse/ENT-7510)

## Testing

1. `make app-shell`
2. `make requirements`
3. `python ./manage.py manufacture_data --model enterprise_catalog.apps.catalog.models.EnterpriseCatalog --title "Test Catalog"`

## Test Cases

- [x] `python ./manage.py manufacture_data --model enterprise_catalog.apps.catalog.models.EnterpriseCatalog --title "Test Catalog"`
- [x] `python ./manage.py manufacture_data --model enterprise_catalog.apps.curation.models. EnterpriseCurationConfig --title "Test Curation Config"`
- [x] `python ./manage.py manufacture_data --model enterprise_catalog.apps.academy.models.Academy --title "Test Academy"`

## TODO

- [x] Add to requirements after https://github.com/openedx/edx-django-utils/pull/369 is merged

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
