### PR TITLE
feat: algolia index should be searchable by aggregation_key

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -136,11 +136,14 @@ ALGOLIA_INDEX_SETTINGS = {
     'attributeForDistinct': 'aggregation_key',
     'distinct': True,
     'typoTolerance': False,
+    # unordered(): Ignores the position of the match within the attribute.
+    # From docs: https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/#modifiers
     'searchableAttributes': [
         'unordered(title)',
         'unordered(full_description)',
         'unordered(short_description)',
         'unordered(additional_information)',
+        'aggregation_key',
         'partners',
         'skill_names',
         'skills',


### PR DESCRIPTION
E.g. I should be able to type "OxfordX+LSC" in algolia and see results.