### PR TITLE
fix: disable fixed price logic

### DIFF
--- a/enterprise_catalog/apps/catalog/serializers.py
+++ b/enterprise_catalog/apps/catalog/serializers.py
@@ -147,8 +147,9 @@ class NormalizedContentMetadataSerializer(ReadOnlySerializer):
     def get_content_price(self, obj) -> float:  # pylint: disable=unused-argument
         if not self.course_run_metadata:
             return None
-        if self.course_run_metadata.get('fixed_price_usd'):
-            return float(self.course_run_metadata.get('fixed_price_usd'))
+        # To be uncommented out after fix forward
+        # if self.course_run_metadata.get('fixed_price_usd'):
+        #     return float(self.course_run_metadata.get('fixed_price_usd'))
         if self.is_exec_ed_2u_course is True:
             for entitlement in self.course_metadata.get('entitlements', []):
                 if entitlement.get('price') and entitlement.get('mode') == CourseMode.PAID_EXECUTIVE_EDUCATION:

--- a/enterprise_catalog/apps/catalog/tests/test_serializers.py
+++ b/enterprise_catalog/apps/catalog/tests/test_serializers.py
@@ -12,7 +12,6 @@ from enterprise_catalog.apps.catalog.serializers import (
     NormalizedContentMetadataSerializer,
 )
 from enterprise_catalog.apps.catalog.tests import factories
-from enterprise_catalog.apps.catalog.utils import get_course_run_by_uuid
 
 
 @ddt.ddt
@@ -152,88 +151,89 @@ class NormalizedContentMetadataSerializerTests(TestCase):
 
         self.assertEqual(serialized_data['enroll_by_date'], actual_deadline)
 
-    @ddt.data(
-        # First enrollable paid seat price
-        {
-            'first_enrollable_paid_seat_price': 50,
-            'fixed_price_usd': None,
-            'entitlements': [],
-            'course_type': 'verified-audit',
-            'expected_content_price': 50.0,
-        },
-        # First enrollable paid seat default normalized price
-        {
-            'first_enrollable_paid_seat_price': None,
-            'fixed_price_usd': None,
-            'entitlements': [],
-            'course_type': 'verified-audit',
-            'expected_content_price': 0.0,
-        },
-        # Fixed price usd
-        {
-            'first_enrollable_paid_seat_price': 50,
-            'fixed_price_usd': "100.00",
-            'entitlements': [],
-            'course_type': 'verified-audit',
-            'expected_content_price': 100.0,
-        },
-        # entitlements
-        {
-            'first_enrollable_paid_seat_price': None,
-            'fixed_price_usd': None,
-            'entitlements': [
-                {
-                    "mode": "paid-executive-education",
-                    "price": "200.00",
-                    "currency": "USD",
-                    "sku": "1234",
-                    "expires": None
-                }
-            ],
-            'course_type': 'executive-education-2u',
-            'expected_content_price': 200.0,
-        },
-        # entitlements default normalized price
-        {
-            'first_enrollable_paid_seat_price': None,
-            'fixed_price_usd': None,
-            'entitlements': [
-                {
-                    "mode": "paid-executive-education",
-                    "price": None,
-                    "currency": "USD",
-                    "sku": "1234",
-                    "expires": None
-                }
-            ],
-            'course_type': 'executive-education-2u',
-            'expected_content_price': 0,
-        }
-    )
-    @ddt.unpack
-    def test_content_price(self,
-                           first_enrollable_paid_seat_price,
-                           fixed_price_usd,
-                           entitlements,
-                           course_type,
-                           expected_content_price,
-                           ):
-        course_content = factories.ContentMetadataFactory(
-            content_type=COURSE,
-        )
-        course_content.json_metadata['entitlements'] = entitlements
-        course_content.json_metadata['course_type'] = course_type
+    # Uncomment out once fix forward complete
+    # @ddt.data(
+    #     # First enrollable paid seat price
+    #     {
+    #         'first_enrollable_paid_seat_price': 50,
+    #         'fixed_price_usd': None,
+    #         'entitlements': [],
+    #         'course_type': 'verified-audit',
+    #         'expected_content_price': 50.0,
+    #     },
+    #     # First enrollable paid seat default normalized price
+    #     {
+    #         'first_enrollable_paid_seat_price': None,
+    #         'fixed_price_usd': None,
+    #         'entitlements': [],
+    #         'course_type': 'verified-audit',
+    #         'expected_content_price': 0.0,
+    #     },
+    #     # Fixed price usd
+    #     {
+    #         'first_enrollable_paid_seat_price': 50,
+    #         'fixed_price_usd': "100.00",
+    #         'entitlements': [],
+    #         'course_type': 'verified-audit',
+    #         'expected_content_price': 100.0,
+    #     },
+    #     # entitlements
+    #     {
+    #         'first_enrollable_paid_seat_price': None,
+    #         'fixed_price_usd': None,
+    #         'entitlements': [
+    #             {
+    #                 "mode": "paid-executive-education",
+    #                 "price": "200.00",
+    #                 "currency": "USD",
+    #                 "sku": "1234",
+    #                 "expires": None
+    #             }
+    #         ],
+    #         'course_type': 'executive-education-2u',
+    #         'expected_content_price': 200.0,
+    #     },
+    #     # entitlements default normalized price
+    #     {
+    #         'first_enrollable_paid_seat_price': None,
+    #         'fixed_price_usd': None,
+    #         'entitlements': [
+    #             {
+    #                 "mode": "paid-executive-education",
+    #                 "price": None,
+    #                 "currency": "USD",
+    #                 "sku": "1234",
+    #                 "expires": None
+    #             }
+    #         ],
+    #         'course_type': 'executive-education-2u',
+    #         'expected_content_price': 0,
+    #     }
+    # )
+    # @ddt.unpack
+    # def test_content_price(self,
+    #                        first_enrollable_paid_seat_price,
+    #                        fixed_price_usd,
+    #                        entitlements,
+    #                        course_type,
+    #                        expected_content_price,
+    #                        ):
+    #     course_content = factories.ContentMetadataFactory(
+    #         content_type=COURSE,
+    #     )
+    #     course_content.json_metadata['entitlements'] = entitlements
+    #     course_content.json_metadata['course_type'] = course_type
 
