### PR TITLE
feat: include `content_price` in Algolia indexed `course_runs` for course objects

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -291,7 +291,7 @@ def _update_full_content_metadata_course(content_keys, dry_run=False):
             # Perform more steps to normalize and move keys around
             # for more consistency across content types.
             normalized_metadata_input = {
-                'course': metadata_record,
+                'course_metadata': metadata_record.json_metadata,
             }
             metadata_record.json_metadata['normalized_metadata'] =\
                 NormalizedContentMetadataSerializer(normalized_metadata_input).data
@@ -299,8 +299,8 @@ def _update_full_content_metadata_course(content_keys, dry_run=False):
             for run in metadata_record.json_metadata.get('course_runs', []):
                 metadata_record.json_metadata['normalized_metadata_by_run'].update({
                     run['key']: NormalizedContentMetadataSerializer({
+                        'course_metadata': metadata_record.json_metadata,
                         'course_run_metadata': run,
-                        'course': metadata_record,
                     }).data
                 })
 

--- a/enterprise_catalog/apps/catalog/tests/test_serializers.py
+++ b/enterprise_catalog/apps/catalog/tests/test_serializers.py
@@ -27,7 +27,7 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         course_content.json_metadata['advertised_course_run_uuid'] = None
 
         normalized_metadata_input = {
-            'course': course_content,
+            'course_metadata': course_content.json_metadata,
         }
         serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
@@ -52,7 +52,7 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         course_content.json_metadata['advertised_course_run_uuid'] = 'the-course-run-uuid'
 
         normalized_metadata_input = {
-            'course': course_content,
+            'course_metadata': course_content.json_metadata,
         }
         if has_course_run:
             normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
@@ -78,7 +78,7 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         ]
         course_content.json_metadata['advertised_course_run_uuid'] = 'the-course-run-uuid'
         normalized_metadata_input = {
-            'course': course_content,
+            'course_metadata': course_content.json_metadata,
         }
         if has_course_run:
             normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
@@ -114,7 +114,7 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         ]
 
         normalized_metadata_input = {
-            'course': course_content,
+            'course_metadata': course_content.json_metadata,
         }
         if has_course_run:
             normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]
@@ -139,7 +139,7 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         course_content.json_metadata['course_runs'][0]['enrollment_end'] = actual_deadline
 
         normalized_metadata_input = {
-            'course': course_content,
+            'course_metadata': course_content.json_metadata,
         }
         if has_course_run:
             normalized_metadata_input['course_run_metadata'] = course_content.json_metadata['course_runs'][0]

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -142,12 +142,11 @@ def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000):
 
 def to_timestamp(datetime_str):
     """
-    Takes a formatted date string to
-    convert it to an epoch timestamp.
+    Takes a formatted date string to convert it to an unix/epoch timestamp.
 
     Ex. to_timestamp("2024-07-30T00:00:00Z") -> 1722297600.0
 
-    The decimal represents a timestamp epoch time down to the millisecond
+    The decimal represents a timestamp epoch time down to the millisecond.
 
     This is useful if we need to pass epoch time to an indexable Algolia value
     which requires it to be in epoch format in order for the indexed field to be
@@ -155,8 +154,25 @@ def to_timestamp(datetime_str):
     """
     try:
         dt = datetime.fromisoformat(datetime_str)
-        epoch_time = dt.timestamp()
-        return epoch_time
-    except (ValueError, TypeError) as error:
-        LOGGER.error(f"[to_timestamp][{error}] Could not parse date string: {datetime_str}")
+        return dt.timestamp()
+    except (ValueError, TypeError) as exc:
+        LOGGER.error(f"[to_timestamp][{exc}] Could not parse date string: {datetime_str}")
         return None
+
+
+def get_course_run_by_uuid(course, course_run_uuid):
+    """
+    Find a course_run based on uuid
+
+    Arguments:
+        course (dict): course dict
+        course_run_uuid (str): uuid to lookup
+
+    Returns:
+        dict: a course_run or None
+    """
+    try:
+        course_run = [run for run in course.get('course_runs', []) if run.get('uuid') == course_run_uuid][0]
+    except IndexError:
+        return None
+    return course_run


### PR DESCRIPTION
[ENT-9504](https://2u-internal.atlassian.net/browse/ENT-9504)

* Ensures the `course_runs` list indexed in Algolia course objects contains `content_price`.
* Refactors to pull `enroll_by` for the indexed `course_runs` from `NormalizedContentMetadataSerializer` vs. largely replicating the same logic in multiple places (DRY).

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
