### PR TITLE
feat: fetch and filter out restricted course runs

### DIFF
--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -10,6 +10,10 @@ from six.moves.urllib.parse import (
     urlunsplit,
 )
 
+from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    is_course_run_active,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -57,25 +61,6 @@ def get_enterprise_utm_context(enterprise_name):
         utm_context['utm_source'] = slugify(enterprise_name)
 
     return utm_context
-
-
-def is_course_run_active(course_run):
-    """
-    Checks whether a course run is active. That is, whether the course run is published,
-    enrollable, and marketable.
-
-    Arguments:
-        course_run (dict): The metadata about a course run.
-
-    Returns:
-        bool: True if course run is "active"
-    """
-    course_run_status = course_run.get('status') or ''
-    is_published = course_run_status.lower() == 'published'
-    is_enrollable = course_run.get('is_enrollable', False)
-    is_marketable = course_run.get('is_marketable', False)
-
-    return is_published and is_enrollable and is_marketable
 
 
 def is_any_course_run_active(course_runs):

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -13,7 +13,7 @@ from enterprise_catalog.apps.catalog.constants import (
     DISCOVERY_PROGRAM_KEY_BATCH_SIZE,
 )
 from enterprise_catalog.apps.catalog.content_metadata_utils import (
-    tansform_force_included_courses,
+    transform_force_included_courses,
 )
 from enterprise_catalog.apps.catalog.utils import batch
 
@@ -301,7 +301,7 @@ class DiscoveryApiClient(BaseOAuthClient):
                     f'attempting to force-include: {forced_aggregation_keys}'
                 )
                 forced_courses = self.fetch_courses_by_keys(forced_aggregation_keys)
