### PR TITLE
fix: Use percentile for filtering courses instead of tfidf values for uniform distribution

### DIFF
--- a/enterprise_catalog/apps/ai_curation/tests/test_views.py
+++ b/enterprise_catalog/apps/ai_curation/tests/test_views.py
@@ -41,6 +41,7 @@ class TestAICurationView(TestCase):
                 'outcome': 'Learn data science with Python',
                 'program_titles': [],
                 'tf_idf_score': 0.3,
+                'tf_idf_percentile': 0.3,
             },
             {
                 'aggregation_key': 'course:MITx+20',
@@ -53,6 +54,7 @@ class TestAICurationView(TestCase):
                 'outcome': 'Learn Programming Basics',
                 'program_titles': ['Learn Programming Basics'],
                 'tf_idf_score': 0.6,
+                'tf_idf_percentile': 0.6,
             },
         ]
         self.partially_filtered_exec_ed_courses = [
@@ -67,6 +69,7 @@ class TestAICurationView(TestCase):
                 'program_titles': ['Java for data science'],
                 'outcome': 'Learn data science with Java',
                 'tf_idf_score': 0.5,
+                'tf_idf_percentile': 0.5,
             },
         ]
 

--- a/enterprise_catalog/apps/ai_curation/tests/utils/test_generate_curation_utils.py
+++ b/enterprise_catalog/apps/ai_curation/tests/utils/test_generate_curation_utils.py
@@ -127,7 +127,7 @@ class TestUtils(TestCase):
             },
         ]
 
-        filtered_courses, _ = apply_tfidf_filter('python data science', courses, tfidf_threshold=0.2)
+        filtered_courses, _ = apply_tfidf_filter('python data science', courses, tfidf_threshold=0.4)
 
         assert {c['title'] for c in filtered_courses} == {'Python for data science', 'Java for data science'}
 


### PR DESCRIPTION
__Description:__
This PR updates filtering logic to use percentiles of `TF-IDF` files instead of raw values for a better filtering on uniformly distributed courses.


## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
