### PR TITLE
ENT-6271: Added the ability to get enterprise portal URL in catalog report.

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -46,6 +46,8 @@ CSV_PROGRAM_HEADERS = [
     'Short Description',
     'Number of courses',
     'Associated Catalogs',
+    'Program UUID',
+    'URL',
 ]
 
 CSV_COURSE_RUN_HEADERS = [
@@ -121,6 +123,7 @@ ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
     'subjects',
     'subtitle',
     'title',
+    'uuid',
 ]
 
 DATE_FORMAT = "%Y-%m-%d"
@@ -149,7 +152,7 @@ def fetch_catalog_types(hit):
     return [catalog for catalog in CATALOG_TYPES if catalog in hit.get('enterprise_catalog_query_titles')]
 
 
-def program_hit_to_row(hit):
+def program_hit_to_row(hit, use_learner_portal_url=False):
     """
     Helper function to construct a CSV row according to a single Algolia result program hit.
     """
@@ -167,6 +170,13 @@ def program_hit_to_row(hit):
     catalogs = fetch_catalog_types(hit)
     csv_row.append(', '.join(catalogs))
 
+    uuid = hit.get('uuid')
+    csv_row.append(uuid)
+    if use_learner_portal_url and uuid:
+        csv_row.append(f'https://enterprise.edx.org/r/program/{uuid}')
+    else:
+        csv_row.append(hit.get('marketing_url'))
+
     return csv_row
 
 
@@ -174,6 +184,7 @@ def _base_csv_row_data(hit):
     """ Returns the formatted, shared attributes common across all course types. """
     title = hit.get('title')
     aggregation_key = hit.get('aggregation_key')
+    key = hit.get('key')
     language = hit.get('language')
     transcript_languages = ', '.join(hit.get('transcript_languages', []))
     marketing_url = hit.get('marketing_url')
@@ -211,6 +222,7 @@ def _base_csv_row_data(hit):
         'end_date': end_date,
         'enroll_by': enroll_by,
         'aggregation_key': aggregation_key,
+        'key': key,
         'advertised_course_run_key': advertised_course_run_key,
         'language': language,
         'transcript_languages': transcript_languages,
@@ -227,7 +239,7 @@ def _base_csv_row_data(hit):
     }
 
 
-def course_hit_to_row(hit):
+def course_hit_to_row(hit, use_learner_portal_url=False):
     """
     Helper function to construct a CSV row according to a single Algolia result course hit.
     """
@@ -256,7 +268,13 @@ def course_hit_to_row(hit):
     csv_row.append(row_data.get('content_price'))
     csv_row.append(row_data.get('language'))
     csv_row.append(row_data.get('transcript_languages'))
-    csv_row.append(row_data.get('marketing_url'))
+
+    key = row_data.get('key')
+    if use_learner_portal_url and key:
+        csv_row.append(f'https://enterprise.edx.org/r/course/{key}')
+    else:
+        csv_row.append(row_data.get('marketing_url'))
+
     csv_row.append(row_data.get('short_description'))
     csv_row.append(row_data.get('subjects'))
     csv_row.append(row_data.get('advertised_course_run_key'))
@@ -275,7 +293,7 @@ def course_hit_to_row(hit):
     return csv_row
 
 
-def exec_ed_course_to_row(hit):
+def exec_ed_course_to_row(hit, use_learner_portal_url=False):
     """
     Helper function to construct a CSV row according to a single executive education course hit.
     """
@@ -291,7 +309,13 @@ def exec_ed_course_to_row(hit):
     csv_row.append(row_data.get('content_price'))
     csv_row.append(row_data.get('language'))
     csv_row.append(row_data.get('transcript_languages'))
-    csv_row.append(row_data.get('marketing_url'))
+
+    key = row_data.get('key')
+    if use_learner_portal_url and key:
+        csv_row.append(f'https://enterprise.edx.org/r/course/{key}')
+    else:
+        csv_row.append(row_data.get('marketing_url'))
+
     csv_row.append(row_data.get('short_description'))
     csv_row.append(row_data.get('subjects'))
     csv_row.append(row_data.get('advertised_course_run_key'))

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1081,6 +1081,17 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
         response = self.client.get(f'{url}?{facets}')
         assert response.status_code == 200
 
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_workbook.get_initialized_algolia_client')
+    def test_use_learner_portal_url(self, mock_algolia_client):
+        """
+        Tests basic, successful output
+        """
+        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        url = self._get_contains_content_base_url()
+        facets = 'language=English&use_learner_portal_url=true'
+        response = self.client.get(f'{url}?{facets}')
+        assert response.status_code == 200
+
 
 class EnterpriseCatalogContainsContentItemsTests(APITestMixin):
     """

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -42,6 +42,7 @@ class CatalogWorkbookView(GenericAPIView):
         GET entry point for the `CatalogWorkbookView`
         """
         facets = export_utils.querydict_to_dict(request.query_params)
+        use_learner_portal_url = facets.pop('use_learner_portal_url', False)
         algoliaQuery = export_utils.facets_to_query(facets)
 
         invalid_facets = export_utils.validate_query_facets(facets)
@@ -100,7 +101,7 @@ class CatalogWorkbookView(GenericAPIView):
                             export_utils.write_headers_to_sheet(
                                 exec_ed_worksheet, export_utils.CSV_EXEC_ED_COURSE_HEADERS, header_format
                             )
-                        course_row = export_utils.exec_ed_course_to_row(hit)
+                        course_row = export_utils.exec_ed_course_to_row(hit, use_learner_portal_url)
                         exec_ed_row_num = write_row_data(course_row, exec_ed_worksheet, exec_ed_row_num)
                     else:
                         if not edx_course_results_found:
@@ -109,7 +110,7 @@ class CatalogWorkbookView(GenericAPIView):
                             export_utils.write_headers_to_sheet(
                                 course_worksheet, export_utils.CSV_COURSE_HEADERS, header_format
                             )
-                        course_row = export_utils.course_hit_to_row(hit)
+                        course_row = export_utils.course_hit_to_row(hit, use_learner_portal_url)
                         course_row_num = write_row_data(course_row, course_worksheet, course_row_num)
                     for course_run in export_utils.course_hit_runs(hit):
                         if not course_run_results_found:
@@ -127,7 +128,7 @@ class CatalogWorkbookView(GenericAPIView):
                         export_utils.write_headers_to_sheet(
                             program_worksheet, export_utils.CSV_PROGRAM_HEADERS, header_format
                         )
-                    program_row = export_utils.program_hit_to_row(hit)
+                    program_row = export_utils.program_hit_to_row(hit, use_learner_portal_url)
                     program_row_num = write_row_data(program_row, program_worksheet, program_row_num)
             search_options['page'] = search_options['page'] + 1
             page = algolia_client.algolia_index.search(algoliaQuery, search_options)


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6271](https://2u-internal.atlassian.net/browse/ENT-6271)

This PR introduces the ability for user to switch between `edx.org` and `enterprise.edx.org` URLs for course and program links included in the public catalog CSV file.


## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
