### PR TITLE
feat: Replaced ai chat client for curation

### DIFF
--- a/enterprise_catalog/apps/ai_curation/tests/test_utils.py
+++ b/enterprise_catalog/apps/ai_curation/tests/test_utils.py
@@ -4,12 +4,10 @@ Tests for ai_curation app utils.
 import json
 import logging
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import httpx
 from django.conf import settings
 from django.test import TestCase
-from openai import APIConnectionError
 
 from enterprise_catalog.apps.ai_curation.errors import AICurationError
 from enterprise_catalog.apps.ai_curation.utils.algolia_utils import (
@@ -75,23 +73,22 @@ class TestUtils(TestCase):
 
 class TestChatCompletionUtils(TestCase):
     @patch('enterprise_catalog.apps.ai_curation.utils.open_ai_utils.LOGGER')
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
-    def test_get_filtered_subjects(self, mock_create, mock_logger):
+    @patch('enterprise_catalog.apps.ai_curation.openai_client.requests.post')
+    def test_get_filtered_subjects(self, mock_requests, mock_logger):
         """
         Test that get_filtered_subjects returns the correct filtered subjects
         """
-        mock_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=json.dumps(['subject1', 'subject2'])))]
-        )
+        mock_requests.return_value.json.return_value = {
+            "role": "assistant",
+            "content": json.dumps(['subject1', 'subject2'])
+        }
         subjects = ['subject1', 'subject2', 'subject3', 'subject4']
         query = 'test query'
         expected_content = settings.AI_CURATION_FILTER_SUBJECTS_PROMPT.format(query=query, subjects=subjects)
 
         result = get_filtered_subjects(query, subjects)
 
-        mock_create.assert_called_once_with(
-            messages=[{'role': 'system', 'content': expected_content}], **CHAT_COMPLETIONS_API_KEYWARGS
-        )
+        mock_requests.assert_called_once()
         mock_logger.info.assert_has_calls(
             [
                 mock.call(
@@ -103,97 +100,22 @@ class TestChatCompletionUtils(TestCase):
         )
         assert result == ['subject1', 'subject2']
 
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.LOGGER')
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
-    def test_invalid_json(self, mock_create, mock_logger):
-        """
-        Test that correct exception is raised if chat.completions.create send an invalid json
-        """
-        mock_create.return_value = MagicMock(choices=[MagicMock(message=MagicMock(content='non json response'))])
-
-        messages = [
-            {
-                'role': 'system',
-                'content': 'I am a prompt'
-            }
-        ]
-        with self.assertRaises(AICurationError):
-            chat_completions(messages)
-
-        assert mock_create.call_count == 3
-        assert mock_logger.error.called
-        mock_logger.error.assert_has_calls([
-            mock.call(
-                '[AI_CURATION] Invalid JSON response received from chatgpt: Prompt: [%s], Response: [%s]',
-                [{'role': 'system', 'content': 'I am a prompt'}],
-                mock.ANY
-            ),
-            mock.call(
-                '[AI_CURATION] Invalid JSON response received from chatgpt: Prompt: [%s], Response: [%s]',
-                [{'role': 'system', 'content': 'I am a prompt'}],
-                mock.ANY
-            ),
-            mock.call(
-                '[AI_CURATION] Invalid JSON response received from chatgpt: Prompt: [%s], Response: [%s]',
-                [{'role': 'system', 'content': 'I am a prompt'}],
-                mock.ANY
-            )
-        ])
-
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.LOGGER')
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
-    def test_valid_json_with_wrong_type(self, mock_create, mock_logger):
-        """
-        Test that correct exception is raised if chat.completions.create send a valid json but wrong type
-        """
-        mock_create.return_value = MagicMock(choices=[MagicMock(message=MagicMock(content='{"a": 1}'))])
-
-        messages = [
-            {
-                'role': 'system',
-                'content': 'I am a prompt'
-            }
-        ]
-        with self.assertRaises(AICurationError):
-            chat_completions(messages)
-
-        assert mock_create.call_count == 3
-        assert mock_logger.error.called
-        mock_logger.error.assert_has_calls([
-            mock.call(
-                '[AI_CURATION] JSON response received but response type is incorrect: Prompt: [%s], Response: [%s]',
-                [{'role': 'system', 'content': 'I am a prompt'}],
-                mock.ANY
-            ),
-            mock.call(
-                '[AI_CURATION] JSON response received but response type is incorrect: Prompt: [%s], Response: [%s]',
-                [{'role': 'system', 'content': 'I am a prompt'}],
-                mock.ANY
-            ),
-            mock.call(
-                '[AI_CURATION] JSON response received but response type is incorrect: Prompt: [%s], Response: [%s]',
-                [{'role': 'system', 'content': 'I am a prompt'}],
-                mock.ANY
-            )
-        ])
-
     @patch('enterprise_catalog.apps.ai_curation.utils.open_ai_utils.LOGGER')
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
-    def test_get_query_keywords(self, mock_create, mock_logger):
+    @patch('enterprise_catalog.apps.ai_curation.openai_client.requests.post')
+    def test_get_query_keywords(self, mock_requests, mock_logger):
         """
         Test that get_query_keywords returns the correct keywords
         """
-        mock_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=json.dumps(['keyword1', 'keyword2'])))]
-        )
+        mock_requests.return_value.json.return_value = {
+            "role": "assistant",
+            "content": json.dumps(['keyword1', 'keyword2'])
+        }
         query = 'test query'
         expected_content = settings.AI_CURATION_QUERY_TO_KEYWORDS_PROMPT.format(query=query)
 
         result = get_query_keywords(query)
 
