### PR TITLE
Remove usage of CatalogUpdateCommandConfig

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -88,23 +88,12 @@ task to run, regardless of how recently the same task with the same input was ru
 Running Management Commands in Stage or Prod environments
 ---------------------------------------------------------
 
-The three commands described in the previous section each have corresponding jenkins jobs in tools-edx-jenkins.edx.org
-under the "Enterprise Catalog Jobs" section.
+The three commands described in the previous section each have corresponding jobs in argocd.tools.edx.org
+under 'prod-enterprise-catalog' section.
 ``update_content_metadata`` and ``reindex_algolia`` are both run on a daily cron (so that new learning content that matches
 an existing content filter will be included in appropriate catalogs as the content is published).  Since these jobs
 only execute the underlying management commands, they are subject to the same hour-long "lock".  In case you
-need to run the same job on the same input more frequently, follow these steps:
-
-- Visit the Django Admin ``/admin/catalog/catalogupdatecommandconfig/`` page for the environment.  Note that you'll
-  need superuser access in enterprise-catalog to do this.
-- Create a new Configuration record, setting both ``enabled`` and ``force`` to true.
-- Save the new record.
-- Rebuild the job from Jenkins.
-- Once the job is complete, go back to the CatalogUpdateCommandConfig Django Admin page and create a new record
-  with ``force`` set to false.
-
-See https://openedx.atlassian.net/wiki/spaces/SRE/pages/146440591/Jenkins for more information about the Tools Jenkins
-service.
+need to run the same job on the same input more frequently, the jobs can be run manually with the '--force' command in argocd.
 
 
 Permissions

--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -1,4 +1,3 @@
-from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
@@ -13,7 +12,6 @@ from enterprise_catalog.apps.catalog.forms import (
 )
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
-    CatalogUpdateCommandConfig,
     ContentMetadata,
     EnterpriseCatalog,
     EnterpriseCatalogRoleAssignment,
@@ -169,6 +167,3 @@ class EnterpriseCatalogRoleAssignmentAdmin(UserRoleAssignmentAdmin):
 
     fields = ('user', 'role', 'enterprise_id', 'applies_to_all_contexts')
     form = EnterpriseCatalogRoleAssignmentAdminForm
-
-
-admin.site.register(CatalogUpdateCommandConfig, ConfigurationModelAdmin)

--- a/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/reindex_algolia.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand
 from enterprise_catalog.apps.api.tasks import (
     index_enterprise_catalog_in_algolia_task,
 )
-from enterprise_catalog.apps.catalog.models import CatalogUpdateCommandConfig
 
 
 logger = logging.getLogger(__name__)
@@ -42,7 +41,6 @@ class Command(BaseCommand):
         """
         Runs a celery task to reindex algolia.  Blocks until celery task returns.
         """
-        options.update(CatalogUpdateCommandConfig.current_options())
         try:
             force_task_execution = options.get('force', False)
             dry_run = options.get('dry_run', False)

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_reindex_algolia.py
@@ -21,43 +21,28 @@ class ReindexAlgoliaCommandTests(TestCase):
         cls.content_metadata = ContentMetadataFactory.create_batch(3, content_type=COURSE)
 
     @mock.patch(PATH_PREFIX + 'index_enterprise_catalog_in_algolia_task')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.reindex_algolia.CatalogUpdateCommandConfig')
-    def test_reindex_algolia(self, mock_command_config, mock_task):
+    def test_reindex_algolia(self, mock_task):
         """
         Verify that the job spins off the correct number of index_enterprise_catalog_in_algolia_task
         """
-        mock_command_config.current_options.return_value = {
-            'force': False,
-            'no_async': False,
-        }
         call_command(self.command_name)
         mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': False})
         mock_task.apply_async.return_value.get.assert_called_once_with()
 
     @mock.patch(PATH_PREFIX + 'index_enterprise_catalog_in_algolia_task')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.reindex_algolia.CatalogUpdateCommandConfig')
-    def test_reindex_algolia_no_async(self, mock_command_config, mock_task):
+    def test_reindex_algolia_no_async(self, mock_task):
         """
         Verify that the job spins off the correct number of index_enterprise_catalog_in_algolia_task
         """
-        mock_command_config.current_options.return_value = {
-            'force': False,
-            'no_async': True,
-        }
-        call_command(self.command_name)
+        call_command(self.command_name, no_async=True)
         mock_task.apply.assert_called_once_with(kwargs={'force': False, 'dry_run': False})  # force=False, dry_run=False
         mock_task.apply_async.assert_not_called()
 
     @mock.patch(PATH_PREFIX + 'index_enterprise_catalog_in_algolia_task')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.reindex_algolia.CatalogUpdateCommandConfig')
-    def test_reindex_algolia_dry_run(self, mock_command_config, mock_task):
+    def test_reindex_algolia_dry_run(self, mock_task):
         """
         Verify that the job spins off the correct number of index_enterprise_catalog_in_algolia_task
         """
-        mock_command_config.current_options.return_value = {
-            'force': False,
-            'no_async': False,
-        }
         call_command(self.command_name, dry_run=True)
         mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': True})
         mock_task.apply_async.return_value.get.assert_called_once_with()

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -10,10 +10,7 @@ from enterprise_catalog.apps.api.tasks import (
     update_full_content_metadata_task,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE, TASK_TIMEOUT
-from enterprise_catalog.apps.catalog.models import (
-    CatalogQuery,
-    CatalogUpdateCommandConfig,
-)
+from enterprise_catalog.apps.catalog.models import CatalogQuery
 
 
 logger = logging.getLogger(__name__)
@@ -74,14 +71,12 @@ class Command(BaseCommand):
         )
 
     def add_arguments(self, parser):
-        # Argument to force execution of celery task, ignoring time since last execution
         parser.add_argument(
             '--force',
             default=False,
             action='store_true',
             help=(
-                'Will read the value of this option from the CatalogUpdateCommandConfig table '
-                'if a record is present and enabled.'
+                'Will force execution of task, ignoring time since last execution'
             ),
         )
         parser.add_argument(
@@ -104,8 +99,6 @@ class Command(BaseCommand):
         Runs a group of `update_catalog_metadata_tasks`, followed by
         a single `update_full_content_metadata_task` instance.
         """
-        options.update(CatalogUpdateCommandConfig.current_options())
-
         no_async = options.get('no_async', False)
         flags = {k: options.get(k, False) for k in ('force', 'dry_run')}
         # Fetch metadata for the courses/programs that are missing.

--- a/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_full_content_metadata.py
@@ -6,7 +6,6 @@ from enterprise_catalog.apps.api.tasks import update_full_content_metadata_task
 from enterprise_catalog.apps.catalog.management.utils import (
     get_all_content_keys,
 )
-from enterprise_catalog.apps.catalog.models import CatalogUpdateCommandConfig
 
 
 logger = logging.getLogger(__name__)
@@ -26,7 +25,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        options.update(CatalogUpdateCommandConfig.current_options())
         try:
             force_task_execution = options.get('force', False)
             result = update_full_content_metadata_task.apply_async(kwargs={'force': force_task_execution}).get()


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-9044)

With our current infrastructure, there is no longer a need to have the `update_content_metadata` and `reindex_algolia` jobs pull their run configs from `CatalogUpdateCommandConfig` database records, and this functionality is now impeding our ability to run one-off jobs with a different configuration than that specified in the database.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed