### PR TITLE
feat: Added function for fetching course-program-subject data from Algolia

### DIFF
--- a/enterprise_catalog/apps/ai_curation/tests/test_utils.py
+++ b/enterprise_catalog/apps/ai_curation/tests/test_utils.py
@@ -1,0 +1,52 @@
+"""
+Tests for the views of the ai_curation app.
+"""
+from unittest import mock
+
+from django.test import TestCase
+
+from enterprise_catalog.apps.ai_curation.utils import (
+    fetch_catalog_metadata_from_algolia,
+)
+
+
+class TestUtils(TestCase):
+    """
+    Tests for the AI Curation util functions.
+    """
+    mock_algolia_hits = {'hits': [
+        {
+            'aggregation_key': 'course:MITx+19',
+            'subjects': ["Business & Management", "Computer Science", "Data Analysis & Statistics"],
+            'content_type': 'course',
+            'course_type': 'executive-education-2u',
+            'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf9-catalog-query-uuids-0'
+        },
+        {
+            'aggregation_key': 'course:MITx+20',
+            'subjects': ["Business & Management", "Economics & Finance", "Philosophy & Ethics", "Engineering"],
+            'content_type': 'course',
+            'course_type': 'verified',
+            'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf7-catalog-query-uuids-0'
+        },
+        {
+            'aggregation_key': 'program:MITx+21',
+            'subjects': ["Computer Science", "Engineering", "Electronics"],
+            'content_type': 'program',
+            'objectID': 'course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf7-catalog-query-uuids-0'
+        }
+    ]}
+
+    @mock.patch('enterprise_catalog.apps.ai_curation.utils.get_initialized_algolia_client')
+    def test_fetch_catalog_metadata_from_algolia(self, mock_algolia_client):
+        """
+        Verify that the catalog metadata from algolia is fetched correctly.
+        """
+        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        ocm_courses, exec_ed_courses, programs, subjects = fetch_catalog_metadata_from_algolia('test_query_title')
+        self.assertEqual(ocm_courses, ['course:MITx+20'])
+        self.assertEqual(exec_ed_courses, ['course:MITx+19'])
+        self.assertEqual(programs, ['program:MITx+21'])
+        self.assertEqual(sorted(subjects), ["Business & Management", "Computer Science",
+                                            "Data Analysis & Statistics", "Economics & Finance",
+                                            "Electronics", "Engineering", "Philosophy & Ethics"])

--- a/enterprise_catalog/apps/ai_curation/utils.py
+++ b/enterprise_catalog/apps/ai_curation/utils.py
@@ -1,0 +1,48 @@
+"""
+Utility functions for ai_curation app.
+"""
+from logging import getLogger
+
+from enterprise_catalog.apps.catalog.algolia_utils import (
+    get_initialized_algolia_client,
+)
+
+
+LOGGER = getLogger(__name__)
+
+
+def fetch_catalog_metadata_from_algolia(enterprise_catalog_query_title):
+    """
+    Returns the ocm_courses, exec_ed_courses, programs, subjects from the
+    Algolia response for the provided catalog_query_title
+    """
+    algolia_client = get_initialized_algolia_client()
+    search_options = {
+        'facetFilters': [f'enterprise_catalog_query_titles:{enterprise_catalog_query_title}',],
+        'attributesToRetrieve': ['aggregation_key', 'content_type', 'course_type', 'subjects',],
+        'hitsPerPage': 100,
+        'page': 0,
+    }
+    page = algolia_client.algolia_index.search('', search_options)
+    ocm_courses = []
+    exec_ed_courses = []
+    programs = []
+    subjects = set()
+
+    while len(page['hits']) > 0:
+        for hit in page.get('hits', []):
+            if hit.get('content_type') == 'course':
+                is_exec_ed = hit.get('course_type') == 'executive-education-2u'
+                if is_exec_ed:
+                    exec_ed_courses.append(hit.get('aggregation_key'))
+                else:
+                    ocm_courses.append(hit.get('aggregation_key'))
+                subjects.update(hit.get('subjects'))
+            elif hit.get('content_type') == 'program':
+                programs.append(hit.get('aggregation_key'))
+                subjects.update(hit.get('subjects'))
+
+        search_options['page'] = search_options['page'] + 1
+        page = algolia_client.algolia_index.search('', search_options)
+
+    return ocm_courses, exec_ed_courses, programs, list(subjects)


### PR DESCRIPTION
## Description

This PR adds a utility function to fetch course/program/subject data against an enterprise catalog query title

## Ticket Link

[ENT-8318](https://2u-internal.atlassian.net/browse/ENT-8318)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
