### PR TITLE
chore: adding status to highlighted content

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -313,6 +313,7 @@ class HighlightedContentSerializer(serializers.ModelSerializer):
             'title',
             'card_image_url',
             'authoring_organizations',
+            'course_run_statuses',
         ]
 
     def get_aggregation_key(self, obj):

--- a/enterprise_catalog/apps/curation/models.py
+++ b/enterprise_catalog/apps/curation/models.py
@@ -209,6 +209,15 @@ class HighlightedContent(TimeStampedModel):
         return self.content_metadata.json_metadata.get('title')  # pylint: disable=no-member
 
     @property
+    def course_run_statuses(self):
+        """
+        Returns the status of the associated ContentMetadata.
+        """
+        if not self.content_metadata:
+            return None
+        return self.content_metadata.json_metadata.get('course_run_statuses')  # pylint: disable=no-member
+
+    @property
     def card_image_url(self):
         """
         Returns the image URL from the raw metadata of the associated ContentMetadata object.


### PR DESCRIPTION
## Description

Adding in the variable 'course_run_statuses' to be able to determine if courses are archived in a highlight set. 

<img width="682" alt="Screenshot 2024-01-18 at 10 37 33 AM" src="https://github.com/openedx/enterprise-catalog/assets/31229189/749fd2e2-a6ee-42ab-8862-192179781286">

## Ticket Link

[Link to the associated ticket](https://2u-internal.atlassian.net/browse/ENT-8238)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
