### PR TITLE
build: backup should only start the mysql container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,12 @@ dev.destroy: dev.down # Kills containers and destroys volumes. If you get an err
 dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
 
-dev.backup: dev.up
+dev.backup:
+	docker-compose up -d mysql
 	docker run --rm --volumes-from enterprise.catalog.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql.tar.gz /var/lib/mysql
 
-dev.restore: dev.up
+dev.restore:
+	dev-compose up -d mysql
 	docker run --rm --volumes-from enterprise.catalog.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql.tar.gz
 
 mysql-client:  # Opens mysql client in the mysql container shell


### PR DESCRIPTION
We don't want the app or worker container writing to the DB while we try to run `mysqldump`

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
