### PR TITLE
feat: more restricted runs and contains_content_items logic

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_contains_content_items.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_contains_content_items.py
@@ -17,6 +17,9 @@ from enterprise_catalog.apps.api.v1.serializers import (
 )
 from enterprise_catalog.apps.api.v1.utils import unquote_course_keys
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
+from enterprise_catalog.apps.catalog.api import (
+    catalog_contains_any_restricted_course_run,
+)
 from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
 
 
@@ -58,4 +61,9 @@ class EnterpriseCatalogContainsContentItems(BaseViewSet, viewsets.ReadOnlyModelV
 
         enterprise_catalog = self.get_object()
         contains_content_items = enterprise_catalog.contains_content_keys(course_run_ids + program_uuids)
-        return Response({'contains_content_items': contains_content_items})
+        contains_requested_restricted_items = catalog_contains_any_restricted_course_run(
+            enterprise_catalog, course_run_ids,
+        )
+        return Response({
+            'contains_content_items': contains_content_items or contains_requested_restricted_items
+        })

--- a/enterprise_catalog/apps/catalog/api.py
+++ b/enterprise_catalog/apps/catalog/api.py
@@ -1,0 +1,73 @@
+"""
+Python interface for the ``catalog`` module.
+"""
+from collections import defaultdict
+
+from enterprise_catalog.apps.catalog.constants import COURSE_RUN_KEY_PREFIX
+
+
+def get_restricted_runs_allowed_for_query(course_run_ids, customer_catalogs):
+    """
+    Filter the set of restricted course keys down to only
+    those requested in ``course_run_ids``.
+
+    Params:
+        course_run_ids: A list of either course or course run keys.
+        customer_catalogs: A list of ``EnterpriseCatalog`` records.
+
+    Returns:
+        A dictionary mapping courses to allowed restricted runs for catalogs that
+        allow the restricted inclusion. That is:
+        ```
+        {
+            'org+key1': {
+                'course-v1:org+key1+restrictedrun': {
+                    'catalog_uuids': {'catalog-1.uuid'}
+                },
+            },
+            'org+key3': {
+                'course-v1:org+key3+restrictedrun': {
+                    'catalog_uuids': {'catalog-2.uuid'}
+                },
+            },
+        }
+        ```
+    """
+    requested_course_keys = {
+        key for key in course_run_ids if not key.startswith(COURSE_RUN_KEY_PREFIX)
+    }
+    requested_run_keys = {
+        key for key in course_run_ids if key.startswith(COURSE_RUN_KEY_PREFIX)
+    }
+    serialized_data = defaultdict(lambda: defaultdict(lambda: {'catalog_uuids': set()}))
+    for catalog in customer_catalogs:
+        if not catalog.restricted_runs_allowed:
+            continue
+
+        for restricted_course_key, restricted_runs in catalog.restricted_runs_allowed.items():
+            matching_runs = bool(set(restricted_runs).intersection(requested_run_keys))
+            matching_course = restricted_course_key in requested_course_keys
+            if not (matching_course or matching_runs):
+                continue
+
+            course_dict = serialized_data[restricted_course_key]
+            for course_run_key in restricted_runs:
+                run_dict = course_dict[course_run_key]
+                run_dict['catalog_uuids'].add(str(catalog.uuid))
+    return serialized_data or None
+
+
+def catalog_contains_any_restricted_course_run(enterprise_catalog, course_run_keys):
+    """
+    Params:
+        course_run_keys: A list of candidate course run keys.
+        customer_catalog: An ``EnterpriseCatalog`` record.
+
+    Returns:
+        A boolean indicating if at least one of the provided course_run_keys
+        is present in the set of restricted runs for the given enterprise_catalog.
+    """
+    for course_run_key in course_run_keys:
+        if course_run_key in enterprise_catalog.restricted_courses_by_run_key:
+            return True
+    return False

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -140,6 +140,29 @@ class CatalogQuery(TimeStampedModel):
             for course_key, course_run_list in mapping.items()
         }
 
+    @cached_property
+    def restricted_courses_by_run_key(self):
+        """
+        Returns a reverse mapping of self.restricted_runs_allowed, e.g.
+        ```
+        {
+            "course-v1:edX+FUN+3T2024": "edX+FUN",
+            "course-v1:edX+FUN+3T2025": "edX+FUN",
+            "course-v1:edX+GAMES+3T2024": "edX+GAMES",
+        }
+        ```
+
+        Returns an empty dict if no restricted runs are allowed for this CatalogQuery.
+        """
+        if not self.restricted_runs_allowed:
+            return {}
+
+        restricted_courses_by_run = {}
+        for course_key, restricted_run_list in self.restricted_runs_allowed.items():
+            for run_key in restricted_run_list:
+                restricted_courses_by_run[run_key] = course_key
+        return restricted_courses_by_run
+
     @classmethod
     def get_by_uuid(cls, uuid):
         try:
@@ -238,6 +261,10 @@ class EnterpriseCatalog(TimeStampedModel):
     @cached_property
     def restricted_runs_allowed(self):
         return self.catalog_query.restricted_runs_allowed
+
+    @cached_property
+    def restricted_courses_by_run_key(self):
+        return self.catalog_query.restricted_courses_by_run_key
 
     @cached_property
     def enterprise_customer(self):


### PR DESCRIPTION
    * contains_content_items endpoint now both utilize the same shared logic around restricted runs
    * contains_content_items top-level key returns true based on explicit content membership *or*
    membership in configured restricted runs mapping
    * The previous point implies that requests about restricted course runs
    will response with contains_content_items=true, even if the run is
    not tied directly to the catalog via ContentMetadata records.
    ENT-9386
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
