### PR TITLE
ENT-8791: Using a different worker for tasks triggered by REST API.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG'
+    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -Q enterprise_catalog.default -l DEBUG'
     container_name: enterprise.catalog.worker
     depends_on:
       - mysql
@@ -77,6 +77,34 @@ services:
       - devstack_default
     ports:
       - "18161:18161"
+    restart: always
+    # Allows attachment to this container using 'docker attach <containerID>'.
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/edx/app/enterprise_catalog/enterprise_catalog
+
+  curations_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -Q enterprise_catalog.curations -l DEBUG'
+    container_name: enterprise.catalog.curations
+    depends_on:
+      - mysql
+    environment:
+      CELERY_ALWAYS_EAGER: 'false'
+      CELERY_BROKER_TRANSPORT: redis
+      CELERY_BROKER_HOSTNAME: edx.devstack.redis:6379
+      CELERY_BROKER_VHOST: 0
+      CELERY_BROKER_PASSWORD: password
+      DJANGO_SETTINGS_MODULE: enterprise_catalog.settings.devstack
+      COLUMNS: 80
+    hostname: curations.catalog.enterprise
+    networks:
+      - devstack_default
+    ports:
+      - "18162:18162"
     restart: always
     # Allows attachment to this container using 'docker attach <containerID>'.
     stdin_open: true

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -369,6 +369,12 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
 # Only allow each worker to run 100 tasks before restarting
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 100
 
+CELERY_TASK_ROUTES = {
+    'enterprise_catalog.apps.ai_curation.tasks.trigger_ai_curations': {
+        'queue': 'enterprise_catalog.curations',
+    },
+}
+
 """############################# END CELERY ##################################"""
 
 MEDIA_STORAGE_BACKEND = {


### PR DESCRIPTION
## Description

Using a different worker for tasks triggered by REST API.

## Ticket Link

Link to the associated ticket
[ENT-8791](https://openedx.atlassian.net/browse/ENT-8791)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
