### PR TITLE
feat: DEPR USE-JWT-COOKIE header - Part 1

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -119,11 +119,7 @@ To get a JWT role defined inside your cookie, do the following:
             "enterprise_learner:{another-enterprise-uuid}",
             "enterprise_openedx_operator:*"
         ]
-   #. Soon, you'll make a request to e.g. http://localhost:18160/api/v1/enterprise-catalogs/?format=json.  Before you do this,
-      it's important that you can make the request with an additional header: ``use_jwt_cookie: true``  This tells
-      our auth middleware to "reconstitute" the JWT cookie header and signature into a single JWT from which auth, roles, etc.
-      can be fetched.  You can do this in your browser using a tool like ModHeader, or with something like Postman.
-   #. Make the request.  For the example endpoint above, you should get a response payload that looks like::
+   #. Make a request to e.g. http://localhost:18160/api/v1/enterprise-catalogs/?format=json. For this example endpoint, you should get a response payload that looks like::
 
         {
           "count": 2,


### PR DESCRIPTION
This repo is no longer using USE-JWT-COOKIE header, since it has the required edx-drf-extensions>10.2.0, where it was fully removed.

This removes all uses of the header, except updating CORS_ALLOW_HEADERS, which can't be done before all MFEs and other callers stop sending the header.

See "[DEPR]: USE-JWT-COOKIE header" for more details:
- https://github.com/openedx/edx-drf-extensions/issues/371

**NOTE:** This restores part of the reverted PR that can land now:
- https://github.com/openedx/enterprise-catalog/pull/924

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
