### PR TITLE
feat: expand `get_content_metadata` REST API to support course run keys

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1394,7 +1394,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
         self.assertEqual(response.json()['results'], [])
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
-    def test_get_content_metadata_content_filters_course_run_Key(self, mock_api_client):
+    def test_get_content_metadata_content_filters_course_run_key(self, mock_api_client):
         """
         Test that the get_content_metadata view GET view will support a filter including
         course run key(s), even when the catalog itself doesn't explictly contain course runs.

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -52,7 +52,7 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         queryset = self.enterprise_catalog.content_metadata
         content_filter = kwargs.get('content_keys_filter')
         if content_filter:
-            queryset = queryset.filter(content_key__in=content_filter)
+            queryset = self.enterprise_catalog.get_matching_content(content_keys=content_filter)
 
         return queryset.order_by('catalog_queries')
 

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -135,6 +135,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'owners': owners,
                 'advertised_course_run_uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
                 'course_runs': course_runs,
+                'course': self.content_key,
             })
         elif self.content_type == COURSE_RUN:
             json_metadata.update({


### PR DESCRIPTION
When a catalog containing only courses is used with `get_content_metadata`, passing _course run_ keys to its `?content_keys` filter, the API will return the associated top-level course records instead of an empty result set.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
