### PR TITLE
feat: new catalog query read only viewset

### DIFF
--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -11,6 +11,9 @@ from enterprise_catalog.apps.api.v1.views.catalog_csv import CatalogCsvView
 from enterprise_catalog.apps.api.v1.views.catalog_csv_data import (
     CatalogCsvDataView,
 )
+from enterprise_catalog.apps.api.v1.views.catalog_query import (
+    CatalogQueryViewSet,
+)
 from enterprise_catalog.apps.api.v1.views.catalog_workbook import (
     CatalogWorkbookView,
 )
@@ -61,6 +64,7 @@ router.register(r'highlight-sets', HighlightSetReadOnlyViewSet, basename='highli
 router.register(r'highlight-sets-admin', HighlightSetViewSet, basename='highlight-sets-admin')
 router.register(r'academies', AcademiesReadOnlyViewSet, basename='academies')
 router.register(r'content-metadata', ContentMetadataView, basename='content-metadata')
+router.register(r'catalog-queries', CatalogQueryViewSet, basename='catalog-queries')
 
 urlpatterns = [
     path('enterprise-catalogs/catalog_csv_data', CatalogCsvDataView.as_view(),
@@ -105,6 +109,11 @@ urlpatterns = [
         'enterprise-customer/<enterprise_uuid>/content-metadata/<content_identifier>/',
         EnterpriseCustomerViewSet.as_view({'get': 'content_metadata'}),
         name='customer-content-metadata-retrieve'
+    ),
+    path(
+        'catalog-queries/get_query_by_hash',
+        CatalogQueryViewSet.as_view({'get': 'get_query_by_hash'}),
+        name='get-query-by-hash'
     ),
 ]
 

--- a/enterprise_catalog/apps/api/v1/views/catalog_query.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_query.py
@@ -1,0 +1,64 @@
+from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+
+from enterprise_catalog.apps.api.v1.decorators import (
+    require_at_least_one_query_parameter,
+)
+from enterprise_catalog.apps.api.v1.serializers import (
+    CatalogQueryGetByHashRequestSerializer,
+    CatalogQuerySerializer,
+)
+from enterprise_catalog.apps.catalog.models import CatalogQuery
+from enterprise_catalog.apps.catalog.rules import (
+    enterprises_with_admin_access,
+    has_access_to_all_enterprises,
+)
+
+
+class CatalogQueryViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only viewset for Catalog Query records"""
+    renderer_classes = [JSONRenderer]
+    serializer_class = CatalogQuerySerializer
+
+    @cached_property
+    def admin_accessible_enterprises(self):
+        """
+        Cached set of enterprise identifiers the requesting user has admin access to.
+        """
+        return enterprises_with_admin_access(self.request)
+
+    def get_queryset(self):
+        """
+        Restrict the queryset to catalog queries the requesting user has access to. Iff the user is staff they have
+        access to all queries.
+        """
+        all_queries = CatalogQuery.objects.all()
+        if not self.admin_accessible_enterprises:
+            return CatalogQuery.objects.none()
+        if has_access_to_all_enterprises(self.admin_accessible_enterprises) or self.request.user.is_staff:
+            return all_queries
+        return all_queries.filter(
+            enterprise_catalogs__enterprise_uuid__in=self.admin_accessible_enterprises
+        )
+
+    @method_decorator(require_at_least_one_query_parameter('hash'))
+    @action(detail=True, methods=['get'])
+    def get_query_by_hash(self, request, **kwargs):
+        """
+        Fetch a Catalog Query by its hash. The hash values are a product of Python's ``hashlib``'s md5 algorithm
+        in hexdigest representation.
+        """
+        request_serializer = CatalogQueryGetByHashRequestSerializer(data=request.query_params)
+        request_serializer.is_valid(raise_exception=True)
+        content_filter_hash = request_serializer.validated_data.get('hash')
+        try:
+            query = self.get_queryset().get(content_filter_hash=content_filter_hash)
+        except CatalogQuery.DoesNotExist as exc:
+            raise NotFound('Catalog query not found.') from exc
+        serialized_data = self.serializer_class(query)
+        return Response(serialized_data.data)

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
@@ -45,7 +45,7 @@ class EnterpriseCatalogCRUDViewSet(BaseViewSet, viewsets.ModelViewSet):
 
     def get_permission_object(self):
         """
-        Retrieves the apporpriate object to use during edx-rbac's permission checks.
+        Retrieves the appropriate object to use during edx-rbac's permission checks.
 
         This object is passed to the rule predicate(s).
         """

--- a/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
@@ -58,7 +58,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
 
     def get_permission_object(self):
         """
-        Retrieves the apporpriate object to use during edx-rbac's permission checks.
+        Retrieves the appropriate object to use during edx-rbac's permission checks.
 
         This object is passed to the rule predicate(s).
         """


### PR DESCRIPTION
Part 1 of https://2u-internal.atlassian.net/browse/ENT-8661

Platform/enterprise needs a way of checking if a particular query/content filter already exists in the catalog service. To do this, I've created a readonly viewset with an endpoint that can fetch queries by hashes.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
