### PR TITLE
fix: fixing serializer when missing ent catalog in context

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -288,6 +288,10 @@ class ContentMetadataSerializer(ImmutableStateSerializer):
         child course run and adds it to the serialized representation of the
         course run record in `serialized_course_runs`.
         """
+        # Early guard in case the context has no catalog
+        if not self.context.get('enterprise_catalog'):
+            return
+
         urls_by_course_run_key = {}
         for course_run in ContentMetadata.get_child_records(course_instance):
             urls_by_course_run_key[course_run.content_key] = \


### PR DESCRIPTION
## Description

Key error when the serializer goes to fetch metadata without an enterprise catalog in the serializer context (to fetch enrollment URLS). Enterprise-less content metadata doesn't care about the enrollment URL, so don't try and fetch if there is no such context.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
