### PR TITLE
feat: adding guard rails to content query association setter to prevent large negative deltas

### DIFF
--- a/docs/decisions/0009-query-content-associations-guard-rails.rst
+++ b/docs/decisions/0009-query-content-associations-guard-rails.rst
@@ -1,0 +1,38 @@
+Query Content Associations Guard Rails
+======================================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+We have on occasion seen moments where Discovery has reported an extreme number of incorrect content records associated
+with customer queries. Almost entirely in these situations we have seen the system right itself after some time and
+return the expected number of records. While ensuring for normal variance and content modification rates, we want to
+catch and prevent moments where Discovery or other sources of truth erroneously reports an extreme loss or gain of
+content associated with a query.
+
+Decision
+--------
+The ``associate_content_metadata_with_query`` method will now consider the size of the existing query/content
+association list as compared to the list of content to update to. Should the content association update surpass a
+configurable threshold, the update to the content associations will be blocked and the old state will be retained.
+
+To be considered for a threshold cutoff, the requester of ``associate_content_metadata_with_query`` must meet the
+following criteria:
+- The existing set of content associations must exceed a configurable cutoff
+- The query must have not been modified today
+- The change in number of content association records must exceed a configurable percentage, both in a positive and
+negative direction (ie the query loses or gains more than x% of its prior number of records)
+
+Consequences
+------------
+Content associations will not be updated in specific cases, causing stagnant data to be displayed to customers. The
+guardrail is also not loud/destructive in that it will log a warning about its action but not stop the process, just
+returning the existing content metadata association set. However, given the high levels of the thresholds set, it is
+intended that this only happens when the alternative of letting the content association update going through would be
+more disruptive to the customer's experience than to continue using old data. It is also intended that the check on the
+``modified`` field value will ensure there is a direct and easy way to allow a large content associations update to go
+through.

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -453,3 +453,12 @@ AI_CURATION_KEYWORDS_TO_PROSE_PROMPT = 'I am a keywords to prose prompt. query: 
 OPENAI_API_KEY = 'I am key'
 
 ############################################## AI CURATION ##############################################
+
+# Decimal percentage cutoff value for queries' content metadata association setting. If the absolute percent change
+# from the old set length to the new set length is greater than the setting value, the update may be prevented
+CATALOG_CONTENT_INCLUSION_GUARDRAIL_ALLOWABLE_DELTA = .8
+# Decimal percentage warning value for queries' content metadata association setting. If the absolute percent change
+# is greater than the setting value, the operation may trigger a warning log
+CATALOG_CONTENT_ASSOCIATIONS_CONTENT_DELTA_WARNING_THRESHOLD = .5
+# Flat minimum value of content associations for a catalog query to be considered for guardrail protections
+CATALOG_CONTENT_INCLUSION_GUARDRAIL_CONSIDERATION_FLOOR = 50


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8778
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
