### PR TITLE
feat: improved handling of json errors

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -79,7 +79,15 @@ class DiscoveryApiClient(BaseOAuthClient):
                 if exception:
                     raise exception
                 break
-        return response.json()
+        try:
+            return response.json()
+        except requests.exceptions.JSONDecodeError as err:
+            LOGGER.exception(
+                f'Invalid JSON while retrieving results from course-discovery for page {page}, '
+                f'resonse status code: {response.status_code}, '
+                f'response body: {response.text}'
+            )
+            raise err
 
     def _retrieve_course_reviews(self, request_params):
         """
@@ -120,7 +128,15 @@ class DiscoveryApiClient(BaseOAuthClient):
                 if exception:
                     raise exception
                 break
-        return response.json()
+        try:
+            return response.json()
+        except requests.exceptions.JSONDecodeError as err:
+            LOGGER.exception(
+                f'Invalid JSON while retrieving course review results from course-discovery for page {page}, '
+                f'resonse status code: {response.status_code}, '
+                f'response body: {response.text}'
+            )
+            raise err
 
     def get_course_reviews(self, course_keys=None):
         """


### PR DESCRIPTION
## Description

- better logging of errors related to invalid json
- help us debug why... bad query? transient discovery error?

```
2024-02-02 18:38:43,651 ERROR 23 [request_id None] [enterprise_catalog.apps.catalog.models] models.py:963 - update_contentmetadata_from_discovery failed <CatalogQuery: (211) with content_filter_hash '210486dc22d5186416012be05fe37ab4' and content_filter '{    "course_type__exclude": "executive-education-2u"}'>Traceback (most recent call last):  File "/venv/lib/python3.8/site-packages/requests/models.py", line 971, in json    return complexjson.loads(self.text, **kwargs)  File "/venv/lib/python3.8/site-packages/simplejson/__init__.py", line 514, in loads    return _default_decoder.decode(s)  File "/venv/lib/python3.8/site-packages/simplejson/decoder.py", line 386, in decode    obj, end = self.raw_decode(s)  File "/venv/lib/python3.8/site-packages/simplejson/decoder.py", line 416, in raw_decode    return self.scan_once(s, idx=_w(s, idx).end())simplejson.errors.JSONDecodeError: Expecting value: line 2 column 1 (char 1)During handling of the above exception, another exception occurred:Traceback (most recent call last):  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/catalog/models.py", line 961, in update_contentmetadata_from_discovery    metadata = CatalogQueryMetadata(catalog_query).metadata  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api_client/discovery.py", line 328, in __init__    self.catalog_query_data = self._get_catalog_query_metadata(catalog_query)  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api_client/discovery.py", line 350, in _get_catalog_query_metadata    catalog_query_data = client.get_metadata_by_query(catalog_query)  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api_client/discovery.py", line 194, in get_metadata_by_query    raise exc  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api_client/discovery.py", line 185, in get_metadata_by_query    response = self._retrieve_metadata_for_content_filter(content_filter, page, request_params)  File "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/apps/api_client/discovery.py", line 82, in _retrieve_metadata_for_content_filter    return response.json()  File "/venv/lib/python3.8/site-packages/requests/models.py", line 975, in json    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)requests.exceptions.JSONDecodeError: Expecting value: line 2 column 1 (char 1)
```