### PR TITLE
fix: changing number of highlight sets

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -48,7 +48,7 @@ from enterprise_catalog.apps.curation.models import (
 
 REQUEST_CACHE_NAMESPACE = 'CURATION_REQUEST_CACHE'
 CONTENT_PER_HIGHLIGHTSET_LIMIT = 24
-HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = 12
+HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = 16
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Changing the maximum number of highlights allowed
Associated PRs in [frontend-app-admin-portal](https://github.com/openedx/frontend-app-admin-portal/pull/1306) and frontend-app-learner-portal
[Jira ticket](https://2u-internal.atlassian.net/browse/ENT-9493)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
