### PR TITLE
[ENT-9472] Created a new API that will expose the enterprise-jobs relationship

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -31,6 +31,7 @@ from enterprise_catalog.apps.curation.models import (
     HighlightedContent,
     HighlightSet,
 )
+from enterprise_catalog.apps.jobs.models import Job
 from enterprise_catalog.apps.video_catalog.models import Video, VideoSkill
 
 
@@ -510,3 +511,17 @@ class VideoSerializer(serializers.ModelSerializer):
             'json_metadata', 'summary_transcripts', 'parent_content_metadata', 'skills',
         ]
         lookup_field = 'edx_video_id'
+
+
+class JobSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `Job` model.
+    """
+
+    class Meta:
+        model = Job
+        fields = [
+            "job_id",
+            "external_id",
+            "title"
+        ]

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -50,6 +50,9 @@ from enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_d
 from enterprise_catalog.apps.api.v1.views.enterprise_customer import (
     EnterpriseCustomerViewSet,
 )
+from enterprise_catalog.apps.api.v1.views.enterprise_jobs import (
+    EnterpriseJobReadOnlyViewSet,
+)
 from enterprise_catalog.apps.api.v1.views.video_catalog import (
     VideoReadOnlyViewSet,
 )
@@ -127,6 +130,11 @@ urlpatterns = [
         'catalog-queries/get_content_filter_hash',
         CatalogQueryViewSet.as_view({'get': 'get_content_filter_hash'}),
         name='get-content-filter-hash'
+    ),
+    re_path(
+        r"^enterprise-jobs/(?P<enterprise_uuid>[-\w]+)$",
+        EnterpriseJobReadOnlyViewSet.as_view({"get": "list"}),
+        name="enterprise-jobs",
     ),
 ]
 

--- a/enterprise_catalog/apps/api/v1/views/enterprise_jobs.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_jobs.py
@@ -1,0 +1,29 @@
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
+from rest_framework import permissions, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.renderers import JSONRenderer
+from rest_framework_xml.renderers import XMLRenderer
+
+from enterprise_catalog.apps.api.v1.serializers import JobSerializer
+from enterprise_catalog.apps.jobs.models import Job
+
+
+class EnterpriseJobReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    A viewset for retrieving all the jobs for a given enterprise.
+    """
+
+    authentication_classes = [JwtAuthentication, SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+    renderer_classes = [JSONRenderer, XMLRenderer]
+    serializer_class = JobSerializer
+    lookup_field = "enterprise_uuid"
+
+    def get_queryset(self):
+        """
+        Returns a list of all the jobs associated with the given enterprise UUID.
+        """
+        enterprise_uuid = self.kwargs.get("enterprise_uuid")
+        return Job.objects.filter(enterprises__enterprise_uuid=enterprise_uuid)

--- a/enterprise_catalog/apps/jobs/tests/factories.py
+++ b/enterprise_catalog/apps/jobs/tests/factories.py
@@ -13,6 +13,7 @@ class JobFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Job
 
+    job_id = FuzzyInteger(0, 100)
     title = FuzzyText(length=32)
     description = FuzzyText(length=255)
 
@@ -25,6 +26,7 @@ class JobEnterpriseFactory(factory.django.DjangoModelFactory):
         model = JobEnterprise
 
     enterprise_uuid = factory.LazyFunction(uuid4)
+    job = factory.SubFactory(JobFactory)
 
 
 class JobSkillFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
**Ticket**
https://2u-internal.atlassian.net/browse/ENT-9472

**Description**
This PR creates a new API that will take the `enterprise_uuid` as input and return all associated jobs as a JSON response.

**Endpoint & Response**

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/5804eb81-ecfc-4e34-b02c-867c02391fd2">



## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
