### PR TITLE
refactor: use serializer to compute normalized_metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         architecture: x64
     - name: Start container
       run: |
-        docker-compose -f .github/docker-compose-github.yml up -d
+        docker compose -f .github/docker-compose-github.yml up -d
     - name: Install test dependencies and run validation
       run: |
         docker exec -e TOXENV=py312-${{ matrix.django-version }} -u root enterprise.catalog.app /edx/app/enterprise_catalog/enterprise_catalog/validate.sh

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -24,6 +24,10 @@ from enterprise_catalog.apps.catalog.constants import (
     PROGRAM,
 )
 from enterprise_catalog.apps.catalog.models import CatalogQuery, ContentMetadata
+from enterprise_catalog.apps.catalog.serializers import (
+    DEFAULT_NORMALIZED_PRICE,
+    _find_best_mode_seat,
+)
 from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     ContentMetadataFactory,
@@ -394,8 +398,7 @@ class UpdateFullContentMetadataTaskTests(TestCase):
         """
         Test the behavior of _find_best_mode_seat().
         """
-        # pylint: disable=protected-access
-        assert tasks._find_best_mode_seat(seats) == expected_seat
+        assert _find_best_mode_seat(seats) == expected_seat
 
     # pylint: disable=unused-argument
     @mock.patch('enterprise_catalog.apps.api.tasks.task_recently_run', return_value=False)
@@ -491,7 +494,7 @@ class UpdateFullContentMetadataTaskTests(TestCase):
 
         assert metadata_2.json_metadata['aggregation_key'] == f'course:{course_key_2}'
         assert metadata_2.json_metadata['full_course_only_field'] == 'test_2'
-        assert metadata_2.json_metadata['normalized_metadata']['content_price'] == tasks.DEFAULT_NORMALIZED_PRICE
+        assert metadata_2.json_metadata['normalized_metadata']['content_price'] == DEFAULT_NORMALIZED_PRICE
         assert set(program_data.items()).issubset(set(metadata_2.json_metadata['programs'][0].items()))
 
         assert metadata_3.json_metadata['aggregation_key'] == f'course:{course_key_3}'

