### PR TITLE
feat: Filter academy tags with no indexed data. ENT-8406

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -17,7 +17,10 @@ from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 from six.moves.urllib.parse import quote_plus
 
-from enterprise_catalog.apps.academy.tests.factories import AcademyFactory
+from enterprise_catalog.apps.academy.tests.factories import (
+    AcademyFactory,
+    TagFactory,
+)
 from enterprise_catalog.apps.api.v1.serializers import ContentMetadataSerializer
 from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
 from enterprise_catalog.apps.api.v1.utils import is_any_course_run_active
@@ -2336,11 +2339,24 @@ class AcademiesViewSetTests(APITestMixin):
     """
     Tests for the AcademyViewSet.
     """
+    mock_algolia_hits = {'facetHits': [
+        {
+            'value': 'leadership',
+            'count': 4
+        },
+        {
+            'value': 'management',
+            'count': 0
+        }
+    ]}
+
     def setUp(self):
         super().setUp()
         self.set_up_catalog_learner()
+        self.tag1 = TagFactory(title=self.mock_algolia_hits['facetHits'][0]['value'])
+        self.tag2 = TagFactory(title=self.mock_algolia_hits['facetHits'][1]['value'])
         self.academy1 = AcademyFactory()
-        self.academy2 = AcademyFactory()
+        self.academy2 = AcademyFactory(tags=[self.tag1, self.tag2])
         self.enterprise_catalog_query = CatalogQueryFactory(uuid=uuid.uuid4())
         self.enterprise_catalog1 = EnterpriseCatalogFactory(catalog_query=self.enterprise_catalog_query)
         self.enterprise_catalog1.academies.add(self.academy1)
@@ -2348,10 +2364,14 @@ class AcademiesViewSetTests(APITestMixin):
         self.enterprise_catalog2.academies.add(self.academy2)
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
-    def test_list_for_academies(self, mock_client):  # pylint: disable=unused-argument
+    @mock.patch('enterprise_catalog.apps.api.v1.serializers.get_initialized_algolia_client')
+    def test_list_for_academies(self, mock_algolia_client, mock_client):  # pylint: disable=unused-argument
         """
         Verify the viewset returns enterprise specific academies
         """
+        mock_algolia_client.return_value.algolia_index.search_for_facet_values.side_effect = [
+            self.mock_algolia_hits, {'facetHits': []}
+        ]
         params = {
             'enterprise_customer': str(self.enterprise_catalog2.enterprise_customer.uuid)
         }
@@ -2362,16 +2382,40 @@ class AcademiesViewSetTests(APITestMixin):
         results = response.data['results']
         self.assertEqual(uuid.UUID(results[0]['uuid']), self.academy2.uuid)
 
-    def test_retrieve_for_academies(self):
+    @mock.patch('enterprise_catalog.apps.api.v1.serializers.get_initialized_algolia_client')
+    def test_retrieve_for_academies(self, mock_algolia_client):
         """
         Verify the viewset retrieves an academy
         """
+        mock_algolia_client.return_value.algolia_index.search_for_facet_values.side_effect = [
+            self.mock_algolia_hits, {'facetHits': []}
+        ]
         url = reverse('api:v1:academies-detail', kwargs={
             'uuid': self.academy2.uuid,
         })
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(uuid.UUID(response.data['uuid']), self.academy2.uuid)
+
+    @mock.patch('enterprise_catalog.apps.api.v1.serializers.get_initialized_algolia_client')
+    def test_retrieve_for_tags_no_hits(self, mock_algolia_client):
+        """
+        Verify the viewset retrieves tags of an academy only if algolia hits for tag are > 0
+        """
+        mock_algolia_client.return_value.algolia_index.search_for_facet_values.side_effect = [
+            self.mock_algolia_hits, {'facetHits': []}
+        ]
+        url = reverse('api:v1:academies-detail', kwargs={
+            'uuid': self.academy2.uuid,
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(uuid.UUID(response.data['uuid']), self.academy2.uuid)
+        self.assertEqual(len(response.data['tags']), 1)
+        self.assertEqual(
+            response.data['tags'][0].get('title'),
+            self.mock_algolia_hits['facetHits'][0]['value']
+        )
 
     def test_list_with_missing_enterprise_customer(self):
         """

--- a/enterprise_catalog/apps/api/v1/views/academies.py
+++ b/enterprise_catalog/apps/api/v1/views/academies.py
@@ -23,6 +23,12 @@ class AcademiesReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
     def request_action(self):
         return getattr(self, 'action', None)
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        academy_uuid = str(self.kwargs['uuid']) if 'uuid' in self.kwargs else None
+        context.update({'academy_uuid': academy_uuid})
+        return context
+
     def get_queryset(self):
         """
         Returns the queryset corresponding to all academies the requesting user has access to.

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -119,7 +119,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'enterprise_catalog_query_uuids',
         'enterprise_customer_uuids',
         'academy_uuids',
-        'academy_tags',
+        'searchable(academy_tags)',
         'language',
         'level_type',
         'program_type',


### PR DESCRIPTION
## Description

This PR removes the academy tags with zero Algolia objects from the viewset response

## Ticket Link

[ENT-8406](https://2u-internal.atlassian.net/browse/ENT-8406)

## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
