### PR TITLE
feat: DEPR USE-JWT-COOKIE header

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -119,11 +119,7 @@ To get a JWT role defined inside your cookie, do the following:
             "enterprise_learner:{another-enterprise-uuid}",
             "enterprise_openedx_operator:*"
         ]
-   #. Soon, you'll make a request to e.g. http://localhost:18160/api/v1/enterprise-catalogs/?format=json.  Before you do this,
-      it's important that you can make the request with an additional header: ``use_jwt_cookie: true``  This tells
-      our auth middleware to "reconstitute" the JWT cookie header and signature into a single JWT from which auth, roles, etc.
-      can be fetched.  You can do this in your browser using a tool like ModHeader, or with something like Postman.
-   #. Make the request.  For the example endpoint above, you should get a response payload that looks like::
+   #. Make a request to e.g. http://localhost:18160/api/v1/enterprise-catalogs/?format=json. For this example endpoint, you should get a response payload that looks like::
 
         {
           "count": 2,

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -107,9 +107,7 @@ LOG_REQUESTS = False
 
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers + (
-    'use-jwt-cookie',
-)
+CORS_ALLOW_HEADERS = corsheaders_default_headers
 CORS_ORIGIN_WHITELIST = []
 
 ROOT_URLCONF = 'enterprise_catalog.urls'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -21,7 +21,7 @@ edx-auth-backends
 edx-celeryutils
 edx-django-release-util
 edx-django-utils
-edx-drf-extensions>=10.2.0  # removes use-jwt-cookie header
+edx-drf-extensions>=10.2.0  # 10.2.0 removes use-jwt-cookie header
 edx_rbac
 edx-rest-api-client
 edx-toggles

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -21,7 +21,7 @@ edx-auth-backends
 edx-celeryutils
 edx-django-release-util
 edx-django-utils
-edx-drf-extensions
+edx-drf-extensions>=10.2.0  # removes use-jwt-cookie header
 edx_rbac
 edx-rest-api-client
 edx-toggles


### PR DESCRIPTION
This repo is no longer using USE-JWT-COOKIE header, since it has the required edx-drf-extensions>10.2.0, where it was fully removed.

This is final clean-up for this repo.

See "[DEPR]: USE-JWT-COOKIE header" for more details:
- https://github.com/openedx/edx-drf-extensions/issues/371

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