--- a/enterprise_catalog/apps/catalog/serializers.py
+++ b/enterprise_catalog/apps/catalog/serializers.py
@@ -1,0 +1,151 @@
+"""
+Defines serializers to process data at the boundaries
+of the `catalog` domain.
+"""
+import logging
+
+from django.utils.functional import cached_property
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from enterprise_catalog.apps.api.constants import CourseMode
+
+from .algolia_utils import _get_course_run_by_uuid
+
+
+logger = logging.getLogger(__name__)
+
+# The default normalized content price for any content which otherwise
+# would have a null price
+DEFAULT_NORMALIZED_PRICE = 0.0
+
+# The closer a mode is to the beginning of this list, the more likely a seat with that mode will be used to find the
+# upgrade deadline for the course (and course run).
+BEST_MODE_ORDER = [
+    CourseMode.VERIFIED,
+    CourseMode.PROFESSIONAL,
+    CourseMode.NO_ID_PROFESSIONAL_MODE,
+    CourseMode.UNPAID_EXECUTIVE_EDUCATION,
+    CourseMode.AUDIT,
+]
+
+
+def _find_best_mode_seat(seats):
+    """
+    Find the seat with the "best" course mode.  See BEST_MODE_ORDER to find which modes are best.
+    """
+    sort_key_for_mode = {mode: index for (index, mode) in enumerate(BEST_MODE_ORDER)}
+
+    def sort_key(seat):
+        """
+        Get a sort key (int) for a seat dictionary based on the position of its mode in the BEST_MODE_ORDER list.
+
+        Modes not found in the BEST_MODE_ORDER list get sorted to the end of the list.
+        """
+        mode = seat['type']
+        return sort_key_for_mode.get(mode, len(sort_key_for_mode))
+
+    sorted_seats = sorted(seats, key=sort_key)
+    if sorted_seats:
+        return sorted_seats[0]
+    return None
+
+
+class ReadOnlySerializer(serializers.Serializer):
+    """
+    A serializer that supports serialization only. Does not support
+    deserialization, updates, or creates.
+    """
+    def to_internal_value(self, data):
+        """
+        This serializer does not support deserialization.
+        """
+        raise NotImplementedError
+
+    def create(self, validated_data):
+        """
+        This serializer does not support creates.
+        """
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        """
+        This serializer does not support updates.
+        """
+        raise NotImplementedError
+
+
+# pylint: disable=abstract-method
+class NormalizedContentMetadataSerializer(ReadOnlySerializer):
+    """
+    Produces a dict of metadata keys with values calculated
+    by normalizing existing key-values. This will be helpful for
+    downstream consumers, who should be able to use this dictionary
+    instead of doing their own independent normalization.
+
+    Note that course-type-specific definitions of each of these keys may be more nuanced.
+    """
+    start_date = serializers.SerializerMethodField(help_text='When the course starts')
+    end_date = serializers.SerializerMethodField(help_text='When the course ends')
+    enroll_by_date = serializers.SerializerMethodField(help_text='The deadline for enrollment')
+    content_price = serializers.SerializerMethodField(help_text='The price of a course in USD')
+
+    @cached_property
+    def advertised_course_run(self):
+        advertised_course_run_uuid = self.instance.json_metadata.get('advertised_course_run_uuid')
+        return _get_course_run_by_uuid(self.instance.json_metadata, advertised_course_run_uuid)
+
+    @cached_property
+    def additional_metadata(self):
+        return self.instance.json_metadata.get('additional_metadata', {})
+
+    @extend_schema_field(serializers.DateTimeField)
+    def get_start_date(self, obj) -> str:
+        if obj.is_exec_ed_2u_course:
+            return self.additional_metadata.get('start_date')
+
+        if not self.advertised_course_run:
+            return None
+
+        if start_date_string := self.advertised_course_run.get('start'):
+            return start_date_string
+
+        return None
+
+    @extend_schema_field(serializers.DateTimeField)
+    def get_end_date(self, obj) -> str:
+        if obj.is_exec_ed_2u_course:
+            return self.additional_metadata.get('end_date')
+
+        if not self.advertised_course_run:
+            return None
+
+        if end_date_string := self.advertised_course_run.get('end'):
+            return end_date_string
+
+        return None
+
+    @extend_schema_field(serializers.DateTimeField)
+    def get_enroll_by_date(self, obj) -> str:
+        if obj.is_exec_ed_2u_course:
+            return self.additional_metadata.get('registration_deadline')
+
+        all_seats = self.advertised_course_run.get('seats', [])
+        seat = _find_best_mode_seat(all_seats)
+        if seat:
+            return seat.get('upgrade_deadline')
+        else:
+            logger.info(
+                f"No Seat Found for course run '{self.advertised_course_run.get('key')}'. "
+                f"Seats: {all_seats}"
+            )
+            return None
+
+    @extend_schema_field(serializers.FloatField)
+    def get_content_price(self, obj) -> float:
+        if obj.is_exec_ed_2u_course:
+            for entitlement in obj.json_metadata.get('entitlements', []):
+                if entitlement.get('mode') == CourseMode.PAID_EXECUTIVE_EDUCATION:
+                    return entitlement.get('price') or DEFAULT_NORMALIZED_PRICE
+
+        return self.advertised_course_run.get('first_enrollable_paid_seat_price') or DEFAULT_NORMALIZED_PRICE


### PR DESCRIPTION
Introduces an explicit serializer, `NormalizedContentMetadataSerializer`, for populating the `normalized_metadata` key inside of `json_metadata`.  I'm hoping for two things:
1. To expand the number of fields in this serializer, and to eventually utilize it in emiting openedx events.
2. To illustrate a pattern for future adoption of serializer-based data transformation.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
