### PR TITLE
fix: get_course_bayesian_average TypeError

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -388,15 +388,18 @@ def get_course_bayesian_average(course):
     Using the global average review value to calculate an individual course's bayesian average review value.
     https://www.algolia.com/doc/guides/managing-results/must-do/custom-ranking/how-to/bayesian-average/
     """
-    total_avg = get_global_course_review_avg()
-    avg_review = course.get('avg_course_rating')
-    ratings_count = course.get('reviews_count')
-    if avg_review is not None and ratings_count is not None:
-        return (
-            (avg_review * ratings_count) + (total_avg * COURSE_REVIEW_BAYESIAN_CONFIDENCE_NUMBER)
-        ) / (ratings_count + COURSE_REVIEW_BAYESIAN_CONFIDENCE_NUMBER)
-    else:
+    if course.get('avg_course_rating') is None:
         return 0
+
+    if course.get('reviews_count') is None:
+        return 0
+
+    total_avg = float(get_global_course_review_avg())
+    avg_review = float(course.get('avg_course_rating'))
+    ratings_count = float(course.get('reviews_count'))
+    return (
+        (avg_review * ratings_count) + (total_avg * COURSE_REVIEW_BAYESIAN_CONFIDENCE_NUMBER)
+    ) / (ratings_count + COURSE_REVIEW_BAYESIAN_CONFIDENCE_NUMBER)
 
 
 def get_course_language(course):


### PR DESCRIPTION
## Description

- type error in the new bayesian average calculation, python thinks its doing string concatenation rather than math

```
    return wrapped(*args, **kwargs)
  File "/venv/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 100, in wrapper
    return wrapped(*args, **kwargs)
  File "/venv/lib/python3.8/site-packages/celery/app/task.py", line 411, in __call__
    return self.run(*args, **kwargs)
  File "/venv/lib/python3.8/site-packages/celery/app/autoretry.py", line 38, in run
    return task._orig_run(*args, **kwargs)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 221, in wrapped_task
    return task(self, *args, **kwargs)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 592, in index_enterprise_catalog_in_algolia_task
    raise exep
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 583, in index_enterprise_catalog_in_algolia_task
    _reindex_algolia(
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 1079, in _reindex_algolia
    _index_content_keys_in_algolia(
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 1034, in _index_content_keys_in_algolia
    algolia_client.replace_all_objects(algolia_products_generator)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api_client/algolia.py", line 109, in replace_all_objects
    self.algolia_index.replace_all_objects(algolia_objects, {
  File "/venv/lib/python3.8/site-packages/algoliasearch/search_index.py", line 112, in replace_all_objects
    responses.push(tmp_index.save_objects(objects, request_options))
  File "/venv/lib/python3.8/site-packages/algoliasearch/search_index.py", line 71, in save_objects
    response = self._chunk("updateObject", objects, request_options)
  File "/venv/lib/python3.8/site-packages/algoliasearch/search_index.py", line 511, in _chunk
    for obj in objects:
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 1022, in <genexpr>
    algolia_products_generator = (
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 1007, in <genexpr>
    _get_algolia_products_for_batch(
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api/tasks.py", line 971, in _get_algolia_products_for_batch
    return create_algolia_objects(algolia_products_by_object_id.values(), ALGOLIA_FIELDS)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/algolia_utils.py", line 1333, in create_algolia_objects
    algolia_objects = [
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/algolia_utils.py", line 1334, in <listcomp>
    _algolia_object_from_product(product, algolia_fields)
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/algolia_utils.py", line 1275, in _algolia_object_from_product
    'course_bayesian_average': get_course_bayesian_average(searchable_product),
  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/algolia_utils.py", line 396, in get_course_bayesian_average
    (avg_review * ratings_count) + (total_avg * COURSE_REVIEW_BAYESIAN_CONFIDENCE_NUMBER)
TypeError: can only concatenate str (not "float") to str

2024-01-29 18:51:35,238 INFO 1 [request_id None] [enterprise_catalog.apps.catalog.management.commands.reindex_algolia] reindex_algolia.py:60 - index_enterprise_catalog_in_algolia_task from command reindex_algolia finished successfully.
```