### PR TITLE
Remove CSRF_TRUSTED_ORIGINS_WITH_SCHEMES variable

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -234,7 +234,6 @@ LANGUAGE_COOKIE_NAME = 'openedx-language-preference'
 
 CSRF_COOKIE_SECURE = False
 CSRF_TRUSTED_ORIGINS = []
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = [] # just for Django 4.2 upgrade
 
 # AUTHENTICATION CONFIGURATION
 LOGIN_URL = '/login/'

--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -72,6 +72,3 @@ CELERY_RESULT_BACKEND = 'django-db'
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
## Description

- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/460
- Since we have upgraded to Django 4.2, we can remove the additional condition and variable.
