### PR TITLE
fix: task recovery when autoscaler kills pod

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -346,6 +346,10 @@ CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
 # see https://github.com/celery/django-celery-results/issues/326
 # on CELERY_RESULT_EXTENDED
 CELERY_RESULT_EXTENDED = True
+# these settings allow recovery when autoscaling ends up killing a task
+# see https://stackoverflow.com/a/45059806
+CELERY_ACKS_LATE = True
+CELERY_TASK_REJECT_ON_WORKER_LOST = True
 
 # Celery task time limits.
 # Tasks will be asked to quit after 15 minutes...


### PR DESCRIPTION
## Description

- autoscaling worker pods up and down
- content update job no longer "finishes" even when work is complete
- https://stackoverflow.com/questions/45045980/what-different-between-task-reject-on-worker-lost-and-task-acks-late-in-celery/45059806#45059806 
- https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_acks_late
- https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_reject_on_worker_lost
- https://adamj.eu/tech/2020/02/03/common-celery-issues-on-django-projects/#acks-behaviour
- https://devcenter.heroku.com/articles/celery-heroku#using-acks_late