-        mock_create.assert_called_once_with(
-            messages=[{'role': 'system', 'content': expected_content}], **CHAT_COMPLETIONS_API_KEYWARGS
-        )
+        mock_requests.assert_called_once()
         mock_logger.info.assert_has_calls(
             [
                 mock.call(
@@ -206,25 +128,24 @@ class TestChatCompletionUtils(TestCase):
         assert result == ['keyword1', 'keyword2']
 
     @patch('enterprise_catalog.apps.ai_curation.utils.open_ai_utils.LOGGER')
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
+    @patch('enterprise_catalog.apps.ai_curation.openai_client.requests.post')
     @patch('enterprise_catalog.apps.ai_curation.utils.open_ai_utils.get_query_keywords')
-    def test_get_keywords_to_prose(self, mock_get_query_keywords, mock_create, mock_logger):
+    def test_get_keywords_to_prose(self, mock_get_query_keywords, mock_requests, mock_logger):
         """
         Test that get_keywords_to_prose returns the correct prose
         """
         mock_get_query_keywords.return_value = ['keyword1', 'keyword2']
-        mock_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=json.dumps(['I am a prose'])))]
-        )
+        mock_requests.return_value.json.return_value = {
+            "role": "assistant",
+            "content": json.dumps(['I am a prose'])
+        }
         query = 'test query'
         keywords = ['keyword1', 'keyword2']
         expected_content = settings.AI_CURATION_KEYWORDS_TO_PROSE_PROMPT.format(query=query, keywords=keywords)
 
         result = get_keywords_to_prose(query)
 
