### PR TITLE
feat: content metadata list filter accepts uuids

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2395,7 +2395,8 @@ class ContentMetadataViewTests(APITestMixin):
         Test a successful, expected api response for the metadata list endpoint with a supplied content keys query
         param
         """
-        url = reverse('api:v1:content-metadata-list') + f"?content_keys={self.content_metadata_object.content_key}"
+        query_param_string = f"?content_identifiers={self.content_metadata_object.content_key}"
+        url = reverse('api:v1:content-metadata-list') + query_param_string
         response = self.client.get(url)
         response_json = response.json()
         assert len(response_json.get('results')) == 1
@@ -2413,3 +2414,15 @@ class ContentMetadataViewTests(APITestMixin):
         response = self.client.get(url)
         response_json = response.json()
         assert response_json.get('title') == self.content_metadata_object.json_metadata.get('title')
+
+    def test_filter_list_by_uuid(self):
+        """
+        Test that the list content_identifiers query param accepts uuids
+        """
+        query_param_string = f"?content_identifiers={self.content_metadata_object.content_uuid}"
+        url = reverse('api:v1:content-metadata-list') + query_param_string
+        response = self.client.get(url)
+        response_json = response.json()
+        assert len(response_json.get('results')) == 1
+        assert response_json.get('results')[0].get("key") == self.content_metadata_object.content_key
+        assert response_json.get('results')[0].get("course_runs")[0].get('start') == '2024-02-12T11:00:00Z'

--- a/enterprise_catalog/apps/api/v1/views/content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/content_metadata.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     JwtAuthentication,
 )
@@ -26,10 +27,10 @@ class ContentMetadataView(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self, **kwargs):
         """
-        Returns all content metadata objects filtered by an optional request query param ``content_keys`` (LIST).
+        Returns all content metadata objects filtered by an optional request query param (LIST) ``content_identifiers``
         """
-        content_filter = kwargs.get('content_keys')
+        content_filter = kwargs.get('content_identifiers')
         queryset = self.queryset
         if content_filter:
-            return queryset.filter(content_key__in=content_filter)
+            return queryset.filter(Q(content_key__in=content_filter) | Q(uuid__in=content_filter))
         return queryset


### PR DESCRIPTION
## Description

Allow the content metadata read only endpoint to specify uuid as an identifying filter

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
