### PR TITLE
fix: Removed json prefix from GPT response

### DIFF
--- a/enterprise_catalog/apps/ai_curation/openai_client.py
+++ b/enterprise_catalog/apps/ai_curation/openai_client.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import re
 
 import backoff
 import requests
@@ -83,6 +84,7 @@ def chat_completions(
     LOGGER.info('[AI_CURATION] [CHAT_COMPLETIONS] Response: [%s]', response.json())
     try:
         response_content = response.json().get('content')
+        response_content = re.sub(r'```json\n?|```', '', response_content)
         if response_format == 'json':
             return json.loads(response_content)
         return response_content


### PR DESCRIPTION
**Description**: This PR removes the ```json prefix from the GPT response. This was triggering json` loads` errors.

**JIRA**: [ENT-9495](https://2u-internal.atlassian.net/browse/ENT-9495)

**Previous response:** 
`Response: [{'role': 'assistant', 'content': '```json\n["Business & Management", "Philanthropy", "Social Sciences"]\n```'}]
`
**Modified response:**
`Response: [{'role': 'assistant', 'content': '["Business & Management", "Philanthropy", "Social Sciences"]\n'}]
`
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
