### PR TITLE
feat: drop include_exec_ed_2u_courses logic

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -76,6 +76,11 @@ class ContentMetadataAdmin(UnchangeableMixin):
 @admin.register(CatalogQuery)
 class CatalogQueryAdmin(UnchangeableMixin):
     """ Admin configuration for the custom CatalogQuery model. """
+    fields = (
+        'uuid',
+        'title',
+        'content_filter',
+    )
     list_display = (
         'uuid',
         'content_filter_hash',


### PR DESCRIPTION
## Description

- in prep for dropping the field entirely
- we've already added query exclusions: https://2u-internal.atlassian.net/browse/ENT-7893
- we've already already remove it from the LMS ui: https://github.com/openedx/edx-enterprise/pull/2001