### PR TITLE
[REFERENCE] fix: ensure course run key is passed in legacy enrollment urls

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -57,6 +57,7 @@ from enterprise_catalog.apps.catalog.utils import (
     get_parent_content_key,
     localized_utcnow,
 )
+from enterprise_catalog.apps.catalog.algolia_utils import get_advertised_course_run
 
 
 LOGGER = getLogger(__name__)
@@ -555,10 +556,19 @@ class EnterpriseCatalog(TimeStampedModel):
         else:
             # Catalog param only needed for legacy (non-learner-portal) enrollment URLs
             params['catalog'] = self.uuid
+
+            course_key = content_key if parent_content_key else None
+            course_run_key = content_key if not parent_content_key else None
+
+            if parent_content_key:
+                advertised_course_run = get_advertised_course_run(content_metadata.json_metadata)
+                if advertised_course_run:
+                    course_run_key = advertised_course_run['key']
+
             url = '{}/enterprise/{}/course/{}/enroll/'.format(
                 settings.LMS_BASE_URL,
                 self.enterprise_uuid,
-                content_key,
+                course_run_key or course_key,
             )
 
         return update_query_parameters(url, params)


### PR DESCRIPTION
While further triaging https://2u-internal.atlassian.net/browse/ENT-9770, we raised the question of **_WHY_** learners are seemingly visiting the legacy `enrollment_url` with a top-level _course_ key vs. an explicit _course run_ key.

When this occurs, it seems the `InvalidKeyError` is raised, regardless of the `/enroll` suffix being included in the course identifier passed to `CourseKey.from_string(...)`.

This PR demonstrates a possible fix for what seems like a bug where generating an `enrollment_url` for a `ContentMetadata` record with `content_type="course"` results in the top-level course key being included instead. The proposed fix here would be to resolve the advertised course run key to use in the `enrollment_url` instead of the top-level course key, which should also help mitigate the `InvalidKeyError` error.

In theory, no `InvalidKeyError` errors should be raised from this legacy enrollment view.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
