### PR TITLE
fix: Made AI Curations task the highest priority.

### DIFF
--- a/enterprise_catalog/apps/ai_curation/api/v1/views.py
+++ b/enterprise_catalog/apps/ai_curation/api/v1/views.py
@@ -93,5 +93,7 @@ class AICurationView(APIView):
         """
         serializer = AICurationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        task = trigger_ai_curations.delay(**serializer.validated_data)
+        # 9 is the highest priority for the task
+        # Find more information at https://docs.celeryq.dev/en/stable/userguide/routing.html#redis-message-priorities
+        task = trigger_ai_curations.apply_async(kwargs=serializer.validated_data, priority=9)
         return Response({'task_id': str(task.task_id), 'status': task.status})

--- a/enterprise_catalog/apps/ai_curation/tests/test_views.py
+++ b/enterprise_catalog/apps/ai_curation/tests/test_views.py
@@ -200,7 +200,8 @@ class TestAICurationView(TestCase):
         """
         Verify that the job calls the trigger_ai_curations with the test data
         """
-        mock_trigger_ai_curations.delay = MagicMock(return_value=self.task)
+        mock_trigger_ai_curations.apply_async = MagicMock(return_value=self.task)
+
         data = {'query': 'Give all courses from edX org.', 'catalog_name': 'Test Catalog'}
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -208,7 +209,7 @@ class TestAICurationView(TestCase):
         self.assertIn('status', response.data)
         self.assertEqual(response.data['status'], self.task.status)
 
-        mock_trigger_ai_curations.delay.assert_called_once()
+        mock_trigger_ai_curations.apply_async.assert_called_once()
 
     def test_post_with_query(self):
         """

--- a/enterprise_catalog/celery.py
+++ b/enterprise_catalog/celery.py
@@ -9,6 +9,7 @@ app = Celery('enterprise_catalog', )
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
 app.conf.task_protocol = 1
+app.conf.task_default_priority = 5
 app.config_from_object('django.conf:settings', namespace="CELERY")
 
 # Load task modules from all registered Django app configs.

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -364,6 +364,8 @@ CELERY_EAGER_PROPAGATES = True
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'fanout_patterns': True,
     'fanout_prefix': True,
+    'queue_order_strategy': 'priority',
+    'sep': ':',
 }
 
 # Only allow each worker to run 100 tasks before restarting


### PR DESCRIPTION
## Description

This PR makes AI Curations task the highest priority so that they are not blocked by management commands.

## Ticket Link

Link to the associated ticket
[ENT-8791](https://2u-internal.atlassian.net/browse/ENT-8791)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
