### PR TITLE
fix: adding production variable for https

### DIFF
--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -9,6 +9,14 @@ from enterprise_catalog.settings.utils import get_env_setting, get_logger_config
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 ALLOWED_HOSTS = ['*']
 
 LOGGING = get_logger_config()


### PR DESCRIPTION
**Release Plan** 

[Jira Ticket 
](https://2u-internal.atlassian.net/browse/ENT-9225)
When we have paginated list endpoints, the "next" page URL is mistakenly HTTP. We suspect this is because the URL is constructed based on the current request scheme.  edx-platform seems to workaround this issue by setting [SECURE_PROXY_SSL_HEADER](https://github.com/openedx/edx-platform/blob/c27d55a25383c08363671c2a847442b7a816b54c/lms/envs/production.py#L60) which overrides the current request scheme when DRF tries to fetch it to construct a next URL, so this PR is mimicking that behavior. It doesn’t affect local in the same way, meaning testing locally is off the table. Therefore, we are planning to bubble this change all the way up to prod with a plan for rollback if anything goes wrong. The plan is as follows:
- Release to production on enterprise-catalog
- Test to see if the response back from a paginated endpoint (like /api/v1/highlight-sets/ or /api/v1/enterprise-curations/) has changed from an http prefix to the correct https
- If It works with no errors, propagate this change to more enterprise repositories like access and subsidy 

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
