### PR TITLE
feat: add default availability filter in catalog algolia query

### DIFF
--- a/enterprise_catalog/apps/ai_curation/utils/algolia_utils.py
+++ b/enterprise_catalog/apps/ai_curation/utils/algolia_utils.py
@@ -43,6 +43,7 @@ def extract_course_data(hit: dict):
         'program_titles': hit.get('program_titles', []),
         'skills': hit.get('skill_names', []),
         'subjects': hit.get('subjects', []),
+        'availability': hit.get('availability', [])
     }
 
 
@@ -66,12 +67,23 @@ def fetch_catalog_metadata_from_algolia(enterprise_catalog_query_title: str):
     """
     algolia_client = get_initialized_algolia_client()
     search_options = {
-        'facetFilters': [f'enterprise_catalog_query_titles:{enterprise_catalog_query_title}', ],
+        'facetFilters': [
+            [
+                'availability:Available Now',
+                'availability:Starting Soon',
+                'availability:Upcoming'
+            ],
+            [
+                f'enterprise_catalog_query_titles:{enterprise_catalog_query_title}'
+            ]
+        ],
+        'filters': 'learning_type:course OR learning_type:program OR learning_type:"Executive Education"',
         'attributesToRetrieve': [
             'key',
             'aggregation_key',
             'content_type',
             'course_type',
+            'availability',
             'title',
             'short_description',
             'full_description',
@@ -80,6 +92,7 @@ def fetch_catalog_metadata_from_algolia(enterprise_catalog_query_title: str):
             'skill_names',
             'subjects',
         ],
+        'facetingAfterDistinct': True,
         'hitsPerPage': 100,
         'page': 0,
     }


### PR DESCRIPTION
**Description**

***Problem***
When we send a query to our Xpert from the frontend-app-enterprise-public-catalog, some of the default filters are applied. Consequently, we do not obtain the same count on the XpertStat card as the results shown below.

***Solution***
We have applied an `availability` filter in the backend Algolia query to synchronize the result counts on the frontend-app-enterprise-public-catalog.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
