### PR TITLE
fix: Added enterprise uuid to facet search filter for academy tags

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -398,9 +398,10 @@ class AcademyTagsListSerializer(serializers.ListSerializer):  # pylint: disable=
         tags = super().to_representation(obj)
         algolia_client = get_initialized_algolia_client()
         academy_uuid = self.context.get('academy_uuid')
-        if academy_uuid:
+        enterprise_uuid = self.context.get('enterprise_uuid')
+        if academy_uuid and enterprise_uuid:
             search_query = {
-                'filters': f'academy_uuids:{academy_uuid}',
+                'filters': f'academy_uuids:{academy_uuid} AND enterprise_customer_uuids:{enterprise_uuid}',
                 'maxFacetHits': 50
             }
         else:

--- a/enterprise_catalog/apps/api/v1/views/academies.py
+++ b/enterprise_catalog/apps/api/v1/views/academies.py
@@ -26,7 +26,8 @@ class AcademiesReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
     def get_serializer_context(self):
         context = super().get_serializer_context()
         academy_uuid = str(self.kwargs['uuid']) if 'uuid' in self.kwargs else None
-        context.update({'academy_uuid': academy_uuid})
+        enterprise_customer = self.request.GET.get('enterprise_customer', None)
+        context.update({'academy_uuid': academy_uuid, 'enterprise_uuid': enterprise_customer})
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
**Description**: This PR adds the enterprise uuid to the search query for academy tags facet filtering. This will ensure that tags with no results for the particular academy and enterprise combination donot show up on the frontend.

**JIRA**: [ENT-8867](https://2u-internal.atlassian.net/browse/ENT-8867)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
