### PR TITLE
build: set docker-compose working_dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     image: edxops/enterprise-catalog-dev
     container_name: enterprise.catalog.app
     hostname: app.catalog.enterprise
+    working_dir: /edx/app/enterprise_catalog/enterprise_catalog
     volumes:
       - .:/edx/app/enterprise_catalog/enterprise_catalog
       - ../src:/edx/src:cached
@@ -66,6 +67,7 @@ services:
       DJANGO_SETTINGS_MODULE: enterprise_catalog.settings.devstack
       COLUMNS: 80
     hostname: worker.catalog.enterprise
+    working_dir: /edx/app/enterprise_catalog/enterprise_catalog
     networks:
       - devstack_default
     ports:
@@ -92,6 +94,7 @@ services:
       DJANGO_SETTINGS_MODULE: enterprise_catalog.settings.devstack
       COLUMNS: 80
     hostname: curations.catalog.enterprise
+    working_dir: /edx/app/enterprise_catalog/enterprise_catalog
     networks:
       - devstack_default
     ports:


### PR DESCRIPTION
https://docs.docker.com/reference/compose-file/services/#working_dir
We likely lost the root `WORKDIR` when the Dockerfile was moved.
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
