### PR TITLE
bug: fix makefile to remove extraenous common_constraints.txt. file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ upgrade: $(COMMON_CONSTRAINTS_TXT) piptools ## update the requirements/*.txt fil
 	# Make sure to compile files after any other files they include!
 	sed 's/Django<4.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	sed -i.'' 's/django-simple-history==//g' requirements/common_constraints.txt
+	sed -i 's/django-simple-history==//g' requirements/common_constraints.txt
 	pip-compile --allow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt


### PR DESCRIPTION
## Description

The `make upgrade` command was generating an extraneous `common_constraints.txt.` file as a result of a bug in the `Makefile`. 

## Ticket Link

Link to the associated ticket
[enterprise-catalog: make upgrade adding extraneous common_contraints.txt.](https://2u-internal.atlassian.net/browse/ENT-8309)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
