### PR TITLE
fix: set enrollment url course id to advertised course run key

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -959,6 +959,27 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         test_course.catalog_queries.set(catalog_queries[0:3])
 
         algolia_objects = tasks.get_algolia_objects_from_course_content_metadata(test_course)
+
+        expected_transformed_advertised_course_run = {
+            'key': 'course-v1:edX+DemoX+2T2024',
+            'pacing_type': None,
+            'availability': 'current',
+            'start': '2024-02-12T11:00:00Z',
+            'end': '2026-02-05T11:00:00Z',
+            'min_effort': None,
+            'max_effort': None,
+            'weeks_to_complete': None,
+            'upgrade_deadline': 1769471999.0,
+            'enroll_by': 1769471999.0,
+            'has_enroll_by': True,
+            'enroll_start': None,
+            'has_enroll_start': False,
+            'content_price': 50.0,
+            'is_active': True,
+            'is_late_enrollment_eligible': False,
+            'restriction_type': None
+        }
+
         # Should look something like-
         #  [{'advertised_course_run': {'availability': 'current',
         #                             'end': None,
@@ -1004,6 +1025,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         for algo_object in algolia_objects:
             assert algo_object.get('key') == test_course.content_key
             assert algo_object.get('uuid') == test_course.json_metadata.get('uuid')
+            assert algo_object.get('advertised_course_run') == expected_transformed_advertised_course_run
 
             if object_catalogs := algo_object.get('enterprise_catalog_uuids'):
                 assert set(object_catalogs) == {str(catalog.uuid) for catalog in catalogs}

--- a/enterprise_catalog/apps/catalog/content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/content_metadata_utils.py
@@ -89,7 +89,7 @@ def get_course_first_paid_enrollable_seat_price(course):
     # Use advertised course run.
     # If that fails use one of the other active course runs.
     # (The latter is what Discovery does)
-    advertised_course_run = get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
+    advertised_course_run = get_advertised_course_run(course)
     if advertised_course_run and advertised_course_run.get('first_enrollable_paid_seat_price'):
         return advertised_course_run.get('first_enrollable_paid_seat_price')
 
@@ -102,3 +102,20 @@ def get_course_first_paid_enrollable_seat_price(course):
         if 'first_enrollable_paid_seat_price' in course_run:
             return course_run['first_enrollable_paid_seat_price']
     return None
