### PR TITLE
feat: include restricted runs in algolia objects

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -424,6 +424,10 @@ COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL = os.environ.get(
 # /api/v1/courses endpoint
 SHOULD_FETCH_RESTRICTED_COURSE_RUNS = False
 
+# Whether to consider restricted runs at all (fetched via
+# SHOULD_FETCH_RESTRICTED_COURSE_RUNS) during algolia indexing.
+SHOULD_INDEX_COURSES_WITH_RESTRICTED_RUNS = False
+
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     # The enterprise catalog admin role is for users who need to perform state altering requests on catalogs


### PR DESCRIPTION
[ENT-9505](https://2u-internal.atlassian.net/browse/ENT-9505)

Important features:
* **Restricted Runs Visible:** The metadata actually used for indexing courses always comes from the "canonical restricted course" object if one exists (i.e. the related RestrictedCourseMetadata that has catalog_query=null).
* **Unicorn Course Support:** A course normally is not indexed at all if it has no advertised course run.  Now we index "empty" courses as long as they contain at least one restricted run (i.e. the canonical restricted variant does have an advertised run).
  * Furthermore, we do NOT associate the course with the standard set of related catalog queries.  Instead we use a subset that represents only the catalog queries that explicitly allow runs in that course.