-        mock_create.assert_called_once_with(
-            messages=[{'role': 'system', 'content': expected_content}], **CHAT_COMPLETIONS_API_KEYWARGS
-        )
+        mock_requests.assert_called_once()
         mock_logger.info.assert_has_calls(
             [
                 mock.call(
@@ -237,12 +158,12 @@ class TestChatCompletionUtils(TestCase):
         assert result == 'I am a prose'
 
     @patch('enterprise_catalog.apps.ai_curation.openai_client.LOGGER')
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
-    def test_chat_completions_retries(self, mock_create, mock_logger):
+    @patch('enterprise_catalog.apps.ai_curation.openai_client.requests.post')
+    def test_chat_completions_retries(self, mock_requests, mock_logger):
         """
         Test that retries work as expected for chat_completions
         """
-        mock_create.side_effect = APIConnectionError(request=httpx.Request("GET", "https://api.example.com"))
+        mock_requests.side_effect = ConnectionError()
         messages = [
             {
                 'role': 'system',
@@ -254,34 +175,8 @@ class TestChatCompletionUtils(TestCase):
             with mock.patch.multiple(backoff_logger, info=mock.DEFAULT, error=mock.DEFAULT) as mock_backoff_logger:
                 chat_completions(messages=messages)
 
-        assert mock_create.call_count == 3
+        assert mock_requests.call_count == 3
         assert mock_backoff_logger['info'].call_count == 2
-        mock_backoff_logger['info'].assert_has_calls(
-            [
-                mock.call(
-                    'Backing off %s(...) for %.1fs (%s)',
-                    'chat_completions',
-                    mock.ANY,
-                    'openai.APIConnectionError: Connection error.'
-                ),
-                mock.call(
-                    'Backing off %s(...) for %.1fs (%s)',
-                    'chat_completions',
-                    mock.ANY,
-                    'openai.APIConnectionError: Connection error.'
-                )
-            ]
-        )
         assert mock_backoff_logger['error'].call_count == 1
-        mock_backoff_logger['error'].assert_has_calls(
-            [
-                mock.call(
-                    'Giving up %s(...) after %d tries (%s)',
-                    'chat_completions',
-                    3,
-                    'openai.APIConnectionError: Connection error.'
-                )
-            ]
-        )
         assert mock_logger.exception.called
         mock_logger.exception.assert_has_calls([mock.call('[AI_CURATION] API Error: Prompt: [%s]', messages)])

--- a/enterprise_catalog/apps/ai_curation/tests/utils/test_generate_curation_utils.py
+++ b/enterprise_catalog/apps/ai_curation/tests/utils/test_generate_curation_utils.py
@@ -2,7 +2,7 @@
 Tests for ai_curation app utils.
 """
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -95,16 +95,17 @@ class TestUtils(TestCase):
 
         assert apply_keywords_filter(courses, ['java']) == []
 
-    @patch('enterprise_catalog.apps.ai_curation.openai_client.client.chat.completions.create')
+    @patch('enterprise_catalog.apps.ai_curation.openai_client.requests.post')
     @patch('enterprise_catalog.apps.ai_curation.utils.open_ai_utils.get_query_keywords')
-    def test_apply_tfidf_filter(self, mock_get_query_keywords, mock_create):
+    def test_apply_tfidf_filter(self, mock_get_query_keywords, mock_requests):
         """
         Validate apply_tfidf_filter function.
         """
         mock_get_query_keywords.return_value = ['keyword1', 'keyword2']
-        mock_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=json.dumps(['Learn data science with python'])))]
-        )
+        mock_requests.return_value.json.return_value = {
+            "role": "assistant",
+            "content": json.dumps(['Learn data science with python'])
+        }
 
         courses = [
             {

--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -87,3 +87,8 @@ CACHES = {
         'LOCATION': 'enterprise.catalog.memcached:11211',
     }
 }
+
+CHAT_COMPLETION_API = 'http://test.chat.ai'
+CHAT_COMPLETION_API_KEY = 'test chat completion api key'
+CHAT_COMPLETION_API_CONNECT_TIMEOUT = 1
+CHAT_COMPLETION_API_READ_TIMEOUT = 15

--- a/enterprise_catalog/settings/local.py
+++ b/enterprise_catalog/settings/local.py
@@ -61,6 +61,10 @@ JWT_AUTH.update({
 })
 
 ENABLE_AUTO_AUTH = True
+CHAT_COMPLETION_API = 'http://test.chat.ai'
+CHAT_COMPLETION_API_KEY = 'test chat completion api key'
+CHAT_COMPLETION_API_CONNECT_TIMEOUT = 1
+CHAT_COMPLETION_API_READ_TIMEOUT = 15
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -30,3 +30,8 @@ CELERY_TASK_ALWAYS_EAGER = True
 
 results_dir = tempfile.TemporaryDirectory()
 CELERY_RESULT_BACKEND = f'file://{results_dir.name}'
+
+CHAT_COMPLETION_API = 'http://test.chat.ai'
+CHAT_COMPLETION_API_KEY = 'test chat completion api key'
+CHAT_COMPLETION_API_CONNECT_TIMEOUT = 1
+CHAT_COMPLETION_API_READ_TIMEOUT = 15


### PR DESCRIPTION
## Post-review

* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
