### PR TITLE
feat: upgrade edx-rbac to 1.10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -175,7 +175,7 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-opaque-keys==2.10.0
     # via edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.in
 edx-rest-api-client==5.7.1
     # via -r requirements/base.in
@@ -297,7 +297,7 @@ rules==3.4
     # via -r requirements/base.in
 scikit-learn==1.5.1
     # via -r requirements/base.in
-scipy==1.14.0
+scipy==1.14.1
     # via scikit-learn
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -327,7 +327,7 @@ social-auth-core==4.5.4
     #   social-auth-app-django
 sqlparse==0.5.1
     # via django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -337,7 +337,7 @@ edx-opaque-keys==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -351,7 +351,7 @@ edx-toggles==5.2.0
     #   -r requirements/test.txt
 factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==27.0.0
+faker==27.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -384,7 +384,7 @@ idna==3.7
     #   anyio
     #   httpx
     #   requests
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via inflect
 inflect==3.0.2
     # via
@@ -698,7 +698,7 @@ scikit-learn==1.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -755,7 +755,7 @@ sqlparse==0.5.1
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -273,7 +273,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/test.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/test.txt
@@ -281,7 +281,7 @@ edx-toggles==5.2.0
     # via -r requirements/test.txt
 factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==27.0.0
+faker==27.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -553,7 +553,7 @@ rules==3.4
     # via -r requirements/test.txt
 scikit-learn==1.5.1
     # via -r requirements/test.txt
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements/test.txt
     #   scikit-learn
@@ -618,7 +618,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/test.txt
     #   code-annotations

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==72.2.0
+setuptools==73.0.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -205,7 +205,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/base.txt
@@ -393,7 +393,7 @@ rules==3.4
     # via -r requirements/base.txt
 scikit-learn==1.5.1
     # via -r requirements/base.txt
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -434,7 +434,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -225,7 +225,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/base.txt
@@ -432,7 +432,7 @@ rules==3.4
     # via -r requirements/base.txt
 scikit-learn==1.5.1
     # via -r requirements/base.txt
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -476,7 +476,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -241,7 +241,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/base.txt
@@ -249,7 +249,7 @@ edx-toggles==5.2.0
     # via -r requirements/base.txt
 factory-boy==3.3.1
     # via -r requirements/test.in
-faker==27.0.0
+faker==27.4.0
     # via factory-boy
 filelock==3.15.4
     # via
@@ -479,7 +479,7 @@ rules==3.4
     # via -r requirements/base.txt
 scikit-learn==1.5.1
     # via -r requirements/base.txt
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -521,7 +521,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -319,7 +319,7 @@ edx-opaque-keys==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -333,7 +333,7 @@ edx-toggles==5.2.0
     #   -r requirements/test.txt
 factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==27.0.0
+faker==27.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -643,7 +643,7 @@ scikit-learn==1.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -699,7 +699,7 @@ sqlparse==0.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
Allows use of the `RBAC_IGNORE_INVALID_JWT_COOKIE` setting.
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
