### PR TITLE
chore: debug MIT Micromasters exclusion

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -873,6 +873,18 @@ def _get_algolia_products_for_batch(
                             academy_tags_by_key[content_key].add(str(tag.title))
                             academy_tags_by_catalog_uuid[str(catalog.uuid)].add(str(tag.title))
 
+        # adding temporary debug logging for MIT's Finance Micromasters Program
+        if content_key in (
+            "MITx+15.415.2x",
+            "MITx+15.435x",
+            "MITx+15.516x",
+            "MITx+15.455x",
+            "MITx+15.415.1x",
+            "MITx+FIN.CFx"
+        ):
+            logger.info('Debugging content key = {} ...'.format(content_key))
+            logger.info('catalog_queries_by_key: {}'.format(catalog_queries_by_key[content_key]))
+
     # Second pass.  This time the goal is to capture indirect relationships on programs:
     #  * For each program:
     #    - Absorb all UUIDs associated with every associated course.
@@ -905,6 +917,19 @@ def _get_algolia_products_for_batch(
                 academy_tags_by_key[program_content_key].update(
                     academy_tags_by_catalog_uuid[catalog_uuid]
                 )
+
+        # adding temporary logging for MIT's Finance Micromasters Program
+        if program_content_key in (
+            "MITx+15.415.2x",
+            "MITx+15.435x",
+            "MITx+15.516x",
+            "MITx+15.455x",
+            "MITx+15.415.1x",
+            "MITx+FIN.CFx"
+        ):
+            logger.info('Pass 2 - Debugging program_content_key = {} ...'.format(program_content_key))
+            logger.info('Pass 2 - catalog_queries_by_key: {}'.format(catalog_queries_by_key[program_content_key]))
+
 
     # Third pass.  This time the goal is to capture indirect relationships on pathways:
     #  * For each pathway:


### PR DESCRIPTION
MIT Micromaster Programs are not showing up in Catalog Search due to not getting tagged with the correct metadata in Algolia. 

- This change adds debug logging to enterprise-catalog's Algolia metadata creation logic after consulting with @iloveagent57. This will help us identify why MIT Micromasters program courses are not getting tagged with `enterprise_catalog_query_titles` = 'a la carte'
- `catalog_queries_by_key ` field is used to derive the setting of the `enterprise_catalog_query_titles` field in Algolia. Reference is [here](https://github.com/openedx/enterprise-catalog/blob/07d4a048cf608247bb0f8bde4dc4feb6d27cc6ef/enterprise_catalog/apps/api/tasks.py#L541)

Tested the change via unit tests.

JIRA: https://2u-internal.atlassian.net/browse/ENT-8812

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
