### PR TITLE
feat: mark course as active in Agolia if is_marketable_external

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from enterprise_catalog.apps.api.v1.utils import (
     get_archived_content_count,
     get_most_recent_modified_time,
+    is_course_run_active,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
@@ -82,3 +83,52 @@ class ApiUtilsTests(TestCase):
             [highlighted_content_1, highlighted_content_2, highlighted_content_3]
         )
         assert archived_content_count == 2
+
+    def test_is_course_run_active(self):
+        """
+        Test that the is_course_run_active function correctly identifies active course runs.
+        """
+        # Test case where course run is active
+        active_course_run = {
+            'is_enrollable': True,
+            'is_marketable_external': True,
+            'status': 'published',
+            'is_marketable': True
+        }
+        assert is_course_run_active(active_course_run) is True
+
+        # Test case where course run is not active due to not being enrollable
+        not_enrollable_course_run = {
+            'is_enrollable': False,
+            'is_marketable_external': True,
+            'status': 'published',
+            'is_marketable': True
+        }
+        assert is_course_run_active(not_enrollable_course_run) is False
+
+        # Test case where course is not is_marketable but is_marketable_external
+        not_marketable_course_run = {
+            'is_enrollable': True,
+            'is_marketable_external': True,
+            'status': 'published',
+            'is_marketable': False
+        }
+        assert is_course_run_active(not_marketable_course_run) is True
+
+        # Test case where course run is not active due to not being published
+        not_published_course_run = {
+            'is_enrollable': False,
+            'is_marketable_external': False,
+            'status': 'archived',
+            'is_marketable': True
+        }
+        assert is_course_run_active(not_published_course_run) is False
+
+        # Test case where course run is active due to being marketable externally
+        marketable_external_course_run = {
+            'is_enrollable': True,
+            'is_marketable_external': True,
+            'status': 'reviewed',
+            'is_marketable': False
+        }
+        assert is_course_run_active(marketable_external_course_run) is True

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -10,6 +10,10 @@ from six.moves.urllib.parse import (
     urlunsplit,
 )
 
+from enterprise_catalog.apps.catalog.content_metadata_utils import (
+    is_course_run_active,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -57,27 +61,6 @@ def get_enterprise_utm_context(enterprise_name):
         utm_context['utm_source'] = slugify(enterprise_name)
 
     return utm_context
-
-
-def is_course_run_active(course_run):
-    """
-    Checks whether a course run is active. That is, whether the course run is published,
-    enrollable, and marketable.
-
-    Arguments:
-        course_run (dict): The metadata about a course run.
-
-    Returns:
-        bool: True if course run is "active"
-    """
-    is_enrollable = course_run.get('is_enrollable', False)
-    if course_run.get("is_marketable_external") and is_enrollable:
-        return True
-    course_run_status = course_run.get('status') or ''
-    is_published = course_run_status.lower() == 'published'
-    is_marketable = course_run.get('is_marketable', False)
-
-    return is_published and is_enrollable and is_marketable
 
 
 def is_any_course_run_active(course_runs):

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -70,9 +70,11 @@ def is_course_run_active(course_run):
     Returns:
         bool: True if course run is "active"
     """
+    is_enrollable = course_run.get('is_enrollable', False)
+    if course_run.get("is_marketable_external") and is_enrollable:
+        return True
     course_run_status = course_run.get('status') or ''
     is_published = course_run_status.lower() == 'published'
-    is_enrollable = course_run.get('is_enrollable', False)
     is_marketable = course_run.get('is_marketable', False)
 
     return is_published and is_enrollable and is_marketable

--- a/enterprise_catalog/apps/catalog/content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/content_metadata_utils.py
@@ -66,19 +66,23 @@ def is_course_run_active(course_run):
     """
     Checks whether a course run is active. That is, whether the course run is published,
     enrollable, and marketable.
+    Checking is_published in case of is_marketable_external is redundant because
+    the Discovery service already handles the status behind is_marketable_external
+    property.
     Arguments:
         course_run (dict): The metadata about a course run.
     Returns:
         bool: True if course run is "active"
     """
-    is_enrollable = course_run.get('is_enrollable', False)
-    if course_run.get("is_marketable_external") and is_enrollable:
-        return True
     course_run_status = course_run.get('status') or ''
     is_published = course_run_status.lower() == 'published'
     is_marketable = course_run.get('is_marketable', False)
+    is_enrollable = course_run.get('is_enrollable', False)
 
-    return is_published and is_enrollable and is_marketable
+    is_marketable_internal = is_published and is_marketable
+    is_marketable_external = course_run.get("is_marketable_external", False)
+
+    return is_enrollable and (is_marketable_internal or is_marketable_external)
 
 
 def get_course_first_paid_enrollable_seat_price(course):

--- a/enterprise_catalog/apps/catalog/content_metadata_utils.py
+++ b/enterprise_catalog/apps/catalog/content_metadata_utils.py
@@ -71,9 +71,11 @@ def is_course_run_active(course_run):
     Returns:
         bool: True if course run is "active"
     """
+    is_enrollable = course_run.get('is_enrollable', False)
+    if course_run.get("is_marketable_external") and is_enrollable:
+        return True
     course_run_status = course_run.get('status') or ''
     is_published = course_run_status.lower() == 'published'
-    is_enrollable = course_run.get('is_enrollable', False)
     is_marketable = course_run.get('is_marketable', False)
 
     return is_published and is_enrollable and is_marketable

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -119,6 +119,18 @@ class AlgoliaUtilsTests(TestCase):
             'enrollment_end': days_from_now(30),
             'restriction_type': RESTRICTION_FOR_B2B,
         },
+        # A Exec-Ed course, not is_marketable but is_marketable_external.
+        {
+            'expected_result': True,
+            'course_type': EXEC_ED_2U_COURSE_TYPE,
+            'start': days_from_now(1),
+            'end': days_from_now(30),
+            'enrollment_end': days_from_now(1),
+            'is_marketable': False,
+            'is_marketable_external': True,
+            'advertised_course_run_status': 'reviewed',
+            'course_run_availability': 'Upcoming'
+        },
     )
     @ddt.unpack
     def test_should_index_course(
@@ -130,6 +142,7 @@ class AlgoliaUtilsTests(TestCase):
         advertised_course_run_status='published',
         is_enrollable=True,
         is_marketable=True,
+        is_marketable_external=True,
         course_run_availability='current',
         seats=None,
         course_type=COURSE,
@@ -155,6 +168,7 @@ class AlgoliaUtilsTests(TestCase):
                     'status': advertised_course_run_status,
                     'is_enrollable': is_enrollable,
                     'is_marketable': is_marketable,
+                    'is_marketable_external': is_marketable_external,
                     'availability': course_run_availability,
                     'seats': seats or [],
                     'start': start,
@@ -782,6 +796,18 @@ class AlgoliaUtilsTests(TestCase):
                 }]
             },
             ['Archived'],
+        ),
+        (
+            {
+                'course_runs': [{
+                    'status': 'reviewed',
+                    'is_enrollable': True,
+                    'is_marketable': False,
+                    'is_marketable_external': True,
+                    'availability': 'Upcoming'
+                }]
+            },
+            ['Upcoming'],
         ),
     )
     @ddt.unpack


### PR DESCRIPTION
Updated the utility functions to ensure that course runs with the `is_marketable_external` property set to `True` are indexed as `active` in Algolia. This change affects the logic in the `is_course_run_active` function, which now includes a check for the `is_marketable_external` property.
* [x] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
