### PR TITLE
fix: replace deprecated github actions

### DIFF
--- a/.github/workflows/mysql-migrations-check.yml
+++ b/.github/workflows/mysql-migrations-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
       id: cache-dependencies
       uses: actions/cache@v2


### PR DESCRIPTION
## Description
github action set-output is deprecated and gives warning when the job runs. This PR replaces the deprecated ones with the updated syntax.