-                results += tansform_force_included_courses(forced_courses)
+                results += transform_force_included_courses(forced_courses)
         except Exception as exc:
             LOGGER.exception(
                 f'unable to add unlisted courses for catalog_id: {catalog_query.id}'
@@ -425,12 +425,14 @@ class DiscoveryApiClient(BaseOAuthClient):
 
         return programs
 
-    def fetch_courses_by_keys(self, course_keys):
+    def fetch_courses_by_keys(self, course_keys, additional_params=None):
         """
         Fetches course data from discovery's /api/v1/courses endpoint for the provided course keys.
 
         Args:
             course_keys (list of str): Content keys for Course ContentMetadata objects.
+            additional_params (dict): Optional dict of additional query parameters
+              to send in request for course metadata.
         Returns:
             list of dict: Returns a list of dictionaries where each dictionary represents the course
             data from discovery.
@@ -442,6 +444,7 @@ class DiscoveryApiClient(BaseOAuthClient):
         for course_keys_chunk in batched_course_keys:
             # Discovery expects the keys param to be in the format ?keys=course1,course2,...
             query_params = {'keys': ','.join(course_keys_chunk)}
+            query_params.update(additional_params or {})
             courses.extend(self.get_courses(query_params=query_params))
 
         return courses

--- a/enterprise_catalog/apps/catalog/constants.py
+++ b/enterprise_catalog/apps/catalog/constants.py
@@ -121,6 +121,8 @@ AGGREGATION_KEY_PREFIX = 'course:'
 
 COURSE_RUN_KEY_PREFIX = 'course-v1:'
 
+COURSE_RUN_RESTRICTION_TYPE_KEY = 'restriction_type'
+
 
 def json_serialized_course_modes():
     """

--- a/enterprise_catalog/apps/catalog/content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/content_metadata_utils.py
@@ -6,13 +6,16 @@ from logging import getLogger
 
 from enterprise_catalog.apps.catalog.utils import get_content_key
 
-from .constants import FORCE_INCLUSION_METADATA_TAG_KEY
+from .constants import (
+    COURSE_RUN_RESTRICTION_TYPE_KEY,
+    FORCE_INCLUSION_METADATA_TAG_KEY,
+)
 
 
 LOGGER = getLogger(__name__)
 
 
-def tansform_force_included_courses(courses):
+def transform_force_included_courses(courses):
     """
     Transform a list of forced/unlisted course metadata
     ENT-8212
@@ -41,3 +44,124 @@ def transform_course_metadata_to_visible(course_metadata):
         course_run_statuses.append(course_run.get('status'))
     course_metadata['course_run_statuses'] = course_run_statuses
     return course_metadata
+
+
+def get_course_run_by_uuid(course, course_run_uuid):
+    """
+    Find a course_run based on uuid
+
+    Arguments:
+        course (dict): course dict
+        course_run_uuid (str): uuid to lookup
+
+    Returns:
+        dict: a course_run or None
+    """
+    try:
+        course_run = [
+            run for run in course.get('course_runs', [])
+            if run.get('uuid') == course_run_uuid
+        ][0]
+    except IndexError:
+        return None
+    return course_run
+
+
+def is_course_run_active(course_run):
+    """
+    Checks whether a course run is active. That is, whether the course run is published,
+    enrollable, and marketable.
+
+    Arguments:
+        course_run (dict): The metadata about a course run.
+
+    Returns:
+        bool: True if course run is "active"
+    """
+    course_run_status = course_run.get('status') or ''
+    is_published = course_run_status.lower() == 'published'
+    is_enrollable = course_run.get('is_enrollable', False)
+    is_marketable = course_run.get('is_marketable', False)
+
+    return is_published and is_enrollable and is_marketable
+
+
+def get_course_first_paid_enrollable_seat_price(course):
+    """
+    Arguments:
+        course (dict): a dictionary representing a course
+
+    Returns:
+        The first enrollable paid seat price for the course.
+    """
+    # Use advertised course run.
+    # If that fails use one of the other active course runs.
+    # (The latter is what Discovery does)
+    advertised_course_run = get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
+    if advertised_course_run and advertised_course_run.get('first_enrollable_paid_seat_price'):
+        return advertised_course_run.get('first_enrollable_paid_seat_price')
+
+    course_runs = course.get('course_runs') or []
+    active_course_runs = [run for run in course_runs if is_course_run_active(run)]
+    for course_run in sorted(
+        active_course_runs,
+        key=lambda active_course_run: active_course_run['key'].lower(),
+    ):
+        if 'first_enrollable_paid_seat_price' in course_run:
+            return course_run['first_enrollable_paid_seat_price']
+    return None
+
+
+def find_restricted_course_runs(course_json_metadata):
+    """
+    Filter to find and enumerate any restricted runs present in a dictionary
+    of course JSON metadata.
+    """
+    found_restricted_runs = []
+    for course_run in course_json_metadata.get('course_runs', []):
+        if course_run.get(COURSE_RUN_RESTRICTION_TYPE_KEY):
+            found_restricted_runs.append(course_run)
+    return found_restricted_runs
+
+
+def remove_restricted_course_runs(course_json_metadata):
+    """
+    Prevents restricted runs from being written to ContentMetadata.json_metadata before saving.
+    This includes removing the run from all run-based json keys:
+    * ContentMetadata.json_metadata["course_runs"]
+    * ContentMetadata.json_metadata["course_run_keys"]
+    * ContentMetadata.json_metadata["course_run_statuses"]
+
+    It also updates the `first_enrollable_paid_seat_price` of the course after restricted runs
+    are removed.
+    """
+    found_restricted_runs = find_restricted_course_runs(course_json_metadata)
+    if not found_restricted_runs:
+        return
+
+    restricted_keys = {run['key'] for run in found_restricted_runs}
+    LOGGER.info(
+        '[restricted runs] Course %s has restricted runs %s that will be removed.',
+        course_json_metadata['key'],
+        restricted_keys,
+    )
+
+    non_restricted_keys = []
+    non_restricted_runs = []
+    non_restricted_statuses = set()
+
+    for course_run in course_json_metadata['course_runs']:
+        if course_run['key'] not in restricted_keys:
+            non_restricted_keys.append(course_run['key'])
+            non_restricted_runs.append(course_run)
+            non_restricted_statuses.add(course_run['status'])
+
+    course_json_metadata['course_runs'] = non_restricted_runs
+    course_json_metadata['course_run_keys'] = non_restricted_keys
+    course_json_metadata['course_run_statuses'] = sorted(list(non_restricted_statuses))
+
+    # also recompute the first enrollable paid seat price for the course
+    # now that we've removed any restricted runs
+    course_json_metadata['first_enrollable_paid_seat_price'] = get_course_first_paid_enrollable_seat_price(
+        course_json_metadata,
+    )

--- a/enterprise_catalog/apps/catalog/serializers.py
+++ b/enterprise_catalog/apps/catalog/serializers.py
@@ -10,7 +10,9 @@ from rest_framework import serializers
 
 from enterprise_catalog.apps.api.constants import CourseMode
 from enterprise_catalog.apps.catalog.constants import EXEC_ED_2U_COURSE_TYPE
-from enterprise_catalog.apps.catalog.utils import get_course_run_by_uuid
+from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    get_course_run_by_uuid,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/enterprise_catalog/apps/catalog/tests/test_content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_content_metadata_utils.py
@@ -2,9 +2,14 @@ from uuid import uuid4
 
 from django.test import TestCase
 
+from enterprise_catalog.apps.catalog.constants import (
+    COURSE_RUN_RESTRICTION_TYPE_KEY,
+)
 from enterprise_catalog.apps.catalog.content_metadata_utils import (
-    tansform_force_included_courses,
+    find_restricted_course_runs,
+    remove_restricted_course_runs,
     transform_course_metadata_to_visible,
+    transform_force_included_courses,
 )
 
 
@@ -33,7 +38,7 @@ class ContentMetadataUtilsTests(TestCase):
         assert content_metadata['course_runs'][0]['availability'] == 'Current'
         assert content_metadata['course_run_statuses'][0] == 'published'
 
-    def test_tansform_force_included_courses(self):
+    def test_transform_force_included_courses(self):
         advertised_course_run_uuid = str(uuid4())
         content_metadata = {
             'advertised_course_run_uuid': advertised_course_run_uuid,
@@ -49,5 +54,141 @@ class ContentMetadataUtilsTests(TestCase):
             ]
         }
         courses = [content_metadata]
-        tansform_force_included_courses(courses)
+        transform_force_included_courses(courses)
         assert courses[0]['course_runs'][0]['status'] == 'published'
+
+    def test_find_restricted_runs(self):
+        course_metadata = {
+            'course_runs': [
+                {
+                    'key': 'the-normal-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                },
+                {
+                    'key': 'the-restricted-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: 'custom-b2b-enterprise',
+                },
+                {
+                    'key': 'the-other-restricted-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: 'another-restriction-type',
+                },
+                {
+                    'key': 'another-normal-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: None,
+                },
+            ]
+        }
+
+        actual_restricted_runs = find_restricted_course_runs(course_metadata)
+
+        expected_restricted_runs = [
+            course_metadata['course_runs'][1], course_metadata['course_runs'][2],
+        ]
+        self.assertEqual(actual_restricted_runs, expected_restricted_runs)
+
+    def test_find_restricted_runs_none_exist(self):
+        course_metadata = {
+            'course_runs': [
+                {
+                    'key': 'the-normal-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                },
+                {
+                    'key': 'another-normal-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: None,
+                },
+            ]
+        }
+
+        actual_restricted_runs = find_restricted_course_runs(course_metadata)
+
+        self.assertEqual(actual_restricted_runs, [])
+
+    def test_remove_restricted_runs(self):
+        course_metadata = {
+            'key': 'the-course-key',
+            'advertised_course_run_uuid': 'advertised-run-uuid',
+            'first_enrollable_paid_seat_price': 222,
+            'course_run_statuses': ['published', 'unpublished'],
+            'course_run_keys': [
+                'the-normal-run',
+                'the-restricted-run',
+                'the-other-restricted-run',
+                'another-normal-run',
+            ],
+            'course_runs': [
+                {
+                    'key': 'the-normal-run',
+                    'uuid': 'advertised-run-uuid',
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'first_enrollable_paid_seat_price': 350,
+                },
+                {
+                    'key': 'the-restricted-run',
+                    'uuid': uuid4(),
+                    'status': 'published',
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: 'custom-b2b-enterprise',
+                    'first_enrollable_paid_seat_price': 222,
+                },
+                {
+                    'key': 'the-other-restricted-run',
+                    'uuid': uuid4(),
+                    'status': 'unpublished',
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: 'another-restriction-type',
+                },
+                {
+                    'key': 'another-normal-run',
+                    'uuid': 'another-uuid',
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'first_enrollable_paid_seat_price': 0,
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: None,
+                },
+            ]
+        }
+
+        remove_restricted_course_runs(course_metadata)
+
+        expected_transformation = {
+            'key': 'the-course-key',
+            'advertised_course_run_uuid': 'advertised-run-uuid',
+            'first_enrollable_paid_seat_price': 350,
+            'course_run_statuses': ['published'],
+            'course_run_keys': [
+                'the-normal-run',
+                'another-normal-run',
+            ],
+            'course_runs': [
+                {
+                    'key': 'the-normal-run',
+                    'uuid': 'advertised-run-uuid',
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'first_enrollable_paid_seat_price': 350,
+                },
+                {
+                    'key': 'another-normal-run',
+                    'uuid': 'another-uuid',
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'first_enrollable_paid_seat_price': 0,
+                    COURSE_RUN_RESTRICTION_TYPE_KEY: None,
+                },
+            ]
+        }
+        self.assertEqual(expected_transformation, course_metadata)

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -158,21 +158,3 @@ def to_timestamp(datetime_str):
     except (ValueError, TypeError) as exc:
         LOGGER.error(f"[to_timestamp][{exc}] Could not parse date string: {datetime_str}")
         return None
-
-
-def get_course_run_by_uuid(course, course_run_uuid):
-    """
-    Find a course_run based on uuid
-
-    Arguments:
-        course (dict): course dict
-        course_run_uuid (str): uuid to lookup
-
-    Returns:
-        dict: a course_run or None
-    """
-    try:
-        course_run = [run for run in course.get('course_runs', []) if run.get('uuid') == course_run_uuid][0]
-    except IndexError:
-        return None
-    return course_run

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -419,6 +419,10 @@ COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL = os.environ.get(
     DEFAULT_COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL,
 )
 
+# Whether to fetch restricted course runs from the course-discovery
+# /api/v1/courses endpoint
+SHOULD_FETCH_RESTRICTED_COURSE_RUNS = False
+
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     # The enterprise catalog admin role is for users who need to perform state altering requests on catalogs


### PR DESCRIPTION
* When enabled, fetches restricted b2b runs during syncing of full course metadata from discovery.
* Subsequently prevents restricted runs from being written to ContentMetadata.json_metadata before saving.
* In a future PR, we'll make use of the pruned restricted runs on a per-customer-catalog fashion.

## Local Testing
### Set up a restricted course run locally
It'll be associated with DemoX: https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/1317306375/Setting+up+restricted+runs+locally
### Enable the setting
In your `private.py` settings file, set `SHOULD_FETCH_RESTRICTED_COURSE_RUNS = True`
### Sync full course metadata
1. `make worker-restart worker-logs`
2. In a different shell, do `make app-shell` and then `./manage.py update_full_content_metadata --force`
3. Observe in the worker logs a line like `[restricted runs] Course edX+DemoX has restricted runs {'course-v1:edX+DemoX+restricted_run'} that will be removed.`
### Verify non-presence of restricted run in API
Fetch content metadata for the DemoX course in enterprise-catalog, i.e.
```
curl --location 'http://localhost:18160/api/v1/enterprise-catalogs/7467c9d2-433c-4f7e-ba2e-c5c7798527b2/get_content_metadata/?content_keys=edX%2BDemoX&traverse_pagination=True' \
--header 'Authorization: JWT [your jwt]' \
```
Observe that the restricted run is not included in the payload.

ENT-9404
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
