### PR TITLE
feat: restricted runs to be considered conditionally active

### DIFF
--- a/enterprise_catalog/apps/catalog/content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/content_metadata_utils.py
@@ -6,7 +6,11 @@ from logging import getLogger
 
 from enterprise_catalog.apps.catalog.utils import get_content_key
 
-from .constants import FORCE_INCLUSION_METADATA_TAG_KEY
+from .constants import (
+    COURSE_RUN_RESTRICTION_TYPE_KEY,
+    FORCE_INCLUSION_METADATA_TAG_KEY,
+    RESTRICTION_FOR_B2B,
+)
 
 
 LOGGER = getLogger(__name__)
@@ -65,7 +69,16 @@ def get_course_run_by_uuid(course, course_run_uuid):
 def is_course_run_active(course_run):
     """
     Checks whether a course run is active. That is, whether the course run is published,
-    enrollable, and marketable.
+    enrollable, and either marketable, or has a b2b restriction type. To ellaborate on the latter:
+
+    Restricted course run records will be set with `is_marketable: false` from the
+    upstream source-of-truth (course-discovery).  But because our discovery <-> catalog
+    synchronization has business logic that filters course run json metadata (inside of courses)
+    to only the *allowed* restricted runs for a catalog, we can safely assume
+    when looking at a course run metadata record in the context of a catalog,
+    if that run has a non-null, B2B restriction type, then it is permitted to be
+    part of the catalog and should be considered active (as long as it is published and enrollable).
+
     Arguments:
         course_run (dict): The metadata about a course run.
     Returns:
@@ -75,8 +88,9 @@ def is_course_run_active(course_run):
     is_published = course_run_status.lower() == 'published'
     is_enrollable = course_run.get('is_enrollable', False)
     is_marketable = course_run.get('is_marketable', False)
+    is_restricted = course_run.get(COURSE_RUN_RESTRICTION_TYPE_KEY) == RESTRICTION_FOR_B2B
 
-    return is_published and is_enrollable and is_marketable
+    return is_published and is_enrollable and (is_marketable or is_restricted)
 
 
 def get_course_first_paid_enrollable_seat_price(course):


### PR DESCRIPTION
Restricted course run records will be set with `is_marketable: false` from the upstream source-of-truth (course-discovery).  But because our discovery <-> catalog synchronization has business logic that filters course run json metadata (inside of courses) to only the *allowed* restricted runs for a catalog, we can safely assume when looking at a course run metadata record in the context of a catalog, if that run has a non-null, B2B restriction type, then it is permitted to be part of the catalog and should be considered active (as long as it is published and enrollable).
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
