### PR TITLE
feat: support course run keys in `get_content_metadata`; introduce `normalized_metadata_by_run` in persisted `ContentMetadata` course JSON

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -169,7 +169,6 @@ def program_hit_to_row(hit):
     return csv_row
 
 
-# pylint: disable=too-many-statements
 def course_hit_to_row(hit):
     """
     Helper function to construct a CSV row according to a single Algolia result course hit.

--- a/enterprise_catalog/apps/catalog/tests/test_serializers.py
+++ b/enterprise_catalog/apps/catalog/tests/test_serializers.py
@@ -19,25 +19,30 @@ class NormalizedContentMetadataSerializerTests(TestCase):
     """
     Tests for ``NormalizedContentMetadataSerializer``.
     """
+
     def test_enroll_by_date_no_advertised_run(self):
         course_content = factories.ContentMetadataFactory(
             content_type=COURSE,
         )
         course_content.json_metadata['advertised_course_run_uuid'] = None
 
-        serialized_data = NormalizedContentMetadataSerializer(course_content).data
+        normalized_metadata_input = {
+            'course': course_content,
+        }
+        serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
         self.assertIsNone(serialized_data['enroll_by_date'])
 
-    def test_enroll_by_date_is_exec_ed_course_with_enrollment_end(self):
+    @ddt.data(
+        {'has_course_run': False},
+        {'has_course_run': True},
+    )
+    @ddt.unpack
+    def test_enroll_by_date_is_exec_ed_course_with_enrollment_end(self, has_course_run):
         course_content = factories.ContentMetadataFactory(
             content_type=COURSE,
         )
         course_content.json_metadata['course_type'] = EXEC_ED_2U_COURSE_TYPE
-        course_content.json_metadata['additional_metadata'] = {
-            'will': 'be ignored',
-            'registration_deadline': '1999-12-31T23:59:59Z',
-        }
         course_content.json_metadata['course_runs'] = [
             {
                 'uuid': 'the-course-run-uuid',
@@ -46,19 +51,25 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         ]
         course_content.json_metadata['advertised_course_run_uuid'] = 'the-course-run-uuid'
 
-        serialized_data = NormalizedContentMetadataSerializer(course_content).data
+        normalized_metadata_input = {
+            'course': course_content,
+        }
+        if has_course_run:
+            normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
+        serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
         self.assertEqual(serialized_data['enroll_by_date'], '2024-01-01T00:00:00Z')
 
-    def test_enroll_by_date_is_exec_ed_course_no_enrollment_end(self):
+    @ddt.data(
+        {'has_course_run': False},
+        {'has_course_run': True},
+    )
+    @ddt.unpack
+    def test_enroll_by_date_is_exec_ed_course_no_enrollment_end(self, has_course_run):
         course_content = factories.ContentMetadataFactory(
             content_type=COURSE,
         )
         course_content.json_metadata['course_type'] = EXEC_ED_2U_COURSE_TYPE
-        course_content.json_metadata['additional_metadata'] = {
-            'will': 'not be ignored',
-            'registration_deadline': '1999-12-31T23:59:59Z',
-        }
         course_content.json_metadata['course_runs'] = [
             {
                 'uuid': 'the-course-run-uuid',
@@ -66,13 +77,23 @@ class NormalizedContentMetadataSerializerTests(TestCase):
             }
         ]
         course_content.json_metadata['advertised_course_run_uuid'] = 'the-course-run-uuid'
+        normalized_metadata_input = {
+            'course': course_content,
+        }
+        if has_course_run:
+            normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
+        serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
-        serialized_data = NormalizedContentMetadataSerializer(course_content).data
+        self.assertEqual(serialized_data['enroll_by_date'], None)
 
-        self.assertEqual(serialized_data['enroll_by_date'], '1999-12-31T23:59:59Z')
-
-    @ddt.data(True, False)
-    def test_enroll_by_date_verified_course_with_seat(self, has_override):
+    @ddt.data(
+        {'has_override': True, 'has_course_run': False},
+        {'has_override': False, 'has_course_run': False},
+        {'has_override': True, 'has_course_run': True},
+        {'has_override': False, 'has_course_run': True},
+    )
+    @ddt.unpack
+    def test_enroll_by_date_verified_course_with_seat(self, has_override, has_course_run):
         course_content = factories.ContentMetadataFactory(
             content_type=COURSE,
         )
@@ -92,14 +113,24 @@ class NormalizedContentMetadataSerializerTests(TestCase):
             }
         ]
 
-        serialized_data = NormalizedContentMetadataSerializer(course_content).data
+        normalized_metadata_input = {
+            'course': course_content,
+        }
+        if has_course_run:
+            normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
+        serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
         if has_override:
             self.assertEqual(serialized_data['enroll_by_date'], actual_deadline_override)
         else:
             self.assertEqual(serialized_data['enroll_by_date'], actual_deadline)
 
-    def test_enroll_by_date_verified_course_no_seat(self):
+    @ddt.data(
+        {'has_course_run': False},
+        {'has_course_run': True},
+    )
+    @ddt.unpack
+    def test_enroll_by_date_verified_course_no_seat(self, has_course_run):
         course_content = factories.ContentMetadataFactory(
             content_type=COURSE,
         )
@@ -107,6 +138,11 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         course_content.json_metadata['course_runs'][0]['seats'] = []
         course_content.json_metadata['course_runs'][0]['enrollment_end'] = actual_deadline
 
-        serialized_data = NormalizedContentMetadataSerializer(course_content).data
+        normalized_metadata_input = {
+            'course': course_content,
+        }
+        if has_course_run:
+            normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
+        serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
         self.assertEqual(serialized_data['enroll_by_date'], actual_deadline)


### PR DESCRIPTION
## Description

Related tickets:
* https://2u-internal.atlassian.net/browse/ENT-8876
* https://2u-internal.atlassian.net/browse/ENT-9029

Two primary changes:
1. Updates existing `get_content_metadata` API to support mixed content types in its optional `?content_keys` query parameter, i.e. both course and (with this PR) course run keys. Similar to other content metadata related APIs (e.g., in enterprise-subsidy), passing a course run key will typically return the top-level course.
    * This change was abstracted to its own PR: https://github.com/openedx/enterprise-catalog/pull/940

2. Extends the _full_ `json_metadata` of `ContentMetadata` course objects to include a new `normalized_metadata_by_run` key with a value containing a mapping of normalized metadata per course run key of the top-level course, using the same `NormalizedContentMetadataSerializerTests`.
   * This simplifies consumers of enterprise-catalog APIs such that run-specific dates, prices, etc. across content types doesn't need to occur at the edges. Instead, the interface is created at the time of content ingestion via `update_content_metadata`.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
