### PR TITLE
build: remove vestiges of deprecated docker-compose

### DIFF
--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   mysql:
     image: mysql:8.0.28-oracle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         architecture: x64
     - name: Start container
       run: |
-        docker-compose -f .github/docker-compose-github.yml up -d
+        docker compose -f .github/docker-compose-github.yml up -d
     - name: Install test dependencies and run validation
       run: |
         docker exec -e TOXENV=py312-${{ matrix.django-version }} -u root enterprise.catalog.app /edx/app/enterprise_catalog/enterprise_catalog/validate.sh


### PR DESCRIPTION
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