+
+
+def get_advertised_course_run(course):
+    """
+    Get part of the advertised course_run as per advertised_course_run_uuid
+
+    Argument:
+        course (dict)
+
+    Returns:
+        dict: containing key, pacing_type, start, end, and upgrade deadline
+        for the course_run, or None
+    """
+    full_course_run = get_course_run_by_uuid(course, course.get('advertised_course_run_uuid'))
+    if full_course_run is None:
+        return None
+    return full_course_run

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -45,6 +45,7 @@ from enterprise_catalog.apps.catalog.constants import (
     json_serialized_course_modes,
 )
 from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    get_advertised_course_run,
     get_course_first_paid_enrollable_seat_price,
 )
 from enterprise_catalog.apps.catalog.utils import (
@@ -555,10 +556,15 @@ class EnterpriseCatalog(TimeStampedModel):
         else:
             # Catalog param only needed for legacy (non-learner-portal) enrollment URLs
             params['catalog'] = self.uuid
+
+            course_run_key = content_key
+            if not parent_content_key:
+                if advertised_course_run := get_advertised_course_run(content_metadata.json_metadata):
+                    course_run_key = advertised_course_run['key']
             url = '{}/enterprise/{}/course/{}/enroll/'.format(
                 settings.LMS_BASE_URL,
                 self.enterprise_uuid,
-                content_key,
+                course_run_key,
             )
 
         return update_query_parameters(url, params)

--- a/enterprise_catalog/apps/catalog/serializers.py
+++ b/enterprise_catalog/apps/catalog/serializers.py
@@ -11,7 +11,7 @@ from rest_framework import serializers
 from enterprise_catalog.apps.api.constants import CourseMode
 from enterprise_catalog.apps.catalog.constants import EXEC_ED_2U_COURSE_TYPE
 from enterprise_catalog.apps.catalog.content_metadata_utils import (
-    get_course_run_by_uuid,
+    get_advertised_course_run,
 )
 
 
@@ -113,8 +113,7 @@ class NormalizedContentMetadataSerializer(ReadOnlySerializer):
     def course_run_metadata(self):
         if run_metadata := self.instance.get('course_run_metadata'):
             return run_metadata
-        advertised_course_run_uuid = self.course_metadata.get('advertised_course_run_uuid')
-        return get_course_run_by_uuid(self.course_metadata, advertised_course_run_uuid)
+        return get_advertised_course_run(self.course_metadata)
 
     @extend_schema_field(serializers.DateTimeField)
     def get_start_date(self, obj) -> str:  # pylint: disable=unused-argument

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -99,7 +99,7 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'logo_image_url': fake.image_url() + '.jpg',
             }]
             course_runs = [{
-                'key': 'course-v1:edX+DemoX',
+                'key': 'course-v1:edX+DemoX+2T2024',
                 'uuid': str(FAKE_ADVERTISED_COURSE_RUN_UUID),
                 'content_language': 'en-us',
                 'status': 'published',

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -6,6 +6,7 @@ import ddt
 from django.test import TestCase
 
 from enterprise_catalog.apps.catalog import algolia_utils as utils
+from enterprise_catalog.apps.catalog.algolia_utils import _get_course_run
 from enterprise_catalog.apps.catalog.constants import (
     ALGOLIA_DEFAULT_TIMESTAMP,
     COURSE,
@@ -15,6 +16,9 @@ from enterprise_catalog.apps.catalog.constants import (
     LEARNER_PATHWAY,
     PROGRAM,
     RESTRICTION_FOR_B2B,
+)
+from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    get_advertised_course_run,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
@@ -352,163 +356,6 @@ class AlgoliaUtilsTests(TestCase):
         """
         course_subjects = utils.get_course_subjects(course_metadata)
         assert sorted(course_subjects) == sorted(expected_subjects)
-
-    @ddt.data(
-        (
-            {
-                'course_runs': [{
-                    'key': 'course-v1:org+course+1T2021',
-                    'uuid': ADVERTISED_COURSE_RUN_UUID,
-                    'pacing_type': 'instructor_paced',
-                    'start': '2013-10-16T14:00:00Z',
-                    'end': '2014-10-16T14:00:00Z',
-                    'enrollment_end': '2013-10-17T14:00:00Z',
-                    'availability': 'Current',
-                    'min_effort': 10,
-                    'max_effort': 14,
-                    'weeks_to_complete': 13,
-                    'status': 'published',
-                    'is_enrollable': True,
-                    'is_marketable': True,
-                    'enrollment_start': '2013-10-01T14:00:00Z',
-                }],
-                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
-            },
-            {
-                'key': 'course-v1:org+course+1T2021',
-                'pacing_type': 'instructor_paced',
-                'start': '2013-10-16T14:00:00Z',
-                'end': '2014-10-16T14:00:00Z',
-                'availability': 'Current',
-                'min_effort': 10,
-                'max_effort': 14,
-                'weeks_to_complete': 13,
-                'upgrade_deadline': 32503680000.0,
-                'enroll_start': 1380636000,
-                'has_enroll_start': True,
-                'has_enroll_by': True,
-                'enroll_by': 1382018400.0,
-                'is_active': True,
-                'is_late_enrollment_eligible': False,
-                'content_price': 0.0,
-                'restriction_type': None,
-            },
-        ),
-        (
-            {
-                'course_runs': [{
-                    'uuid': uuid4(),
-                }],
-                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
-            },
-            None,
-        ),
-        (
-            {
-                'course_runs': [{
-                    'key': 'course-v1:org+course+1T2021',
-                    'uuid': ADVERTISED_COURSE_RUN_UUID,
-                    'pacing_type': 'instructor_paced',
-                    'start': '2013-10-16T14:00:00Z',
-                    'end': '2014-10-16T14:00:00Z',
-                    'enrollment_end': '2013-10-17T14:00:00Z',
-                    'enrollment_start_date': '2013-10-01T14:00:00Z',
-                    'availability': 'Current',
-                    'min_effort': 10,
-                    'max_effort': 14,
-                    'weeks_to_complete': 13,
-                    'status': 'published',
-                    'is_enrollable': True,
-                    'is_marketable': True,
-                    'seats': [
-                        {
-                            'type': 'audit',
-                            'upgrade_deadline': None,
-                        },
-                        {
-                            'type': 'verified',
-                            'upgrade_deadline': '2015-01-04T15:52:00Z',
-                            'price': '50.00',
-                        }
-                    ],
-                    'first_enrollable_paid_seat_price': 50,
-                    'enrollment_start': '2013-10-01T14:00:00Z',
-                }],
-                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
-            },
-            {
-                'key': 'course-v1:org+course+1T2021',
-                'pacing_type': 'instructor_paced',
-                'start': '2013-10-16T14:00:00Z',
-                'end': '2014-10-16T14:00:00Z',
-                'availability': 'Current',
-                'min_effort': 10,
-                'max_effort': 14,
-                'weeks_to_complete': 13,
-                'upgrade_deadline': 1420386720.0,
-                'enroll_by': 1382018400.0,
-                'enroll_start': 1380636000.0,
-                'has_enroll_by': True,
-                'has_enroll_start': True,
-                'content_price': 50,
-                'is_active': True,
-                'is_late_enrollment_eligible': False,
-                'restriction_type': None,
-            }
-        ),
-        (
-            {
-                'course_runs': [{
-                    'key': 'course-v1:org+course+1T2021',
-                    'uuid': ADVERTISED_COURSE_RUN_UUID,
-                    'pacing_type': 'instructor_paced',
-                    'start': '2013-10-16T14:00:00Z',
-                    'end': '2014-10-16T14:00:00Z',
-                    'enrollment_end': '2013-10-17T14:00:00Z',
-                    'availability': 'Current',
-                    'min_effort': 10,
-                    'max_effort': 14,
-                    'weeks_to_complete': 13,
-                    'status': 'published',
-                    'is_enrollable': True,
-                    'is_marketable': True,
-                    'seats': [{
-                        'type': 'verified',
-                        'upgrade_deadline': None,
-                        'price': '50.00',
-                    }],
-                    'first_enrollable_paid_seat_price': 50,
-                }],
-                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
-            },
-            {
-                'key': 'course-v1:org+course+1T2021',
-                'pacing_type': 'instructor_paced',
-                'start': '2013-10-16T14:00:00Z',
-                'end': '2014-10-16T14:00:00Z',
-                'availability': 'Current',
-                'min_effort': 10,
-                'max_effort': 14,
-                'weeks_to_complete': 13,
-                'upgrade_deadline': 32503680000.0,
-                'enroll_by': 1382018400.0,
-                'enroll_start': None,
-                'has_enroll_by': True,
-                'has_enroll_start': False,
-                'content_price': 50,
-                'is_active': True,
-                'is_late_enrollment_eligible': False,
-                'restriction_type': None,
-            }
-        )
-    )
-    @ddt.unpack
-    def test_get_advertised_course_run(self, searchable_course, expected_course_run):
-        """
-        Assert get_advertised_course_runs fetches just enough info about advertised course run
-        """
-        advertised_course_run = utils.get_advertised_course_run(searchable_course)
-        assert advertised_course_run == expected_course_run
 
     @ddt.data(
         (
@@ -1788,3 +1635,161 @@ class AlgoliaUtilsTests(TestCase):
         """
         transcript_languages = utils.get_course_transcript_languages(course_metadata)
         assert transcript_languages == expected_transcript_languages
+
+    @ddt.data(
+        (
+            {
+                'course_runs': [{
+                    'key': 'course-v1:org+course+1T2021',
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z',
+                    'enrollment_end': '2013-10-17T14:00:00Z',
+                    'availability': 'Current',
+                    'min_effort': 10,
+                    'max_effort': 14,
+                    'weeks_to_complete': 13,
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'enrollment_start': '2013-10-01T14:00:00Z',
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                'key': 'course-v1:org+course+1T2021',
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
+                'availability': 'Current',
+                'min_effort': 10,
+                'max_effort': 14,
+                'weeks_to_complete': 13,
+                'upgrade_deadline': 32503680000.0,
+                'enroll_start': 1380636000,
+                'has_enroll_start': True,
+                'has_enroll_by': True,
+                'enroll_by': 1382018400.0,
+                'is_active': True,
+                'is_late_enrollment_eligible': False,
+                'content_price': 0.0,
+                'restriction_type': None,
+            },
+        ),
+        (
+            {
+                'course_runs': [{
+                    'uuid': uuid4(),
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            None,
+        ),
+        (
+            {
+                'course_runs': [{
+                    'key': 'course-v1:org+course+1T2021',
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z',
+                    'enrollment_end': '2013-10-17T14:00:00Z',
+                    'enrollment_start_date': '2013-10-01T14:00:00Z',
+                    'availability': 'Current',
+                    'min_effort': 10,
+                    'max_effort': 14,
+                    'weeks_to_complete': 13,
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'seats': [
+                        {
+                            'type': 'audit',
+                            'upgrade_deadline': None,
+                        },
+                        {
+                            'type': 'verified',
+                            'upgrade_deadline': '2015-01-04T15:52:00Z',
+                            'price': '50.00',
+                        }
+                    ],
+                    'first_enrollable_paid_seat_price': 50,
+                    'enrollment_start': '2013-10-01T14:00:00Z',
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                'key': 'course-v1:org+course+1T2021',
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
+                'availability': 'Current',
+                'min_effort': 10,
+                'max_effort': 14,
+                'weeks_to_complete': 13,
+                'upgrade_deadline': 1420386720.0,
+                'enroll_by': 1382018400.0,
+                'enroll_start': 1380636000.0,
+                'has_enroll_by': True,
+                'has_enroll_start': True,
+                'content_price': 50,
+                'is_active': True,
+                'is_late_enrollment_eligible': False,
+                'restriction_type': None,
+            }
+        ),
+        (
+            {
+                'course_runs': [{
+                    'key': 'course-v1:org+course+1T2021',
+                    'uuid': ADVERTISED_COURSE_RUN_UUID,
+                    'pacing_type': 'instructor_paced',
+                    'start': '2013-10-16T14:00:00Z',
+                    'end': '2014-10-16T14:00:00Z',
+                    'enrollment_end': '2013-10-17T14:00:00Z',
+                    'availability': 'Current',
+                    'min_effort': 10,
+                    'max_effort': 14,
+                    'weeks_to_complete': 13,
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'seats': [{
+                        'type': 'verified',
+                        'upgrade_deadline': None,
+                        'price': '50.00',
+                    }],
+                    'first_enrollable_paid_seat_price': 50,
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                'key': 'course-v1:org+course+1T2021',
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
+                'availability': 'Current',
+                'min_effort': 10,
+                'max_effort': 14,
+                'weeks_to_complete': 13,
+                'upgrade_deadline': 32503680000.0,
+                'enroll_by': 1382018400.0,
+                'enroll_start': None,
+                'has_enroll_by': True,
+                'has_enroll_start': False,
+                'content_price': 50,
+                'is_active': True,
+                'is_late_enrollment_eligible': False,
+                'restriction_type': None,
+            }
+        )
+    )
+    @ddt.unpack
+    def test_get_course_run(self, searchable_course, expected_course_run):
+        """
+        Assert get_advertised_course_run fetches just enough info about advertised course run
+        """
+        advertised_course_run = get_advertised_course_run(searchable_course)
+        transformed_advertised_course_run = _get_course_run(searchable_course, advertised_course_run)
+        assert transformed_advertised_course_run == expected_course_run

--- a/enterprise_catalog/apps/catalog/tests/test_content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_content_metadata_utils.py
@@ -1,13 +1,19 @@
 from uuid import uuid4
 
+import ddt
 from django.test import TestCase
 
 from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    get_advertised_course_run,
     tansform_force_included_courses,
     transform_course_metadata_to_visible,
 )
 
 
+ADVERTISED_COURSE_RUN_UUID = uuid4()
+
+
+@ddt.ddt
 class ContentMetadataUtilsTests(TestCase):
     """
     Tests for content metadata utils.
@@ -51,3 +57,128 @@ class ContentMetadataUtilsTests(TestCase):
         courses = [content_metadata]
         tansform_force_included_courses(courses)
         assert courses[0]['course_runs'][0]['status'] == 'published'
+
+    @ddt.data(
+        # Happy path: Multiple runs including advertised_course_run in course_runs, available advertised_course_run_uuid
+        (
+            {
+                'course_runs': [
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': ADVERTISED_COURSE_RUN_UUID,
+                        'pacing_type': 'instructor_paced',
+                        'start': '2013-10-16T14:00:00Z',
+                        'end': '2014-10-16T14:00:00Z',
+                        'enrollment_end': '2013-10-17T14:00:00Z',
+                        'availability': 'Current',
+                        'min_effort': 10,
+                        'max_effort': 14,
+                        'weeks_to_complete': 13,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'enrollment_start': '2013-10-01T14:00:00Z',
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': uuid4(),
+                        'pacing_type': 'instructor_paced',
+                        'start': '2016-10-16T14:00:00Z',
+                        'end': '2019-10-16T14:00:00Z',
+                        'enrollment_end': '2016-10-17T14:00:00Z',
+                        'availability': 'Upcoming',
+                        'min_effort': 11,
+                        'max_effort': 15,
+                        'weeks_to_complete': 15,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'enrollment_start': '2013-10-01T14:00:00Z',
+                    }
+                ],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            {
+                'key': 'course-v1:org+course+1T2021',
+                'uuid': ADVERTISED_COURSE_RUN_UUID,
+                'pacing_type': 'instructor_paced',
+                'start': '2013-10-16T14:00:00Z',
+                'end': '2014-10-16T14:00:00Z',
+                'enrollment_end': '2013-10-17T14:00:00Z',
+                'availability': 'Current',
+                'min_effort': 10,
+                'max_effort': 14,
+                'weeks_to_complete': 13,
+                'status': 'published',
+                'is_enrollable': True,
+                'is_marketable': True,
+                'enrollment_start': '2013-10-01T14:00:00Z',
+            },
+        ),
+        # Edge case: course_runs does not include advertised_course_run with available advertised_course_run_uuid
+        (
+            {
+                'course_runs': [{
+                    'uuid': uuid4(),
+                }],
+                'advertised_course_run_uuid': ADVERTISED_COURSE_RUN_UUID
+            },
+            None,
+        ),
+        # Edge case: No available course_runs and no advertised_course_run_uuid
+        (
+            {
+                'course_runs': [],
+                'advertised_course_run_uuid': None
+            },
+            None
+        ),
+        # Edge case: Available advertised_course_run within course_runs, and no advertised_course_run_uuid
+        (
+            {
+                'course_runs': [
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': ADVERTISED_COURSE_RUN_UUID,
+                        'pacing_type': 'instructor_paced',
+                        'start': '2013-10-16T14:00:00Z',
+                        'end': '2014-10-16T14:00:00Z',
+                        'enrollment_end': '2013-10-17T14:00:00Z',
+                        'availability': 'Current',
+                        'min_effort': 10,
+                        'max_effort': 14,
+                        'weeks_to_complete': 13,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'enrollment_start': '2013-10-01T14:00:00Z',
+                    },
+                    {
+                        'key': 'course-v1:org+course+1T2021',
+                        'uuid': uuid4(),
+                        'pacing_type': 'instructor_paced',
+                        'start': '2016-10-16T14:00:00Z',
+                        'end': '2019-10-16T14:00:00Z',
+                        'enrollment_end': '2016-10-17T14:00:00Z',
+                        'availability': 'Upcoming',
+                        'min_effort': 11,
+                        'max_effort': 15,
+                        'weeks_to_complete': 15,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'enrollment_start': '2013-10-01T14:00:00Z',
+                    }
+                ],
+                'advertised_course_run_uuid': None
+            },
+            None
+        ),
+    )
+    @ddt.unpack
+    def test_get_advertised_course(self, searchable_course, expected_course_run):
+        """
+        Assert get_advertised_course_run fetches the expected_course_run
+        """
+        advertised_course_run = get_advertised_course_run(searchable_course)
+        assert advertised_course_run == expected_course_run

--- a/enterprise_catalog/apps/catalog/tests/test_serializers.py
+++ b/enterprise_catalog/apps/catalog/tests/test_serializers.py
@@ -8,11 +8,13 @@ from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     EXEC_ED_2U_COURSE_TYPE,
 )
+from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    get_advertised_course_run,
+)
 from enterprise_catalog.apps.catalog.serializers import (
     NormalizedContentMetadataSerializer,
 )
 from enterprise_catalog.apps.catalog.tests import factories
-from enterprise_catalog.apps.catalog.utils import get_course_run_by_uuid
 
 
 @ddt.ddt
@@ -224,8 +226,7 @@ class NormalizedContentMetadataSerializerTests(TestCase):
         course_content.json_metadata['entitlements'] = entitlements
         course_content.json_metadata['course_type'] = course_type
 
-        advertised_course_run_uuid = course_content.json_metadata['advertised_course_run_uuid']
-        advertised_course_run = get_course_run_by_uuid(course_content.json_metadata, advertised_course_run_uuid)
+        advertised_course_run = get_advertised_course_run(course_content.json_metadata)
         advertised_course_run['fixed_price_usd'] = fixed_price_usd
         advertised_course_run['first_enrollable_paid_seat_price'] = first_enrollable_paid_seat_price
 

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -158,21 +158,3 @@ def to_timestamp(datetime_str):
     except (ValueError, TypeError) as exc:
         LOGGER.error(f"[to_timestamp][{exc}] Could not parse date string: {datetime_str}")
         return None
-
-
-def get_course_run_by_uuid(course, course_run_uuid):
-    """
-    Find a course_run based on uuid
-
-    Arguments:
-        course (dict): course dict
-        course_run_uuid (str): uuid to lookup
-
-    Returns:
-        dict: a course_run or None
-    """
-    try:
-        course_run = [run for run in course.get('course_runs', []) if run.get('uuid') == course_run_uuid][0]
-    except IndexError:
-        return None
-    return course_run


### PR DESCRIPTION
Updates how we set the enrollment url if the learner portal is not enabled. This is to fix an error that is manifesting in the LMS where the enrollment url is parsed for a course_id, but a top level course is retrieved. This breaks the expectation of what the OpaqueKeys `CourseKey` is expecting which includes a course run. 

The changes included ensures a course run is always passed within the enrollment url.

This is a root cause solution to this [PR](https://github.com/openedx/edx-platform/pull/36028)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
