### PR TITLE
fix: update how fallback value is defined for enrollment_end

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -1258,7 +1258,7 @@ def _get_course_run_enroll_by_date_timestamp(full_course_run):
     since Algolia cannot filter on null values
     """
     upgrade_deadline_timestamp = _get_verified_upgrade_deadline(full_course_run=full_course_run)
-    enrollment_end_timestamp = full_course_run.get('enrollment_end', ALGOLIA_DEFAULT_TIMESTAMP)
+    enrollment_end_timestamp = full_course_run.get('enrollment_end') or ALGOLIA_DEFAULT_TIMESTAMP
     if not isinstance(enrollment_end_timestamp, (int, float)):
         enrollment_end_timestamp = to_timestamp(enrollment_end_timestamp)
     return min(enrollment_end_timestamp, upgrade_deadline_timestamp)


### PR DESCRIPTION
Uses `or` as opposed to the fallback value from `.get`

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