-        advertised_course_run_uuid = course_content.json_metadata['advertised_course_run_uuid']
-        advertised_course_run = get_course_run_by_uuid(course_content.json_metadata, advertised_course_run_uuid)
-        advertised_course_run['fixed_price_usd'] = fixed_price_usd
-        advertised_course_run['first_enrollable_paid_seat_price'] = first_enrollable_paid_seat_price
+    #     advertised_course_run_uuid = course_content.json_metadata['advertised_course_run_uuid']
+    #     advertised_course_run = get_course_run_by_uuid(course_content.json_metadata, advertised_course_run_uuid)
+    #     advertised_course_run['fixed_price_usd'] = fixed_price_usd
+    #     advertised_course_run['first_enrollable_paid_seat_price'] = first_enrollable_paid_seat_price
 
-        normalized_metadata_input = {
-            'course_metadata': course_content.json_metadata,
-            'course_run_metadata': course_content.json_metadata['course_runs'][0]
-        }
+    #     normalized_metadata_input = {
+    #         'course_metadata': course_content.json_metadata,
+    #         'course_run_metadata': course_content.json_metadata['course_runs'][0]
+    #     }
 
-        serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
+    #     serialized_data = NormalizedContentMetadataSerializer(normalized_metadata_input).data
 
-        self.assertEqual(serialized_data['content_price'], expected_content_price)
+    #     self.assertEqual(serialized_data['content_price'], expected_content_price)


### PR DESCRIPTION
Comments out fixed_price_usd related logic and test as a fix forward to prevent the logic being used against production catalog jobs (update-content-metadata/reindex-algolia)

Original PR: https://github.com/openedx/enterprise-catalog/pull/931

This will be followed up with a subsequent PR to uncomment out the code to be merged to stage, but pause the prod pipeline.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
