### PR TITLE
feat: Updated admin interface for m2m fields in academies

### DIFF
--- a/enterprise_catalog/apps/academy/admin.py
+++ b/enterprise_catalog/apps/academy/admin.py
@@ -14,6 +14,7 @@ class TagAdmin(admin.ModelAdmin):
     """
     list_display = ('id', 'title', )
     search_fields = ('title', )
+    filter_horizontal = ('content_metadata',)
 
 
 @admin.register(Academy)
@@ -23,3 +24,4 @@ class AcademyAdmin(SimpleHistoryAdmin):
     """
     list_display = ('uuid', 'title', 'created', 'modified', )
     search_fields = ('title', 'short_description', 'long_description', )
+    filter_horizontal = ('enterprise_catalogs', 'tags', )


### PR DESCRIPTION
## Description

This PR updates the django admin page for academies/tags to show horizontal filtering and selection interface for many to many type fields.

## Ticket Link

Link to the associated ticket
[ENT-8192](https://2u-internal.atlassian.net/browse/ENT-8192)

## Screenshots

<img width="1079" alt="image" src="https://github.com/openedx/enterprise-catalog/assets/34648393/1f027e2b-3a4c-4f54-8f17-272360eb8336">
<img width="1094" alt="image" src="https://github.com/openedx/enterprise-catalog/assets/34648393/1c480337-4754-408c-9388-0fb8d6fe9d41">
<img width="1047" alt="image" src="https://github.com/openedx/enterprise-catalog/assets/34648393/4f443b0e-caea-49ce-9150-d333510c5187">

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
