### PR TITLE
temp: removing debug logging for MIT Micromasters program

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -978,18 +978,6 @@ def _get_algolia_products_for_batch(
                             academy_tags_by_key[content_key].add(str(tag.title))
                             academy_tags_by_catalog_uuid[str(catalog.uuid)].add(str(tag.title))
 
-        # adding temporary debug logging for MIT's Finance Micromasters Program
-        if content_key in (
-            "MITx+15.415.2x",
-            "MITx+15.435x",
-            "MITx+15.516x",
-            "MITx+15.455x",
-            "MITx+15.415.1x",
-            "MITx+FIN.CFx"
-        ):
-            logger.info('Debugging content key = {} ...'.format(content_key))
-            logger.info('catalog_queries_by_key: {}'.format(catalog_queries_by_key[content_key]))
-
     # Second pass.  This time the goal is to capture indirect relationships on programs:
     #  * For each program:
     #    - Absorb all UUIDs associated with every associated course.
@@ -1022,18 +1010,6 @@ def _get_algolia_products_for_batch(
                 academy_tags_by_key[program_content_key].update(
                     academy_tags_by_catalog_uuid[catalog_uuid]
                 )
-
-        # adding temporary logging for MIT's Finance Micromasters Program
-        if program_content_key in (
-            "MITx+15.415.2x",
-            "MITx+15.435x",
-            "MITx+15.516x",
-            "MITx+15.455x",
-            "MITx+15.415.1x",
-            "MITx+FIN.CFx"
-        ):
-            logger.info('Pass 2 - Debugging program_content_key = {} ...'.format(program_content_key))
-            logger.info('Pass 2 - catalog_queries_by_key: {}'.format(catalog_queries_by_key[program_content_key]))
 
     # Third pass.  This time the goal is to capture indirect relationships on pathways:
     #  * For each pathway:


### PR DESCRIPTION
Reversing changes in https://github.com/openedx/enterprise-catalog/pull/861
That PR added debug logging for investigating the MIT MIcromasters program exclusion from the catalog. 

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
