### PR TITLE
feat: Add fixed_price_usd logic to normalized metadata content price

### DIFF
--- a/enterprise_catalog/apps/catalog/serializers.py
+++ b/enterprise_catalog/apps/catalog/serializers.py
@@ -145,10 +145,14 @@ class NormalizedContentMetadataSerializer(ReadOnlySerializer):
 
     @extend_schema_field(serializers.FloatField)
     def get_content_price(self, obj) -> float:  # pylint: disable=unused-argument
-        if self.is_exec_ed_2u_course is True:
-            for entitlement in self.course_metadata.get('entitlements', []):
-                if entitlement.get('mode') == CourseMode.PAID_EXECUTIVE_EDUCATION:
-                    return entitlement.get('price') or DEFAULT_NORMALIZED_PRICE
         if not self.course_run_metadata:
             return None
-        return self.course_run_metadata.get('first_enrollable_paid_seat_price') or DEFAULT_NORMALIZED_PRICE
+        if self.course_run_metadata.get('fixed_price_usd'):
+            return float(self.course_run_metadata.get('fixed_price_usd'))
+        if self.is_exec_ed_2u_course is True:
+            for entitlement in self.course_metadata.get('entitlements', []):
+                if entitlement.get('price') and entitlement.get('mode') == CourseMode.PAID_EXECUTIVE_EDUCATION:
+                    return float(entitlement.get('price'))
+        if self.course_run_metadata.get('first_enrollable_paid_seat_price'):
+            return float(self.course_run_metadata.get('first_enrollable_paid_seat_price'))
+        return DEFAULT_NORMALIZED_PRICE

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -127,6 +127,8 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 ],
                 'start': '2024-02-12T11:00:00Z',
                 'end': '2026-02-05T11:00:00Z',
+                'fixed_price_price_usd': None,
+                'first_enrollable_paid_seat_price': 50,
             }]
             json_metadata.update({
                 'content_type': COURSE,
@@ -136,6 +138,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'advertised_course_run_uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
                 'course_runs': course_runs,
                 'course': self.content_key,
+                'entitlements': [],
             })
         elif self.content_type == COURSE_RUN:
             json_metadata.update({


### PR DESCRIPTION
Considers a course run's `fixed_price_usd` value as part of the `get_content_price` serializer for `normalized_metadata` and upcoming `normalized_metadata_by_run`.

PR includes dependent changes from this PR -> https://github.com/openedx/enterprise-catalog/pull/930

Refactors `get_content_price` to respect `float` type output and to handle `None` type prices gracefully based on the unique incoming data types between `first_enrollable_paid_seat_price` and `fixed_price_usd`/`price`
Adds tests for `get_content_price` for the `NormalizedContentMetadataSerializerTests`.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
