### PR TITLE
Fix provisioning script

### DIFF
--- a/provision-catalog.sh
+++ b/provision-catalog.sh
@@ -1,4 +1,5 @@
 name="enterprise_catalog"
+directory="enterprise-catalog"
 port="18160"
 
 docker-compose up -d
@@ -14,11 +15,11 @@ sleep 5
 
 # Run migrations
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker exec -t enterprise.catalog.app bash -c "cd /edx/app/${name}/${name}/ && make migrate"
+docker exec -t enterprise.catalog.app bash -c "cd /edx/app/${directory}/ && make migrate"
 
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker exec -t enterprise.catalog.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/${name}/manage.py shell"
+docker exec -t enterprise.catalog.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${directory}/manage.py shell"
 
 # Provision IDA User in LMS
 echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"


### PR DESCRIPTION
## Description

This is a fix for the provision script.

## Concerns, please address in review:

I do not know whether the provision script is only used for local development. If it's used for production deployments, for instance, changing the paths here may break things. Can you tell me where this script is used and where not?

## Previous state:

- After creating a fresh install and going to localhost:18160/admin, you cannot log in with "edx": "edx" because
- The "edx" staff user is not created.
- Provision produces two errors (even when the command finishes successfully):
`bash: line 0: cd: /edx/app/enterprise_catalog/enterprise_catalog/: No such file or directory`
`python: can't open file '/edx/app/enterprise_catalog/enterprise_catalog/manage.py': [Errno 2] No such file or directory`.
- Migrations are not applied.
- The provision script goes through, making it non-obvious that these errors are in the log output.

The recent changes to docker images have caused the provision script to contain incorrect paths, which this fixes.

## Testing Instructions

- Run `make dev.provision` in this repository
- It should run through successfully
- Verify that there are no "No such file or directory" errors in the terminal stdout output
- In the log output, you should see migrations running without error (broken state: you see the line `...Running migrations for enterprise_catalog...` but it's followed by an error)
-  You should see no error after `creating super-user`
- Go to `http://localhost:18160/admin/`. Try to log in with user: "edx", password: "edx". This should succeed even on a fresh repo setup.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
