### PR TITLE
fix: making non-editable query field readonly in admin

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -81,6 +81,7 @@ class CatalogQueryAdmin(UnchangeableMixin):
         'title',
         'content_filter',
     )
+    readonly_fields = ('uuid',)
     list_display = (
         'uuid',
         'content_filter_hash',


### PR DESCRIPTION
## Description

UUID is not editable, django throws an error if you don't tell the admin page to make a non editable field read only.  

## Ticket Link

Link to the associated ticket
[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
