### PR TITLE
fix: adding logo/org name override

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -475,13 +475,15 @@ def get_course_partners(course):
     """
     partners = []
     owners = course.get('owners') or []
+    org_name_override = course.get('organization_short_code_override')
+    logo_override = course.get('organization_logo_override_url')
 
     for owner in owners:
         partner_name = owner.get('name')
         if partner_name:
             partner_metadata = {
-                'name': partner_name,
-                'logo_image_url': owner.get('logo_image_url'),
+                'name': org_name_override or partner_name,
+                'logo_image_url': logo_override or owner.get('logo_image_url'),
             }
             partners.append(partner_metadata)
 

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -235,6 +235,25 @@ class AlgoliaUtilsTests(TestCase):
                 },
             ],
         ),
+        (
+            {
+                'owners': [
+                    {
+                        'name': 'Test Org Name',
+                        'logo_image_url': 'https://fake.image1',
+                        'ignored_attr': None,
+                    },
+                ],
+                'organization_short_code_override': 'Org Name Override',
+                'organization_logo_override_url': 'https://fake.image2',
+            },
+            [
+                {
+                    'name': 'Org Name Override',
+                    'logo_image_url': 'https://fake.image2',
+                },
+            ]
+        )
     )
     @ddt.unpack
     def test_get_course_partners(self, course_metadata, expected_partners):


### PR DESCRIPTION
## Description

We aren't using the variables that customers set in discovery `organization_logo_override_url` and `organization_short_code_override`. With this ticket, we will be mimicking the [B2C functionality here](https://github.com/edx/prospectus/blob/111e6a9d93113435586ac78e43950e611e109746/src/packages/common/ui/ProductCard/Wrapper/index.tsx#L36) that prioritizes these variables if they are set. 

## Ticket Link

Link to the associated ticket
[ENT-8368](https://2u-internal.atlassian.net/browse/ENT-8368)

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
