### PR TITLE
feat: ability to include unlisted courses in catalogs

### DIFF
--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -102,6 +102,8 @@ PROGRAM_TYPES_MAP = {
     'Certificación Profesional': 'Certificación Profesional',
 }
 
+FORCE_INCLUSION_METADATA_TAG_KEY = 'enterprise_force_included'
+
 
 def json_serialized_course_modes():
     """

--- a/enterprise_catalog/apps/catalog/content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/content_metadata_utils.py
@@ -1,0 +1,39 @@
+"""
+Utility functions for manipulating content metadata.
+"""
+
+from logging import getLogger
+
+from .constants import FORCE_INCLUSION_METADATA_TAG_KEY
+
+
+LOGGER = getLogger(__name__)
+
+
+def tansform_force_included_courses(courses):
+    """
+    Transform a list of forced/unlisted course metadata
+    ENT-8212
+    """
+    results = []
+    for course_metadata in courses:
+        results += transform_course_metadata_to_visible(course_metadata)
+    return results
+
+
+def transform_course_metadata_to_visible(course_metadata):
+    """
+    Transform an individual forced/unlisted course metadata
+    so that it is visible/available/published in our metadata
+    ENT-8212
+    """
+    course_metadata[FORCE_INCLUSION_METADATA_TAG_KEY] = True
+    advertised_course_run_uuid = course_metadata.get('advertised_course_run_uuid')
+    course_run_statuses = []
+    for course_run in course_metadata.get('course_runs', []):
+        if course_run.get('uuid') == advertised_course_run_uuid:
+            course_run['status'] = 'published'
+            course_run['availability'] = 'Current'
+        course_run_statuses.append(course_run.get('status'))
+    course_metadata['course_run_statuses'] = course_run_statuses
+    return course_metadata

--- a/enterprise_catalog/apps/catalog/tests/test_content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_content_metadata_utils.py
@@ -1,0 +1,53 @@
+from uuid import uuid4
+
+from django.test import TestCase
+
+from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    tansform_force_included_courses,
+    transform_course_metadata_to_visible,
+)
+
+
+class ContentMetadataUtilsTests(TestCase):
+    """
+    Tests for content metadata utils.
+    """
+
+    def test_transform_course_metadata_to_visible(self):
+        advertised_course_run_uuid = str(uuid4())
+        content_metadata = {
+            'advertised_course_run_uuid': advertised_course_run_uuid,
+            'course_runs': [
+                {
+                    'uuid': advertised_course_run_uuid,
+                    'status': 'unpublished',
+                    'availability': 'Coming Soon',
+                }
+            ],
+            'course_run_statuses': [
+                'unpublished'
+            ]
+        }
+        transform_course_metadata_to_visible(content_metadata)
+        assert content_metadata['course_runs'][0]['status'] == 'published'
+        assert content_metadata['course_runs'][0]['availability'] == 'Current'
+        assert content_metadata['course_run_statuses'][0] == 'published'
+
+    def test_tansform_force_included_courses(self):
+        advertised_course_run_uuid = str(uuid4())
+        content_metadata = {
+            'advertised_course_run_uuid': advertised_course_run_uuid,
+            'course_runs': [
+                {
+                    'uuid': advertised_course_run_uuid,
+                    'status': 'unpublished',
+                    'availability': 'Coming Soon',
+                }
+            ],
+            'course_run_statuses': [
+                'unpublished'
+            ]
+        }
+        courses = [content_metadata]
+        tansform_force_included_courses(courses)
+        assert courses[0]['course_runs'][0]['status'] == 'published'


### PR DESCRIPTION
## Description

- introduces a new catalog query parameter `enterprise_force_include_aggregation_keys`
- when a catalog's metadata is downloaded, we include the courseware in addition to whatever the query provides
- discovery ignores keys it doesn't understand
- force-included keys will be added and transformed to appear published and available in the enterprise catalog service
- courses are marked with a magic key
- https://2u-internal.atlassian.net/browse/ENT-8212

## Todo

- [ ] we may need additional metadata transformers, such as enrollment start date