### PR TITLE
feat: catalog django admin useability improvement

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -119,6 +119,14 @@ class EnterpriseCatalogAdmin(UnchangeableMixin):
         'catalog_query__content_filter_hash__exact'
     )
 
+    autocomplete_fields = (
+        'catalog_query',
+    )
+
+    list_select_related = (
+        'catalog_query',
+    )
+
     @admin.display(
         description='Catalog Query'
     )


### PR DESCRIPTION
## Description

* Use an auto-complete field for the catalog query on the catalog details page - avoids trying to load lots of query records into a dropdown.
* Use select-related on the catalog list view - avoids 1+N queries when listing catalogs.
