### PR TITLE
feat: Added fields to the video index objects

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -684,7 +684,18 @@ def add_video_to_algolia_objects(
     json_metadata.update({
         'video_skills': list(video_skills),
     })
-
+    video_parent_cm = video.parent_content_metadata
+    if video_parent_cm:
+        json_metadata.update({
+            'course_run_key': video_parent_cm.json_metadata.get('key'),
+            'title': video_parent_cm.json_metadata.get('title'),
+            'org': video_parent_cm.json_metadata.get('org'),
+            'logo_image_urls': list(video_parent_cm.json_metadata.get('logo_image_urls', [])),
+            'image_url': video_parent_cm.json_metadata.get('image_url'),
+        })
+    json_metadata.update({
+        'duration': video.json_metadata.get('duration'),
+    })
     json_metadata_size = sys.getsizeof(
         json.dumps(_algolia_object_from_product(json_metadata, algolia_fields=ALGOLIA_FIELDS)).strip(" "),
     )

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -52,6 +52,11 @@ ALGOLIA_FIELDS = [
     'transcript_summary',
     'video_usage_key',
     'video_skills',
+    'course_run_key',
+    'org',
+    'logo_image_urls',
+    'image_url',
+    'duration',
     'full_description',
     'key',  # for links to Course about pages from the Learner Portal search page
     'uuid',


### PR DESCRIPTION
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
