### PR TITLE
fix: adding archived count to serializer

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -6,6 +6,7 @@ from rest_framework import serializers, status
 
 from enterprise_catalog.apps.academy.models import Academy, Tag
 from enterprise_catalog.apps.api.v1.utils import (
+    get_archived_content_count,
     get_enterprise_utm_context,
     get_most_recent_modified_time,
     is_any_course_run_active,
@@ -395,6 +396,7 @@ class EnterpriseCurationConfigSerializer(serializers.ModelSerializer):
                 'highlighted_content_uuids': [
                     item.uuid for item in highlight_set.highlighted_content.order_by('created')
                 ],
+                'archived_content_count': get_archived_content_count(highlight_set.highlighted_content.all()),
             }
             for highlight_set in catalog_highlight_sets
         ]

--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -215,6 +215,17 @@ class EnterpriseCurationConfigReadOnlyViewSetTests(CurationAPITestBase):
         expected_highlighted_content_uuids = [str(hc.uuid) for hc in self.highlighted_content_list_one]
         assert highlighted_content_uuids == expected_highlighted_content_uuids
 
+    def test_archive_content_count(self):
+        """
+        Test that the count of archived content is serialized correctly.
+        """
+        url = reverse('api:v1:enterprise-curations-detail', kwargs={'uuid': str(self.curation_config_one.uuid)})
+        self.set_up_catalog_learner()
+
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['highlight_sets'][0]['archived_content_count'] == 0
+
     def test_selected_card_image_url_is_first(self):
         """
         Test that the `card_image_url` of the highlight set is that of the first highlighted content.

--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -2,8 +2,17 @@ from datetime import timedelta
 
 from django.test import TestCase
 
-from enterprise_catalog.apps.api.v1.utils import get_most_recent_modified_time
+from enterprise_catalog.apps.api.v1.utils import (
+    get_archived_content_count,
+    get_most_recent_modified_time,
+)
+from enterprise_catalog.apps.catalog.tests.factories import (
+    ContentMetadataFactory,
+)
 from enterprise_catalog.apps.catalog.utils import localized_utcnow
+from enterprise_catalog.apps.curation.tests.factories import (
+    HighlightedContentFactory,
+)
 
 
 class ApiUtilsTests(TestCase):
@@ -55,3 +64,21 @@ class ApiUtilsTests(TestCase):
         customer_time = None
         most_recent_time = get_most_recent_modified_time(content_time, catalog_time, customer_time)
         assert most_recent_time == content_time
+
+    def test_get_archived_content_count(self):
+        """
+        Test that archived content will increment the count.
+        """
+        content_1 = ContentMetadataFactory.create(json_metadata={'course_run_statuses': ['archived']})
+        content_2 = ContentMetadataFactory.create(json_metadata={'course_run_statuses': ['unpublished', 'archived']})
+        # if there's at least one published course run, the content should not be considered archived
+        content_3 = ContentMetadataFactory.create(json_metadata={'course_run_statuses': ['published', 'archived']})
+
+        highlighted_content_1 = HighlightedContentFactory(content_metadata=content_1)
+        highlighted_content_2 = HighlightedContentFactory(content_metadata=content_2)
+        highlighted_content_3 = HighlightedContentFactory(content_metadata=content_3)
+
+        archived_content_count = get_archived_content_count(
+            [highlighted_content_1, highlighted_content_2, highlighted_content_3]
+        )
+        assert archived_content_count == 2

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -104,3 +104,15 @@ def get_most_recent_modified_time(content_modified, catalog_modified=None, custo
     if customer_modified:
         content_modified = max([content_modified, customer_modified])
     return content_modified
+
+
+def get_archived_content_count(highlighted_content):
+    """
+    Helper function to get the count of archived content from a highlight set
+    """
+    archived_content_count = 0
+    for content in highlighted_content:
+        course_run_statuses = content.course_run_statuses
+        if course_run_statuses and all(status in ('archived', 'unpublished') for status in course_run_statuses):
+            archived_content_count += 1
+    return archived_content_count


### PR DESCRIPTION
## Description

Adding the variable `archived_content_count` to the EnterpriseCurationConfigSerializer for use on the admin-portal's frontend. 

## Ticket Link

Link to the associated ticket
[ENT-8495](https://2u-internal.atlassian.net/browse/ENT-8495)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
