### PR TITLE
feat: adding number of content metadata records associated with a catalog to catalog django admin

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -127,6 +127,14 @@ class EnterpriseCatalogAdmin(UnchangeableMixin):
         'catalog_query',
     )
 
+    readonly_fields = ('get_content_metadata_count',)
+
+    @admin.display(
+        description='Number of content records associated with the catalog'
+    )
+    def get_content_metadata_count(self, obj):
+        return len(obj.catalog_query.contentmetadata_set.all())
+
     @admin.display(
         description='Catalog Query'
     )


### PR DESCRIPTION

![image](https://github.com/openedx/enterprise-catalog/assets/67655836/4e494200-908f-435d-83ec-03f1e21c2d9e)



## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
