### PR TITLE
feat: adding modified time to content metadata django admin page as readonly

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -63,6 +63,7 @@ class ContentMetadataAdmin(UnchangeableMixin):
         'associated_content_metadata',
         'catalog_queries',
         'get_catalog',
+        'modified',
     )
 
     @admin.display(description='Enterprise Catalogs')


### PR DESCRIPTION

![image](https://github.com/openedx/enterprise-catalog/assets/67655836/589acb68-f528-4dcb-9a47-5584bc5cd604)


## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
