### PR TITLE
fix: avoiding api errors from algolia when course metadata gets too large by omitting from indexing

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 
 ALGOLIA_UUID_BATCH_SIZE = 100
 
+ALGOLIA_JSON_METADATA_MAX_SIZE = 100000
+
 
 # keep attributes from content objects that we explicitly want in Algolia
 ALGOLIA_FIELDS = [


### PR DESCRIPTION
We currently flatten algolia objects with the use of `ALGOLIA_UUID_BATCH_SIZE` as more customers are onboarded, but there is no safety guard against the indexer attempting to index content records that are larger than the max algolia object size. In such cases, the indexer blows up and no content is indexed, so as an immediate solution while we investigate the sudden growth of metadata size, we are simply omitting the record from indexing should it exceed a certain size.

According to the algolia docs: https://support.algolia.com/hc/en-us/articles/4406981897617-Is-there-a-size-limit-for-my-index-records 
record size is evaluated by dumping the object into json and read into memory- so I've done a similar method of calculating payload size. 

## Ticket Link

Link to the associated ticket
https://2u-internal.atlassian.net/browse/ENT-8667

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
