### PR TITLE
feat: add get_content_filter_hash endpoint

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2589,6 +2589,25 @@ class CatalogQueryViewTests(APITestMixin):
         response_json = response.json()
         assert response_json == ['You must provide at least one of the following query parameters: hash.']
 
+    def test_get_content_filter_hash(self):
+        """
+        Test that get content filter hash returns md5 hash of query
+        """
+        url = reverse('api:v1:get-content-filter-hash')
+        test_query = json.dumps({"content_type": ["political", "unit", "market"]})
+        response = self.client.generic('GET', url, content_type='application/json', data=test_query)
+        assert response.json() == '35584b583415a5bd4e51cc70d898a0eb'  # pylint: disable=no-member
+
+    def test_get_content_filter_hash_bad_query(self):
+        """
+        Test that get content filter hash returns md5 hash of query
+        """
+        url = reverse('api:v1:get-content-filter-hash')
+        test_query = 'bad query'
+        response = self.client.generic('GET', url, content_type='application/json', data=test_query)
+        err_detail = "Failed to parse catalog query: JSON parse error - Expecting value: line 1 column 1 (char 0)"
+        assert response.json() == {"detail": err_detail}  # pylint: disable=no-member
+
     def test_catalog_query_retrieve(self):
         """
         Test that the Catalog Query viewset supports retrieving individual queries

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -115,6 +115,11 @@ urlpatterns = [
         CatalogQueryViewSet.as_view({'get': 'get_query_by_hash'}),
         name='get-query-by-hash'
     ),
+    path(
+        'catalog-queries/get_content_filter_hash',
+        CatalogQueryViewSet.as_view({'get': 'get_content_filter_hash'}),
+        name='get-content-filter-hash'
+    ),
 ]
 
 urlpatterns += router.urls


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-8661)

Following up on the changes in https://github.com/openedx/enterprise-catalog/pull/837, this adds a method for retrieving content query hashes for query text, which can then be passed to `get_query_by_hash`.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
