### PR TITLE
feat: increase the update_content_metadata timeout

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -80,7 +80,7 @@ DISCOVERY_PROGRAM_KEY_BATCH_SIZE = 50
 # Async task constants
 REINDEX_TASK_BATCH_SIZE = 10
 TASK_BATCH_SIZE = 250
-TASK_TIMEOUT = 2 * 60 * 60  # Gives tasks (usually chains) 2 hours to return before timing out
+TASK_TIMEOUT = 3 * 60 * 60  # Gives tasks (usually chains) 3 hours to return before timing out
 
 # Which fields should be plucked from the /search/all course-discovery API
 # response in `update_catalog_metadata_task` for course content metadata?


### PR DESCRIPTION
## Description

- job is taking longer these days
- new stuff has been added to the index like reviews
- still tuning k8s
- algolia job has already been pushed back so we have space