### PR TITLE
feat: Source price from content_price for fixed_price_usd in CatalogWorkbookView

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -58,6 +58,7 @@ CSV_COURSE_RUN_HEADERS = [
     'End Date',
     'Verified Upgrade Deadline',
     'Enroll-by Date',
+    'Price',
     'Min Effort',
     'Max Effort',
     'Length',
@@ -210,7 +211,10 @@ def course_hit_to_row(hit):
 
     csv_row.append(hit.get('level_type'))
 
-    csv_row.append(hit.get('first_enrollable_paid_seat_price'))
+    if content_price := advertised_course_run.get('content_price'):
+        content_price = math.trunc(float(content_price))
+    csv_row.append(content_price)
+
     csv_row.append(hit.get('language'))
     csv_row.append(', '.join(hit.get('transcript_languages', [])))
     csv_row.append(hit.get('marketing_url'))
@@ -283,8 +287,12 @@ def exec_ed_course_to_row(hit):
     adv_course_run = hit.get('advertised_course_run', {})
     key = adv_course_run.get('key')
 
-    price = float(hit['entitlements'][0]['price'])
-    csv_row.append(math.trunc(price))
+    empty_advertised_course_run = {}
+    advertised_course_run = hit.get('advertised_course_run', empty_advertised_course_run)
+    if content_price := advertised_course_run.get('content_price'):
+        content_price = math.trunc(float(content_price))
+    csv_row.append(content_price)
+
     csv_row.append(hit.get('language'))
     csv_row.append(', '.join(hit.get('transcript_languages', [])))
     csv_row.append(hit.get('marketing_url'))
@@ -354,6 +362,10 @@ def course_run_to_row(hit, course_run):
     if enroll_by := course_run.get('enroll_by', None):
         enroll_by = datetime.datetime.fromtimestamp(enroll_by).strftime(DATE_FORMAT)
     csv_row.append(enroll_by)
+
+    if content_price := course_run.get('content_price'):
+        content_price = math.trunc(float(content_price))
+    csv_row.append(content_price)
 
     # Min Effort
     csv_row.append(course_run.get('min_effort'))

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -731,6 +731,7 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
             'max_effort': 10,
             'min_effort': 1,
             'weeks_to_complete': 1,
+            'content_price': 100,
         },
         'outcome': '<p>learn</p>',
         'prerequisites_raw': '<p>interest</p>',
@@ -777,8 +778,8 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
     def _get_mock_algolia_hits_with_missing_values(self):
         mock_hits_missing_values = copy.deepcopy(self.mock_algolia_hits)
         mock_hits_missing_values['hits'][0]['advertised_course_run'].pop('upgrade_deadline')
+        mock_hits_missing_values['hits'][0]['advertised_course_run'].pop('content_price')
         mock_hits_missing_values['hits'][0].pop('marketing_url')
-        mock_hits_missing_values['hits'][0].pop('first_enrollable_paid_seat_price')
         mock_hits_missing_values['hits'][0]['advertised_course_run']['end'] = None
         return mock_hits_missing_values
 


### PR DESCRIPTION
Updates the CatalogWorkbookView CSV generator to source price from the `content_price` field. The `content_price` for course runs are populated by the `NormalizedContentMetadataSerializer` which standardizes the fields which determine a course price, agnostic of course type (Exec-ed vs OCM).

This was done in support of `fixed_price_usd` which is expected to be included in the `NormalizedContentMetadataSerializer`

This PR is a redo of https://github.com/openedx/enterprise-catalog/pull/954 since major components in the original PR were reverted.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
