### PR TITLE
feat: Source price from content_price for fixed_price_usd in CatalogWorkbookView

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -58,6 +58,7 @@ CSV_COURSE_RUN_HEADERS = [
     'End Date',
     'Verified Upgrade Deadline',
     'Enroll-by Date',
+    'Price',
     'Min Effort',
     'Max Effort',
     'Length',
@@ -200,12 +201,16 @@ def _base_csv_row_data(hit):
     if enroll_by := advertised_course_run.get('enroll_by'):
         enroll_by = datetime.datetime.fromtimestamp(enroll_by).strftime(DATE_FORMAT)
 
+    if content_price := advertised_course_run.get('content_price'):
+        content_price = math.trunc(float(content_price))
+
     return {
         'title': title,
         'partner_name': partner_name,
         'start_date': start_date,
         'end_date': end_date,
         'enroll_by': enroll_by,
+        'price': content_price,
         'aggregation_key': aggregation_key,
         'course_run_key': course_run_key,
         'language': language,
@@ -248,7 +253,7 @@ def course_hit_to_row(hit):
     csv_row.append(pacing_type)
 
     csv_row.append(hit.get('level_type'))
-    csv_row.append(hit.get('first_enrollable_paid_seat_price'))
+    csv_row.append(row_data.get('price'))
     csv_row.append(row_data.get('language'))
     csv_row.append(row_data.get('transcript_languages'))
     csv_row.append(row_data.get('marketing_url'))
@@ -276,15 +281,13 @@ def exec_ed_course_to_row(hit):
     """
     row_data = _base_csv_row_data(hit)
     csv_row = []
+
     csv_row.append(row_data.get('title'))
     csv_row.append(row_data.get('partners'))
-
     csv_row.append(row_data.get('start_date'))
     csv_row.append(row_data.get('end_date'))
     csv_row.append(row_data.get('enroll_by'))
-
-    price = float(hit['entitlements'][0]['price'])
-    csv_row.append(math.trunc(price))
+    csv_row.append(row_data.get('price'))
     csv_row.append(row_data.get('language'))
     csv_row.append(row_data.get('transcript_languages'))
     csv_row.append(row_data.get('marketing_url'))
@@ -348,6 +351,9 @@ def course_run_to_row(hit, course_run):
     if enroll_by := course_run.get('enroll_by', None):
         enroll_by = datetime.datetime.fromtimestamp(enroll_by).strftime(DATE_FORMAT)
     csv_row.append(enroll_by)
+
+    # Price
+    csv_row.append(course_run.get('content_price'))
 
     # Min Effort
     csv_row.append(course_run.get('min_effort'))

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -731,6 +731,7 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
             'max_effort': 10,
             'min_effort': 1,
             'weeks_to_complete': 1,
+            'content_price': 100,
         },
         'outcome': '<p>learn</p>',
         'prerequisites_raw': '<p>interest</p>',
@@ -777,8 +778,8 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
     def _get_mock_algolia_hits_with_missing_values(self):
         mock_hits_missing_values = copy.deepcopy(self.mock_algolia_hits)
         mock_hits_missing_values['hits'][0]['advertised_course_run'].pop('upgrade_deadline')
+        mock_hits_missing_values['hits'][0]['advertised_course_run'].pop('content_price')
         mock_hits_missing_values['hits'][0].pop('marketing_url')
-        mock_hits_missing_values['hits'][0].pop('first_enrollable_paid_seat_price')
         mock_hits_missing_values['hits'][0]['advertised_course_run']['end'] = None
         return mock_hits_missing_values
 


### PR DESCRIPTION
Updates the CatalogWorkbookView CSV generator to source price from the `content_price` field. The `content_price` for course runs are populated by the `NormalizedContentMetadataSerializer` which standardizes the fields which determine a course price, agnostic of course type (Exec-ed vs OCM).

This was done in support of `fixed_price_usd` which is expected to be included in the `NormalizedContentMetadataSerializer`

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
