### PR TITLE
fix: adding page size param to highlights

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -437,6 +437,7 @@ class HighlightSetReadOnlyViewSetTests(CurationAPITestBase):
         ]
 
         url = reverse('api:v1:highlight-sets-list')
+        url = url + f'?enterprise_customer={self.enterprise_uuid}'
 
         self.set_up_catalog_learner()
         self.remove_role_assignments()
@@ -447,7 +448,7 @@ class HighlightSetReadOnlyViewSetTests(CurationAPITestBase):
         highlight_sets_results = response.json()['results']
         assert len(highlight_sets_results) == 2
 
-        limited_url = url + '?page_size=1'
+        limited_url = url + '&page_size=1'
 
         response = self.client.get(limited_url)
 

--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -48,7 +48,7 @@ class CurationAPITestBase(APITestMixin):
         # types including ones not supported by Curations/Highlighting feature, we set up a content type generator that
         # deterministically provides supported content types.
         supported_content_types = [COURSE, PROGRAM]
-        content_type_generator = (
+        self.content_type_generator = (
             supported_content_types[idx % len(supported_content_types)]
             for idx in itertools.count()
         )
@@ -58,7 +58,7 @@ class CurationAPITestBase(APITestMixin):
         self.highlight_set_one = HighlightSetFactory(enterprise_curation=self.curation_config_one)
         self.card_image_urls_one = [fake.image_url() + '.jpg' for idx in range(5)]
         self.highlighted_content_metadata_one = [
-            ContentMetadataFactory(card_image_url=url, content_type=next(content_type_generator))
+            ContentMetadataFactory(card_image_url=url, content_type=next(self.content_type_generator))
             for url in self.card_image_urls_one
         ]
         self.highlighted_content_list_one = [
@@ -72,7 +72,7 @@ class CurationAPITestBase(APITestMixin):
         self.highlight_set_two = HighlightSetFactory(enterprise_curation=self.curation_config_two)
         self.card_image_urls_two = [fake.image_url() + '.jpg' for idx in range(5)]
         self.highlighted_content_metadata_two = [
-            ContentMetadataFactory(card_image_url=url, content_type=next(content_type_generator))
+            ContentMetadataFactory(card_image_url=url, content_type=next(self.content_type_generator))
             for url in self.card_image_urls_two
         ]
         self.highlighted_content_list_two = [
@@ -419,6 +419,41 @@ class HighlightSetReadOnlyViewSetTests(CurationAPITestBase):
             second_response = self.client.get(url)
             assert second_response.json() == response.json()
             assert second_response.status_code == status.HTTP_200_OK
+
+    def test_list_test(self):
+        """
+        A catalog learner should be able to list the highlight sets of their own enterprise customer, but not that of
+        other enterprise customers.
+        """
+        self.highlight_set_two = HighlightSetFactory(enterprise_curation=self.curation_config_one)
+        self.card_image_urls_two = [fake.image_url() + '.jpg' for idx in range(5)]
+        self.highlighted_content_metadata_two = [
+            ContentMetadataFactory(card_image_url=url, content_type=next(self.content_type_generator))
+            for url in self.card_image_urls_one
+        ]
+        self.highlighted_content_list_two = [
+            HighlightedContentFactory(catalog_highlight_set=self.highlight_set_two, content_metadata=cm)
+            for cm in self.highlighted_content_metadata_two
+        ]
+
+        url = reverse('api:v1:highlight-sets-list')
+
+        self.set_up_catalog_learner()
+        self.remove_role_assignments()
+
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        highlight_sets_results = response.json()['results']
+        assert len(highlight_sets_results) == 2
+
+        limited_url = url + '?page_size=1'
+
+        response = self.client.get(limited_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        highlight_sets_results = response.json()['results']
+        assert len(highlight_sets_results) == 1
 
     def test_detail_invalid_uuid(self):
         """

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2737,7 +2737,15 @@ class CatalogQueryViewTests(APITestMixin):
         self.set_up_invalid_jwt_role()
         self.remove_role_assignments()
         response = self.client.get(url)
-        assert response.json() == {'count': 0, 'next': None, 'previous': None, 'results': []}
+        assert response.json() == {
+            'count': 0,
+            'current_page': 1,
+            'next': None,
+            'num_pages': 1,
+            'previous': None,
+            'results': [],
+            'start': 0,
+        }
 
         self.client.logout()
         response = self.client.get(url)

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -210,6 +210,7 @@ class HighlightSetBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
     renderer_classes = [JSONRenderer, XMLRenderer]
     serializer_class = HighlightSetSerializer
     lookup_field = 'uuid'
+    pagination_class = PageNumberWithSizePagination
 
     # Fields required for controlling access in the `list()` action
     list_lookup_field = 'enterprise_curation__enterprise_uuid'

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -22,9 +22,6 @@ from enterprise_catalog.apps.api.v1.constants import SegmentEvents
 from enterprise_catalog.apps.api.v1.event_utils import (
     track_highlight_set_changes,
 )
-from enterprise_catalog.apps.api.v1.pagination import (
-    PageNumberWithSizePagination,
-)
 from enterprise_catalog.apps.api.v1.serializers import (
     ContentMetadataSerializer,
     EnterpriseCurationConfigSerializer,
@@ -210,7 +207,6 @@ class HighlightSetBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
     renderer_classes = [JSONRenderer, XMLRenderer]
     serializer_class = HighlightSetSerializer
     lookup_field = 'uuid'
-    pagination_class = PageNumberWithSizePagination
 
     # Fields required for controlling access in the `list()` action
     list_lookup_field = 'enterprise_curation__enterprise_uuid'

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -138,7 +138,7 @@ DATABASES = {
 
 # Django Rest Framework
 REST_FRAMEWORK = {
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'edx_rest_framework_extensions.paginators.DefaultPagination',
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),


### PR DESCRIPTION
Adding customization to the page_size so that we can increase it to 12 (to fetch all in one page), since 12 is the limit of highlights one customer can add. 

[Jira link 
](https://2u-internal.atlassian.net/browse/ENT-9210)
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
