### PR TITLE
feat: Add --dry-run and --no-async flags to update_content_metadata job

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -226,7 +226,7 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
 
 @shared_task(base=LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
 @expiring_task_semaphore()
-def update_full_content_metadata_task(self, force=False):  # pylint: disable=unused-argument
+def update_full_content_metadata_task(self, force=False, dry_run=False):  # pylint: disable=unused-argument
     """
     Looks up the full metadata from discovery's `/api/v1/courses` and `/api/v1/programs` endpoints to pad all
     ContentMetadata objects. The metadata is merged with the existing contents
@@ -237,9 +237,9 @@ def update_full_content_metadata_task(self, force=False):  # pylint: disable=unu
     """
 
     content_keys = [metadata.content_key for metadata in ContentMetadata.objects.filter(content_type=COURSE)]
-    _update_full_content_metadata_course(content_keys)
+    _update_full_content_metadata_course(content_keys, dry_run)
     content_keys = [metadata.content_key for metadata in ContentMetadata.objects.filter(content_type=PROGRAM)]
-    _update_full_content_metadata_program(content_keys)
+    _update_full_content_metadata_program(content_keys, dry_run)
 
 
 def _find_best_mode_seat(seats):
@@ -308,7 +308,7 @@ def _normalize_course_metadata(course_metadata_record):
     json_meta['normalized_metadata'] = normalized_metadata
 
 
-def _update_full_content_metadata_course(content_keys):
+def _update_full_content_metadata_course(content_keys, dry_run=False):
     """
     Given content_keys, finds the associated ContentMetadata records with a type of course and looks up the full
     course metadata from discovery's /api/v1/courses endpoint to pad the ContentMetadata objects. The course
@@ -385,13 +385,20 @@ def _update_full_content_metadata_course(content_keys):
                 course_metadata_dict.get('programs', []),
                 metadata_record,
             )
-            _update_full_content_metadata_program(program_content_keys)
+            _update_full_content_metadata_program(program_content_keys, dry_run)
+            if dry_run:
+                logger.info('[Dry Run] Updated content metadata json for {}: {}'.format(
+                    content_key, json.dumps(metadata_record.json_metadata)
+                ))
 
-        ContentMetadata.objects.bulk_update(
-            modified_content_metadata_records,
-            ['json_metadata'],
-            batch_size=10,
-        )
+        if dry_run:
+            logger.info('dry_run=True, not updating course metadata')
+        else:
+            ContentMetadata.objects.bulk_update(
+                modified_content_metadata_records,
+                ['json_metadata'],
+                batch_size=10,
+            )
 
         logger.info(
             'Successfully updated %d of %d ContentMetadata records with full metadata from course-discovery.',
@@ -408,7 +415,7 @@ def _update_full_content_metadata_course(content_keys):
     )
 
 
-def _update_full_content_metadata_program(content_keys):
+def _update_full_content_metadata_program(content_keys, dry_run=False):
     """
     Given content_keys, finds the associated ContentMetadata records with a type of program and looks up the full
     program metadata from discovery's /api/v1/programs endpoint to pad the ContentMetadata objects. The program
@@ -454,11 +461,14 @@ def _update_full_content_metadata_program(content_keys):
             metadata_record.json_metadata.update(program_metadata_dict)
             modified_content_metadata_records.append(metadata_record)
 
-        ContentMetadata.objects.bulk_update(
-            modified_content_metadata_records,
-            ['json_metadata'],
-            batch_size=10,
-        )
+        if dry_run:
+            logger.info('dry_run=true, not updating program metadata')
+        else:
+            ContentMetadata.objects.bulk_update(
+                modified_content_metadata_records,
+                ['json_metadata'],
+                batch_size=10,
+            )
 
         logger.info(
             'Successfully updated %d of %d ContentMetadata records with full metadata from course-discovery.',
@@ -1084,7 +1094,7 @@ def _reindex_algolia(indexable_content_keys, nonindexable_content_keys, dry_run=
 
 @shared_task(base=LoggedTaskWithRetry, bind=True)
 @expiring_task_semaphore()
-def update_catalog_metadata_task(self, catalog_query_id, force=False):  # pylint: disable=unused-argument
+def update_catalog_metadata_task(self, catalog_query_id, force=False, dry_run=False):  # pylint: disable=unused-argument
     """
     Associates ContentMetadata objects with the appropriate catalog query by pulling data
     from /search/all on discovery.
@@ -1103,7 +1113,7 @@ def update_catalog_metadata_task(self, catalog_query_id, force=False):  # pylint
         logger.error('Could not find a CatalogQuery with id %s', catalog_query_id)
 
     try:
-        associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+        associated_content_keys = update_contentmetadata_from_discovery(catalog_query, dry_run)
     except Exception as e:
         logger.exception(
             f'Something went wrong while updating content metadata from discovery using catalog: {catalog_query_id} '
@@ -1120,7 +1130,7 @@ def update_catalog_metadata_task(self, catalog_query_id, force=False):  # pylint
 
 @shared_task(base=LoggedTaskWithRetry, bind=True)
 @expiring_task_semaphore()
-def fetch_missing_course_metadata_task(self, force=False):  # pylint: disable=unused-argument
+def fetch_missing_course_metadata_task(self, force=False, dry_run=False):  # pylint: disable=unused-argument
     """
     Creates a CatalogQuery for all the courses that do not have ContentMetadata instance.
 
@@ -1155,7 +1165,7 @@ def fetch_missing_course_metadata_task(self, force=False):  # pylint: disable=un
             defaults={'content_filter': content_filter, 'title': None},
         )
 
-        associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+        associated_content_keys = update_contentmetadata_from_discovery(catalog_query, dry_run)
         logger.info('[FETCH_MISSING_METADATA] Finished fetch_missing_course_metadata_task with {} associated content '
                     'keys for catalog {}'.format(len(associated_content_keys), catalog_query.id))
     else:
@@ -1164,7 +1174,7 @@ def fetch_missing_course_metadata_task(self, force=False):  # pylint: disable=un
 
 @shared_task(base=LoggedTaskWithRetry, bind=True)
 @expiring_task_semaphore()
-def fetch_missing_pathway_metadata_task(self, force=False):  # pylint: disable=unused-argument
+def fetch_missing_pathway_metadata_task(self, force=False, dry_run=False):  # pylint: disable=unused-argument
     """
     Creates ContentMetadata for Learner Pathways and all its associates.
 
@@ -1186,7 +1196,7 @@ def fetch_missing_pathway_metadata_task(self, force=False):  # pylint: disable=u
         content_filter_hash=get_content_filter_hash(content_filter),
         defaults={'content_filter': content_filter, 'title': None},
     )
-    associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+    associated_content_keys = update_contentmetadata_from_discovery(catalog_query, dry_run)
     logger.info(
         '[FETCH_MISSING_METADATA] Finished Pathways fetch_missing_pathway_metadata_task with {} associated content '
         'keys for catalog {}'.format(
@@ -1222,7 +1232,7 @@ def fetch_missing_pathway_metadata_task(self, force=False):  # pylint: disable=u
             defaults={'content_filter': content_filter, 'title': None},
         )
 
-        associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+        associated_content_keys = update_contentmetadata_from_discovery(catalog_query, dry_run)
         logger.info(
             '[FETCH_MISSING_METADATA] Finished programs fetch_missing_pathway_metadata_task with {} keys for '
             'catalog {}'.format(
@@ -1250,7 +1260,7 @@ def fetch_missing_pathway_metadata_task(self, force=False):  # pylint: disable=u
             defaults={'content_filter': content_filter, 'title': None},
         )
 
-        associated_content_keys = update_contentmetadata_from_discovery(catalog_query)
+        associated_content_keys = update_contentmetadata_from_discovery(catalog_query, dry_run)
         logger.info(
             '[FETCH_MISSING_METADATA] Finished courses fetch_missing_pathway_metadata_task with {} keys for '
             'catalog {}'.format(
@@ -1266,13 +1276,22 @@ def fetch_missing_pathway_metadata_task(self, force=False):  # pylint: disable=u
             associated_content_metadata = ContentMetadata.objects.filter(
                 content_key__in=program_uuids + course_keys
             )
-            pathway.associated_content_metadata.set(associated_content_metadata)
-            logger.info(
-                '[FETCH_MISSING_METADATA] Learner Pathway {} associated created. No. of associations: {}'.format(
-                    pathway.content_key,
-                    pathway.associated_content_metadata.count(),
+            if dry_run:
+                logger.info(
+                    ('[FETCH_MISSING_METADATA][Dry Run] Learner Pathway {} associations created.'
+                        'No. of associations: {}').format(
+                        pathway.content_key,
+                        pathway.associated_content_metadata.count(),
+                    )
                 )
-            )
+            else:
+                pathway.associated_content_metadata.set(associated_content_metadata)
+                logger.info(
+                    '[FETCH_MISSING_METADATA] Learner Pathway {} associated created. No. of associations: {}'.format(
+                        pathway.content_key,
+                        pathway.associated_content_metadata.count(),
+                    )
+                )
         else:
             pathway.associated_content_metadata.clear()
 

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -58,14 +58,14 @@ class UpdateContentMetadataCommandTests(TestCase):
         Verify that the job creates an update task for every catalog query
         """
         call_command(self.command_name)
-        assert mock_fetch_missing_pathway.si.call_args._get_call_arguments()[1] == {"force": False}
-        assert mock_fetch_missing_course.si.call_args._get_call_arguments()[1] == {"force": False}
+        assert mock_fetch_missing_pathway.si.call_args._get_call_arguments()[1] == {"force": False, "dry_run": False}
+        assert mock_fetch_missing_course.si.call_args._get_call_arguments()[1] == {"force": False, "dry_run": False}
 
         mock_group.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False),
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False, dry_run=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False, dry_run=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with(force=False)
+        mock_full_metadata_task.si.assert_called_once_with(force=False, dry_run=False)
 
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
@@ -89,10 +89,10 @@ class UpdateContentMetadataCommandTests(TestCase):
         mock_fetch_missing_pathway.si.assert_called()
         mock_fetch_missing_course.si.assert_called()
         mock_group.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False),
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False, dry_run=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False, dry_run=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with(force=False)
+        mock_full_metadata_task.si.assert_called_once_with(force=False, dry_run=False)
 
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
@@ -108,9 +108,31 @@ class UpdateContentMetadataCommandTests(TestCase):
         Verify that the job creates an update task for every catalog query
         """
         call_command(self.command_name, force=True)
-        assert mock_fetch_missing_pathway.si.call_args._get_call_arguments()[1] == {"force": True}
+        assert mock_fetch_missing_pathway.si.call_args._get_call_arguments()[1] == {"force": True, "dry_run": False}
         mock_group.assert_called_once_with([
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=True),
-            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=True),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=True, dry_run=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=True, dry_run=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with(force=True)
+        mock_full_metadata_task.si.assert_called_once_with(force=True, dry_run=False)
+
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_pathway_metadata_task')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.group')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
+    def test_update_content_metadata_no_async(
+        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway, mock_fetch_missing_course
+    ):
+        """
+        Verify that the tasks are executed synchronously when --no-async flag is set
+        """
+        call_command(self.command_name, force=True, no_async=True)
+        mock_fetch_missing_pathway.apply.assert_called_once_with(kwargs={"force": True, "dry_run": False})
+        mock_fetch_missing_course.apply.assert_called_once_with(kwargs={"force": True, "dry_run": False})
+        mock_group.assert_called_once_with([
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=True, dry_run=False),
+            mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=True, dry_run=False),
+        ])
+        mock_full_metadata_task.apply.assert_called_once_with(kwargs={"force": True, "dry_run": False})


### PR DESCRIPTION
## Description

Adds a couple flags to the `update_content_metadata` job

--dry-run: Don't commit changes to the database, just log them
--no-async: Don't spin off sub-tasks into separate threads, to allow for easier local logging

## Ticket Link
[ENT-8602](https://2u-internal.atlassian.net/browse/ENT-8602)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
