### PR TITLE
feat: normalized course price falls back to 0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,3 @@
-## Description
-
-Description of changes made
-
-## Ticket Link
-
-Link to the associated ticket
-[Link title](https://openedx.atlassian.net/browse/ENT-XXXX)
-
 ## Post-review
 
 * [ ] Squash commits into discrete sets of changes

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -78,6 +78,10 @@ BEST_MODE_ORDER = [
     CourseMode.AUDIT,
 ]
 
+# The default normalized content price for any content which otherwise
+# would have a null price
+DEFAULT_NORMALIZED_PRICE = 0.0
+
 
 def _fetch_courses_by_keys(course_keys):
     """
@@ -291,7 +295,7 @@ def _normalize_course_metadata(course_metadata_record):
         normalized_metadata['enroll_by_date'] = additional_metadata.get('registration_deadline')
         for entitlement in json_meta.get('entitlements', []):
             if entitlement.get('mode') == CourseMode.PAID_EXECUTIVE_EDUCATION:
-                normalized_metadata['content_price'] = entitlement.get('price')
+                normalized_metadata['content_price'] = entitlement.get('price') or DEFAULT_NORMALIZED_PRICE
     else:
         # Else case covers OCM courses.
         advertised_course_run_uuid = json_meta.get('advertised_course_run_uuid')
@@ -299,7 +303,8 @@ def _normalize_course_metadata(course_metadata_record):
         if advertised_course_run is not None:
             normalized_metadata['start_date'] = advertised_course_run.get('start')
             normalized_metadata['end_date'] = advertised_course_run.get('end')
-            normalized_metadata['content_price'] = advertised_course_run.get('first_enrollable_paid_seat_price')
+            normalized_metadata['content_price'] = \
+                advertised_course_run.get('first_enrollable_paid_seat_price') or DEFAULT_NORMALIZED_PRICE
             all_seats = advertised_course_run.get('seats', [])
             seat = _find_best_mode_seat(all_seats)
             if seat:

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -410,7 +410,18 @@ class UpdateFullContentMetadataTaskTests(TestCase):
         course_key_1 = 'edX+fakeX'
         course_data_1 = {'key': course_key_1, 'full_course_only_field': 'test_1', 'programs': []}
         course_key_2 = 'edX+testX'
-        course_data_2 = {'key': course_key_2, 'full_course_only_field': 'test_2', 'programs': [program_data]}
+        course_run_2_uuid = str(uuid.uuid4())
+        course_data_2 = {
+            'key': course_key_2,
+            'full_course_only_field': 'test_2',
+            'programs': [program_data],
+            'advertised_course_run_uuid': course_run_2_uuid,
+            'course_runs': [{
+                'uuid': course_run_2_uuid,
+                'key': f'course-v1:{course_key_2}+1',
+                'first_enrollable_paid_seat_price': None,  # should cause fallback to DEFAULT_NORMALIZED_PRICE
+            }],
+        }
 
         course_key_3 = 'edX+fooX'
         course_run_3_uuid = str(uuid.uuid4())
@@ -480,6 +491,7 @@ class UpdateFullContentMetadataTaskTests(TestCase):
 
         assert metadata_2.json_metadata['aggregation_key'] == f'course:{course_key_2}'
         assert metadata_2.json_metadata['full_course_only_field'] == 'test_2'
+        assert metadata_2.json_metadata['normalized_metadata']['content_price'] == tasks.DEFAULT_NORMALIZED_PRICE
         assert set(program_data.items()).issubset(set(metadata_2.json_metadata['programs'][0].items()))
 
         assert metadata_3.json_metadata['aggregation_key'] == f'course:{course_key_3}'


### PR DESCRIPTION
Sets the normalized content price to 0.0 when the upstream content definition explicity has it set to null.
Furthermore, eschew cruft from the PR template.
ENT-8758

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
