### PR TITLE
fix: don't directly tie restricted runs to catalog queries

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -940,8 +940,6 @@ class RestrictedCourseMetadata(BaseContentMetadata):
         # We use a set() here, with clear=True, to clear and then reset the related allowed runs
         # for this restricted course. This is necessary in the case that a previously-allowed
         # run becomes unassociated from the restricted course.
-        self.catalog_query.contentmetadata_set.set(restricted_runs, clear=True)
-        LOGGER.info('Updated restricted runs on catalog query of %s to %s', self, restricted_runs)
         self.restricted_run_allowed_for_restricted_course.set(restricted_runs, clear=True)
         LOGGER.info('Updated restricted runs of %s to %s', self, restricted_runs)
         self.refresh_from_db()

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -1437,6 +1437,18 @@ class TestRestrictedRunsModels(TestCase):
                 'content_key',
             )
         )
+
+        # The catalog_query should not have any content metadata related directly
+        # to it via the "normal" content_metadata M2M relationship.
+        self.assertEqual(catalog_query.contentmetadata_set.all().count(), 0)
+
+        # But the catalog_query should have a direct restricted relationship with
+        # the restricted course.
+        self.assertEqual(
+            list(catalog_query.restricted_content_metadata.all()),
+            [restricted_course],
+        )
+
         self.assertEqual(
             [run.content_key for run in restricted_runs],
             ['course-v1:edX+course+run2', 'course-v1:edX+course+run3'],


### PR DESCRIPTION
I errantly included a direct relationship between restricted course runs and catalog queries when implementing the restricted content synchronization logic. Doing so caused the v2 API content metadata endpoints to return course *run* payloads instead of course payloads, which will break consumers. This change makes it so those direct relationships no longer exist (but the relationship from restricted course run `ContentMetadata` records still related to `RestrictedCourseMetadata` records, which in turn relate directly to a `CatalogQuery`).
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
