### PR TITLE
ENT-8400: Added transcript_languages in Algolia Search

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -93,6 +93,7 @@ ALGOLIA_FIELDS = [
     'reviews_count',
     'avg_course_rating',
     'course_bayesian_average',
+    'transcript_languages',
 ]
 
 # default configuration for the index
@@ -136,6 +137,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'aggregation_key',
         'learning_type',
         'learning_type_v2',
+        'transcript_languages',
     ],
     'unretrievableAttributes': [
         'enterprise_catalog_uuids',
@@ -419,6 +421,25 @@ def get_course_language(course):
 
     content_language_name = advertised_course_run.get('content_language_search_facet_name')
     return content_language_name
+
+
+def get_course_transcript_languages(course):
+    """
+    Gets the human-readable video transcript languages associated with the advertised course run. Used for
+    the "transcript_languages" facet in Algolia.
+
+    Arguments:
+        course (dict): a dict representing with course metadata
+
+    Returns:
+        list: a list of available human-readable video transcript languages parsed from a language code.
+    """
+    advertised_course_run = _get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
+    if not advertised_course_run:
+        return None
+
+    transcript_languages = advertised_course_run.get('transcript_languages_search_facet_names')
+    return transcript_languages
 
 
 def get_course_availability(course):
@@ -1278,6 +1299,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'reviews_count': get_reviews_count(searchable_product),
             'avg_course_rating': get_avg_course_rating(searchable_product),
             'course_bayesian_average': get_course_bayesian_average(searchable_product),
+            'transcript_languages': get_course_transcript_languages(searchable_product),
         })
     elif searchable_product.get('content_type') == PROGRAM:
         searchable_product.update({

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -1426,3 +1426,39 @@ class AlgoliaUtilsTests(TestCase):
         """
         created_learning_type = utils.get_learning_type(course)
         self.assertEqual(expected_result, created_learning_type)
+
+    @ddt.data(
+        (
+            {
+                'course_runs': [{
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'transcript_languages_search_facet_names': ['English', 'Chinese - Mandarin'],
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID,
+            },
+            ['English', 'Chinese - Mandarin'],
+        ),
+        (
+            {
+                'course_runs': [{
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'content_language_search_facet_name': None,
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID,
+            },
+            None,
+        ),
+        (
+            {
+                'advertised_course_run_uuid': None,
+            },
+            None,
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_transcript_languages(self, course_metadata, expected_transcript_languages):
+        """
+        Assert correct parsing of ``transcript_languages`` for a given course run.
+        """
+        transcript_languages = utils.get_course_transcript_languages(course_metadata)
+        assert transcript_languages == expected_transcript_languages


### PR DESCRIPTION
## Description
This PR adds the `transcript_languages` facet in Algolia search fields

## Ticket Link
[ENT-8400](https://2u-internal.atlassian.net/browse/ENT-8400)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
