### PR TITLE
fix: 403 for provisioning-admins due to crum

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
@@ -68,6 +68,7 @@ class EnterpriseCatalogCRUDViewSet(BaseViewSet, viewsets.ModelViewSet):
         for which the `rules` predicate checks against.
         """
         # Grant provisioning-admins access to few actions
+        crum.set_current_request(request)
         is_provisioning_admin = self.request.user.has_perm(PERMISSION_HAS_PROVISIONING_ADMIN_ACCESS)
         if self.request_action in ('create', 'partial_update', 'update', 'retrieve', 'list') and \
                 is_provisioning_admin:


### PR DESCRIPTION
Description: Auth was working fine via swagger but while making calls through postman returns 403. Manually setting crum request resolves the issue.


## Post-review


* [x] Squash commits into discrete sets of changes
* [x] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
