### PR TITLE
feat: include parent key in serialized content metadata responses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ docs/_build/
 
 # emacs
 *~
+.projectile
 
 # transifex exe
 tx


### PR DESCRIPTION
ENT-8875 | enterprise-access, a consumer of the content metadata API, will soon want to rely on the presence of the `parent_content_key` field for use in the `content_assignments` feature. This change ensures said field is present in responses to the `get_content_metadata` endpoint.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
