### PR TITLE
feat: add API endpoint to retrieve secured Algolia API key for an EnterpriseCustomer

### DIFF
--- a/enterprise_catalog/apps/api/base/tests/enterprise_customer_views.py
+++ b/enterprise_catalog/apps/api/base/tests/enterprise_customer_views.py
@@ -64,10 +64,24 @@ class BaseEnterpriseCustomerViewSetTests(APITestMixin):
         )
 
     def _get_content_metadata_base_url(self, enterprise_uuid, content_identifier):
+        """
+        Helper to construct the base url for the customer content metadata endpoint
+        """
         return reverse(
             f'api:{self.VERSION}:customer-content-metadata-retrieve',
             kwargs={
                 'enterprise_uuid': enterprise_uuid,
                 'content_identifier': content_identifier,
+            },
+        )
+
+    def _get_secured_algolia_api_key_base_url(self, enterprise_uuid):
+        """
+        Helper to construct the base url for the secured Algolia API key endpoint
+        """
+        return reverse(
+            f'api:{self.VERSION}:enterprise-customer-secured-algolia-api-key',
+            kwargs={
+                'enterprise_uuid': enterprise_uuid,
             },
         )

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -87,6 +87,25 @@ def find_and_modify_catalog_query(
         return content_filter_from_hash
 
 
+class BaseSerializer(serializers.Serializer):
+    """
+    Base serializer.
+    """
+    def create(self, *args, **kwargs):
+        return None
+
+    def update(self, *args, **kwargs):
+        return None
+
+
+class BaseErrorSerializer(BaseSerializer):
+    """
+    Base error serializer.
+    """
+    user_message = serializers.CharField()
+    developer_message = serializers.CharField()
+
+
 class CatalogQuerySerializer(serializers.ModelSerializer):
     """
     Serializer for the `CatalogQuery` model
@@ -525,3 +544,28 @@ class JobSerializer(serializers.ModelSerializer):
             "external_id",
             "title"
         ]
+
+
+class SecuredAlgoliaAPIKeySerializer(BaseSerializer):
+    """
+    Serializer for the secured Algolia API key and expiration.
+    """
+    secured_api_key = serializers.CharField()
+    valid_until = serializers.DateTimeField()
+
+
+class SecuredAlgoliaAPIKeyResponseSerializer(BaseSerializer):
+    """
+    Serializer for the response of the secured Algolia API key endpoint.
+    """
+    algolia = SecuredAlgoliaAPIKeySerializer(help_text='Secured Algolia API key and expiration.')
+    catalog_uuids_to_catalog_query_uuids = serializers.DictField(
+        child=serializers.UUIDField(),
+        help_text='Mapping of catalog UUIDs to catalog query UUIDs.',
+    )
+
+
+class SecuredAlgoliaAPIKeyErrorResponseSerializer(BaseErrorSerializer):
+    """
+    Serializer for the error response of the secured Algolia API key endpoint.
+    """

--- a/enterprise_catalog/apps/api/v1/tests/mixins.py
+++ b/enterprise_catalog/apps/api/v1/tests/mixins.py
@@ -96,7 +96,7 @@ class APITestMixin(JwtMixin, APITestCase):
         self.assign_catalog_admin_feature_role()
         self.assign_catalog_admin_jwt_role()
 
-    def set_up_catalog_learner(self):
+    def set_up_catalog_learner(self, enterprise_uuid=None):
         """
         Helper for setting up tests as a catalog learner
         """
@@ -106,7 +106,7 @@ class APITestMixin(JwtMixin, APITestCase):
         self.role_assignment = EnterpriseCatalogRoleAssignmentFactory(
             role=self.role,
             user=self.user,
-            enterprise_id=self.enterprise_uuid
+            enterprise_id=(enterprise_uuid or self.enterprise_uuid)
         )
         self.set_jwt_cookie([(ENTERPRISE_CATALOG_LEARNER_ROLE, self.enterprise_uuid)])
 

--- a/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytz
+from algoliasearch.exceptions import AlgoliaException
+from django.test import override_settings
 from rest_framework import status
 
 from enterprise_catalog.apps.api.base.tests.enterprise_customer_views import (
@@ -470,3 +472,98 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
 
         # response should only contain content keys found in the "second_catalog"
         self.assertEqual(response.get('filtered_content_keys'), [relevant_content_key])
+
+    @override_settings(ALGOLIA={'SEARCH_API_KEY': 'fake-search-api-search'})
+    def test_secured_algolia_api_key_generation(self):
+        """
+        Test that the secured Algolia API key is generated correctly.
+        """
+        url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_catalog_to_catalog_query_mappings = {
+            str(self.enterprise_catalog.uuid): str(self.enterprise_catalog.catalog_query.uuid),
+        }
+        self.assertIsInstance(response.data['algolia']['secured_api_key'], str)
+        self.assertTrue(bool(response.data['algolia']['secured_api_key']))  # Ensures the string isn't empty
+
+        # Validate ISO format for valid_until
+        valid_until = response.data['algolia']['valid_until']
+        try:
+            datetime.fromisoformat(valid_until)  # Will raise ValueError if the format is incorrect
+        except ValueError:
+            self.fail(f"Invalid ISO format for valid_until: {valid_until}")
+
+        # Validate catalog uuids to catalog query uuids mapping
+        self.assertEqual(
+            response.data['catalog_uuids_to_catalog_query_uuids'],
+            expected_catalog_to_catalog_query_mappings,
+        )
+
+    @override_settings(ALGOLIA={})
+    def test_secured_algolia_api_key_missing_search_api_key(self):
+        """
+        Test that the secured Algolia API key is not generated if the search API key is missing.
+        """
+        url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': (
+                'Cannot generate secured Algolia API key without the ALGOLIA.SEARCH_API_KEY in settings.'
+            ),
+        }
+        self.assertEqual(response.data, expected_error_response)
+
+    @mock.patch(
+        "algoliasearch.search_client.SearchClient.generate_secured_api_key",
+        side_effect=AlgoliaException("Mocked exception"),
+    )
+    @override_settings(ALGOLIA={'SEARCH_API_KEY': 'fake-search-api-search'})
+    def test_secured_algolia_api_key_algolia_exception(self, mock_generate_key):  # pylint: disable=unused-argument
+        """
+        Test that the secured Algolia API key is not generated if an AlgoliaException occurs.
+        """
+        url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': 'Mocked exception',
+        }
+        self.assertEqual(response.data, expected_error_response)
+
+    def test_secured_algolia_api_key_no_catalogs(self):
+        """
+        Test that the secured Algolia API key is not generated if there are no catalogs.
+        """
+        fake_enterprise_uuid = uuid.uuid4()
+        self.set_up_catalog_learner(enterprise_uuid=fake_enterprise_uuid)
+        url = self._get_secured_algolia_api_key_base_url(enterprise_uuid=fake_enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': 'No enterprise catalogs found for the specified enterprise customer.',
+        }
+        self.assertEqual(response.data, expected_error_response)
+
+    def test_secured_algolia_api_key_no_catalog_queries(self):
+        """
+        Test that the secured Algolia API key is not generated if there are no catalog queries.
+        """
+        fake_enterprise_uuid = uuid.uuid4()
+        EnterpriseCatalogFactory(
+            enterprise_uuid=fake_enterprise_uuid,
+            catalog_query=None,  # Ensure no catalog query is associated with the catalog
+        )
+        self.set_up_catalog_learner(enterprise_uuid=fake_enterprise_uuid)
+        url = self._get_secured_algolia_api_key_base_url(enterprise_uuid=fake_enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': 'No catalog queries found for the specified enterprise customer.',
+        }
+        self.assertEqual(response.data, expected_error_response)

--- a/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
@@ -1,7 +1,10 @@
 import logging
 import uuid
 
+from algoliasearch.exceptions import AlgoliaException
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import method_decorator
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from edx_rbac.utils import get_decoded_jwt
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied
@@ -11,9 +14,14 @@ from rest_framework.status import HTTP_400_BAD_REQUEST
 from enterprise_catalog.apps.api.v1.decorators import (
     require_at_least_one_query_parameter,
 )
-from enterprise_catalog.apps.api.v1.serializers import ContentMetadataSerializer
+from enterprise_catalog.apps.api.v1.serializers import (
+    ContentMetadataSerializer,
+    SecuredAlgoliaAPIKeyErrorResponseSerializer,
+    SecuredAlgoliaAPIKeyResponseSerializer,
+)
 from enterprise_catalog.apps.api.v1.utils import unquote_course_keys
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
+from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
 
 
@@ -209,3 +217,122 @@ class EnterpriseCustomerViewSet(BaseViewSet):
         """
         serializer = self.get_metadata_item_serializer()
         return Response(serializer.data)
+
+    @extend_schema(
+        summary='Get secured Algolia API key for enterprise customer',
+        description='Returns a secured Algolia API key for the given enterprise UUID. '
+                    'The key can be used within frontends to access Algolia search API, '
+                    'restricted with the enterprise\'s available catalog query UUIDs.',
+        responses={
+            200: SecuredAlgoliaAPIKeyResponseSerializer,
+            400: SecuredAlgoliaAPIKeyErrorResponseSerializer,
+        },
+        tags=['Enterprise Customer'],
+        examples=[
+            OpenApiExample(
+                'Secured Algolia API Key Response',
+                value={
+                    'algolia': {
+                        'secured_api_key': '...',
+                        'valid_until': '2025-02-28T12:00:00Z',
+                    },
+                    'catalog_uuids_to_catalog_query_uuids': {
+                        'catalog_uuid_1': 'catalog_query_uuid_1',
+                        'catalog_uuid_2': 'catalog_query_uuid_2',
+                    },
+                },
+            ),
+        ]
+    )
+    @action(detail=True, methods=['get'], url_path='secured-algolia-api-key')
+    def secured_algolia_api_key(self, request, enterprise_uuid, **kwargs):
+        """
+        Returns a secured Algolia API key for the given enterprise UUID.
+        The key can be used within frontends to access Algolia search API,
+        restricted with the enterprise's available catalog query UUIDs.
+        """
+        # Fetch all EnterpriseCatalogs associated with the given enterprise_uuid
+        enterprise_catalogs = EnterpriseCatalog.objects.filter(
+            enterprise_uuid=enterprise_uuid
+        ).select_related('catalog_query')
+        algolia_api_key_error_message = 'Error generating secured Algolia API key.'
+
+        # Return an error response if no EnterpriseCatalogs are found
+        if not enterprise_catalogs:
+            logger.error(
+                f'No enterprise catalogs found for the given enterprise UUID: {enterprise_uuid}.'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': 'No enterprise catalogs found for the specified enterprise customer.',
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        catalog_query_uuids = [
+            enterprise_catalog.catalog_query.uuid for enterprise_catalog in enterprise_catalogs
+            if enterprise_catalog.catalog_query
+        ]
+        # Return an error response if no CatalogQueries are found
+        if not catalog_query_uuids:
+            logger.error(
+                f'No catalog queries found for the given enterprise UUID: {enterprise_uuid}.'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': 'No catalog queries found for the specified enterprise customer.'
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        # Create a mapping of catalog UUIDs to their corresponding catalog query UUIDs
+        catalog_uuids_to_catalog_query_uuids = {
+            str(catalog.uuid): str(catalog.catalog_query.uuid) if catalog.catalog_query else None
+            for catalog in enterprise_catalogs
+        }
+
+        # Generate a secured Algolia API key using the AlgoliaSearchClient
+        algolia_client = AlgoliaSearchClient()
+        try:
+            result = algolia_client.generate_secured_api_key(
+                user_id=request.user.id,
+                enterprise_catalog_query_uuids=catalog_query_uuids,
+            )
+        except ImproperlyConfigured as exc:
+            logger.exception(
+                f'Secured Algolia API key generation failed for enterprise UUID {enterprise_uuid}'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': exc,
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+        except AlgoliaException as exc:
+            logger.exception(
+                f'Secured Algolia API key generation failed for enterprise UUID {enterprise_uuid}'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': exc
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        # Serialize the response data
+        response_data = {
+            'algolia': {
+                'secured_api_key': result.get('secured_api_key'),
+                'valid_until': result.get('valid_until'),
+            },
+            'catalog_uuids_to_catalog_query_uuids': catalog_uuids_to_catalog_query_uuids,
+        }
+        return Response(SecuredAlgoliaAPIKeyResponseSerializer(response_data).data)

--- a/enterprise_catalog/apps/api/v2/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v2/views/enterprise_customer.py
@@ -1,5 +1,7 @@
 import logging
 
+from rest_framework.decorators import action
+
 from enterprise_catalog.apps.api.v1.views.enterprise_customer import (
     EnterpriseCustomerViewSet,
 )
@@ -38,3 +40,10 @@ class EnterpriseCustomerViewSetV2(EnterpriseCustomerViewSet):
 
     def contains_content_keys(self, catalog, content_keys):
         return catalog.contains_content_keys(content_keys, include_restricted=True)
+
+    @action(detail=False, methods=['get'], url_path='secured-algolia-api-key')
+    def secured_algolia_api_key(self, request, enterprise_uuid, **kwargs):
+        """
+        There is no V2 version of this endpoint.
+        """
+        raise NotImplementedError('This endpoint is not available in V2.')

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -3,10 +3,13 @@ Algolia api client code.
 """
 
 import logging
+import time
+from datetime import datetime, timezone
 
 from algoliasearch.exceptions import AlgoliaException
 from algoliasearch.search_client import SearchClient
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
 logger = logging.getLogger(__name__)
@@ -17,42 +20,69 @@ class AlgoliaSearchClient:
     Object builds an API client to make calls to an Algolia index.
     """
 
-    ALGOLIA_APPLICATION_ID = settings.ALGOLIA.get('APPLICATION_ID')
-    ALGOLIA_API_KEY = settings.ALGOLIA.get('API_KEY')
-    ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME')
-    ALGOLIA_REPLICA_INDEX_NAME = settings.ALGOLIA.get('REPLICA_INDEX_NAME')
-
     def __init__(self):
         self._client = None
         self.algolia_index = None
         self.replica_index = None
 
+    @property
+    def algolia_application_id(self):
+        return settings.ALGOLIA.get('APPLICATION_ID')
+
+    @property
+    def algolia_api_key(self):
+        return settings.ALGOLIA.get('API_KEY')
+
+    @property
+    def algolia_search_api_key(self):
+        return settings.ALGOLIA.get('SEARCH_API_KEY')
+
+    @property
+    def algolia_index_name(self):
+        return settings.ALGOLIA.get('INDEX_NAME')
+
+    @property
+    def algolia_replica_index_name(self):
+        return settings.ALGOLIA.get('REPLICA_INDEX_NAME')
+
     def init_index(self):
         """
         Initializes an index within Algolia. Initializing an index will create it if it doesn't exist.
         """
-        if not self.ALGOLIA_INDEX_NAME or not self.ALGOLIA_REPLICA_INDEX_NAME:
+        if not self.algolia_index_name or not self.algolia_replica_index_name:
             logger.error('Could not initialize Algolia index due to missing index name.')
             return
 
-        if not self.ALGOLIA_APPLICATION_ID or not self.ALGOLIA_API_KEY:
+        if not self.algolia_application_id or not self.algolia_api_key:
             logger.error(
                 'Could not initialize Algolia\'s %s index due to missing Algolia settings: %s',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
                 ['APPLICATION_ID', 'API_KEY'],
             )
             return
 
-        self._client = SearchClient.create(self.ALGOLIA_APPLICATION_ID, self.ALGOLIA_API_KEY)
-        try:
-            self.algolia_index = self._client.init_index(self.ALGOLIA_INDEX_NAME)
-            self.replica_index = self._client.init_index(self.ALGOLIA_REPLICA_INDEX_NAME)
-        except AlgoliaException as exc:
-            logger.exception(
-                'Could not initialize %s index in Algolia due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
-            )
-            raise exc
+        # Create SearchClient
+        self._client = SearchClient.create(self.algolia_application_id, self.algolia_api_key)
+
+        # Initialize Algolia indices
+        if self.algolia_index_name:
+            try:
+                self.algolia_index = self._client.init_index(self.algolia_index_name)
+            except AlgoliaException as exc:
+                logger.exception(
+                    'Could not initialize %s index in Algolia due to an exception.',
+                    self.algolia_index_name,
+                )
+                raise exc
+        if self.algolia_replica_index_name:
+            try:
+                self.replica_index = self._client.init_index(self.algolia_replica_index_name)
+            except AlgoliaException as exc:
+                logger.exception(
+                    'Could not initialize %s index in Algolia due to an exception.',
+                    self.algolia_replica_index_name,
+                )
+                raise exc
 
     def set_index_settings(self, index_settings, primary_index=True):
         """
@@ -76,7 +106,7 @@ class AlgoliaSearchClient:
         except AlgoliaException as exc:
             logger.exception(
                 'Unable to set settings for Algolia\'s %s index due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
             raise exc
 
@@ -93,12 +123,12 @@ class AlgoliaSearchClient:
         if not primary_exists:
             logger.warning(
                 'Index with name %s does not exist in Algolia.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
         if not replica_exists:
             logger.warning(
                 'Index with name %s does not exist in Algolia.',
-                self.ALGOLIA_REPLICA_INDEX_NAME,
+                self.algolia_replica_index_name,
             )
 
         return primary_exists and replica_exists
@@ -121,11 +151,11 @@ class AlgoliaSearchClient:
             self.algolia_index.replace_all_objects(algolia_objects, {
                 'safe': True,  # wait for asynchronous indexing operations to complete
             })
-            logger.info('The %s Algolia index was successfully indexed.', self.ALGOLIA_INDEX_NAME)
+            logger.info('The %s Algolia index was successfully indexed.', self.algolia_index_name)
         except AlgoliaException as exc:
             logger.exception(
                 'Could not index objects in the %s Algolia index due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
             raise exc
 
@@ -164,12 +194,75 @@ class AlgoliaSearchClient:
             self.algolia_index.delete_objects(object_ids)
             logger.info(
                 'The following objects were successfully removed from the %s Algolia index: %s',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
                 object_ids,
             )
         except AlgoliaException as exc:
             logger.exception(
                 'Could not remove objects from the %s Algolia index due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
             raise exc
+
+    def generate_secured_api_key(self, user_id, enterprise_catalog_query_uuids):
+        """
+        Generates a secured api key for the Algolia search API.
+        The secured api key will be used to restrict the search results to only those
+        that are associated with the given enterprise catalog query uuids.
+        The secured api key will also be restricted to the given user id.
+        Arguments:
+            user_id (str): The user id to restrict the api key to.
+            enterprise_catalog_query_uuids (list): The enterprise catalog query uuids to restrict the api key to.
+        Returns:
+            dict: A dictionary containing the secured api key and the expiration time.
+            The expiration time is in ISO format.
+        """
+        if not self.algolia_search_api_key:
+            logger.error(
+                'Could not generate secured Algolia API key due to missing Algolia settings: %s',
+                'SEARCH_API_KEY',
+            )
+            raise ImproperlyConfigured(
+                'Cannot generate secured Algolia API key without the ALGOLIA.SEARCH_API_KEY in settings.'
+            )
+
+        expiration_time = getattr(settings, 'SECURED_algolia_api_key_EXPIRATION', 3600)  # Default to 1 hour
+        valid_until = int(time.time()) + expiration_time
+        iso_format = "%Y-%m-%dT%H:%M:%SZ"
+        valid_until_iso = datetime.fromtimestamp(valid_until, tz=timezone.utc).strftime(iso_format)
+        catalog_query_filter = ' OR '.join(
+            [f'enterprise_catalog_query_uuids:{query_uuid}' for query_uuid in enterprise_catalog_query_uuids]
+        )
+
+        # Base secured API key restrictions
+        restrictions = {
+            'filters': catalog_query_filter,
+            'validUntil': valid_until,
+            'userToken': user_id,
+        }
+
+        # Determine indices to restrict
+        indices = []
+        if self.algolia_index_name:
+            indices.append(self.algolia_index_name)
+        if self.algolia_replica_index_name:
+            indices.append(self.algolia_replica_index_name)
+        if indices:
+            restrictions |= {'restrictIndices': indices}
+
+        # Generate secured api key
+        logger.info('[AlgoliaSearchClient.generate_secured_api_key] restrictions: %s', restrictions)
+        try:
+            secured_api_key = SearchClient.generate_secured_api_key(
+                self.algolia_search_api_key,
+                restrictions,
+            )
+        except AlgoliaException as exc:
+            logger.exception('Could not generate secured Algolia API key due to an AlgoliaException.')
+            raise exc
+
+        # Return secured api key and expiration time
+        return {
+            'secured_api_key': secured_api_key,
+            'valid_until': valid_until_iso,
+        }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ click-repl==0.3.0
     # via celery
 code-annotations==2.2.0
     # via edx-toggles
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -109,7 +109,7 @@ django-celery-results==2.5.1
     # via -r requirements/base.in
 django-clearcache==1.2.1
     # via -r requirements/base.in
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via -r requirements/base.in
 django-cors-headers==4.7.0
     # via -r requirements/base.in
@@ -121,7 +121,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-extensions==3.2.3
     # via -r requirements/base.in
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via -r requirements/base.in
 django-log-request-id==2.1.0
     # via -r requirements/base.in
@@ -177,9 +177,9 @@ edx-opaque-keys==2.11.0
     # via edx-drf-extensions
 edx-rbac==1.10.0
     # via -r requirements/base.in
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via -r requirements/base.in
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via -r requirements/base.in
 h11==0.14.0
     # via httpcore
@@ -216,7 +216,7 @@ mysqlclient==2.2.7
     # via -r requirements/base.in
 newrelic==10.6.0
     # via edx-django-utils
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   scikit-learn
     #   scipy
@@ -234,7 +234,7 @@ ply==3.11
     # via djangoql
 prompt-toolkit==3.0.50
     # via click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
@@ -251,7 +251,7 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.in
-pymongo==4.11
+pymongo==4.11.1
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -288,7 +288,7 @@ requests==2.32.3
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via social-auth-core
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
@@ -296,11 +296,11 @@ rules==3.5
     # via -r requirements/base.in
 scikit-learn==1.6.1
     # via -r requirements/base.in
-scipy==1.15.1
+scipy==1.15.2
     # via scikit-learn
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via -r requirements/base.in
 six==1.17.0
     # via
@@ -313,17 +313,17 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.5.3
     # via django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,7 +61,7 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.5.1
+cachetools==5.5.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -138,11 +138,11 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coverage[toml]==7.6.11
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -222,7 +222,7 @@ django-clearcache==1.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -245,7 +245,7 @@ django-extensions==3.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -341,17 +341,17 @@ edx-rbac==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==35.2.0
+faker==36.1.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -443,7 +443,7 @@ kombu==5.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-lxml[html-clean,html_clean]==5.3.0
+lxml[html-clean,html_clean]==5.3.1
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -473,7 +473,7 @@ newrelic==10.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -533,7 +533,7 @@ prompt-toolkit==3.0.50
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -596,7 +596,7 @@ pymemcache==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pymongo==4.11
+pymongo==4.11.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -622,7 +622,7 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -630,7 +630,6 @@ python-dateutil==2.9.0.post0
     #   -r requirements/test.txt
     #   analytics-python
     #   celery
-    #   faker
 python-memcached==1.62
     # via -r requirements/dev.in
 python-slugify==8.0.4
@@ -687,7 +686,7 @@ responses==0.25.6
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -701,7 +700,7 @@ scikit-learn==1.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -711,7 +710,7 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -735,12 +734,12 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -752,7 +751,7 @@ sqlparse==0.5.3
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -792,7 +791,6 @@ typing-extensions==4.12.2
     #   -r requirements/test.txt
     #   anyio
     #   edx-opaque-keys
-    #   faker
     #   openai
     #   pydantic
     #   pydantic-core
@@ -802,6 +800,7 @@ tzdata==2025.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
+    #   faker
     #   kombu
 uritemplate==4.1.1
     # via
@@ -822,7 +821,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -56,7 +56,7 @@ billiard==4.2.1
     # via
     #   -r requirements/test.txt
     #   celery
-cachetools==5.5.1
+cachetools==5.5.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -121,11 +121,11 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coverage[toml]==7.6.11
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -187,7 +187,7 @@ django-celery-results==2.5.1
     # via -r requirements/test.txt
 django-clearcache==1.2.1
     # via -r requirements/test.txt
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via -r requirements/test.txt
 django-cors-headers==4.7.0
     # via -r requirements/test.txt
@@ -201,7 +201,7 @@ django-dynamic-fixture==4.0.1
     # via -r requirements/test.txt
 django-extensions==3.2.3
     # via -r requirements/test.txt
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via -r requirements/test.txt
 django-log-request-id==2.1.0
     # via -r requirements/test.txt
@@ -275,13 +275,13 @@ edx-opaque-keys==2.11.0
     #   edx-drf-extensions
 edx-rbac==1.10.0
     # via -r requirements/test.txt
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via -r requirements/test.txt
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==35.2.0
+faker==36.1.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -369,7 +369,7 @@ newrelic==10.6.0
     #   edx-django-utils
 nh3==0.2.20
     # via readme-renderer
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements/test.txt
     #   scikit-learn
@@ -386,6 +386,7 @@ openai==1.13.3
 packaging==24.2
     # via
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   pyproject-api
     #   pytest
     #   sphinx
@@ -413,7 +414,7 @@ prompt-toolkit==3.0.50
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -429,7 +430,7 @@ pydantic-core==2.27.2
     # via
     #   -r requirements/test.txt
     #   pydantic
-pydata-sphinx-theme==0.16.1
+pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.1
     # via
@@ -468,7 +469,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/test.txt
-pymongo==4.11
+pymongo==4.11.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -487,14 +488,13 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   analytics-python
     #   celery
-    #   faker
 python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
@@ -542,7 +542,9 @@ responses==0.25.6
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
-rpds-py==0.22.3
+roman-numerals-py==3.1.0
+    # via sphinx
+rpds-py==0.23.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -551,7 +553,7 @@ rules==3.5
     # via -r requirements/test.txt
 scikit-learn==1.6.1
     # via -r requirements/test.txt
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   -r requirements/test.txt
     #   scikit-learn
@@ -559,7 +561,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via -r requirements/test.txt
 six==1.17.0
     # via
@@ -577,23 +579,23 @@ sniffio==1.3.1
     #   openai
 snowballstemmer==2.2.0
     # via sphinx
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.1.3
+sphinx==8.2.1
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.1.3
+sphinx-book-theme==1.1.4
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -611,7 +613,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -646,7 +648,6 @@ typing-extensions==4.12.2
     #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
-    #   faker
     #   openai
     #   pydantic
     #   pydantic-core
@@ -656,6 +657,7 @@ tzdata==2025.1
     # via
     #   -r requirements/test.txt
     #   celery
+    #   faker
     #   kombu
 uritemplate==4.1.1
     # via
@@ -673,7 +675,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -84,7 +84,7 @@ code-annotations==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -134,7 +134,7 @@ django-celery-results==2.5.1
     # via -r requirements/base.txt
 django-clearcache==1.2.1
     # via -r requirements/base.txt
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via -r requirements/base.txt
 django-cors-headers==4.7.0
     # via -r requirements/base.txt
@@ -146,7 +146,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-extensions==3.2.3
     # via -r requirements/base.txt
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
@@ -207,9 +207,9 @@ edx-opaque-keys==2.11.0
     #   edx-drf-extensions
 edx-rbac==1.10.0
     # via -r requirements/base.txt
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via -r requirements/base.txt
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via -r requirements/base.txt
 gevent==24.11.1
     # via -r requirements/production.in
@@ -279,7 +279,7 @@ newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -305,7 +305,7 @@ prompt-toolkit==3.0.50
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -331,7 +331,7 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.11
+pymongo==4.11.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -383,7 +383,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -392,7 +392,7 @@ rules==3.5
     # via -r requirements/base.txt
 scikit-learn==1.6.1
     # via -r requirements/base.txt
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -400,7 +400,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -415,11 +415,11 @@ sniffio==1.3.1
     #   -r requirements/base.txt
     #   anyio
     #   openai
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -428,7 +428,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -96,7 +96,7 @@ code-annotations==2.2.0
     #   -r requirements/base.txt
     #   edx-lint
     #   edx-toggles
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -150,7 +150,7 @@ django-celery-results==2.5.1
     # via -r requirements/base.txt
 django-clearcache==1.2.1
     # via -r requirements/base.txt
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via -r requirements/base.txt
 django-cors-headers==4.7.0
     # via -r requirements/base.txt
@@ -162,7 +162,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-extensions==3.2.3
     # via -r requirements/base.txt
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
@@ -227,9 +227,9 @@ edx-opaque-keys==2.11.0
     #   edx-drf-extensions
 edx-rbac==1.10.0
     # via -r requirements/base.txt
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via -r requirements/base.txt
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via -r requirements/base.txt
 h11==0.14.0
     # via
@@ -299,7 +299,7 @@ newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -327,7 +327,7 @@ prompt-toolkit==3.0.50
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -371,7 +371,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.11
+pymongo==4.11.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -422,7 +422,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -431,7 +431,7 @@ rules==3.5
     # via -r requirements/base.txt
 scikit-learn==1.6.1
     # via -r requirements/base.txt
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -439,7 +439,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -457,11 +457,11 @@ sniffio==1.3.1
     #   openai
 snowballstemmer==2.2.0
     # via pydocstyle
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -470,7 +470,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,7 +45,7 @@ billiard==4.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-cachetools==5.5.1
+cachetools==5.5.2
     # via tox
 celery==5.4.0
     # via
@@ -103,11 +103,11 @@ code-annotations==2.2.0
     #   edx-toggles
 colorama==0.4.6
     # via tox
-coverage[toml]==7.6.11
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -164,7 +164,7 @@ django-celery-results==2.5.1
     # via -r requirements/base.txt
 django-clearcache==1.2.1
     # via -r requirements/base.txt
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via -r requirements/base.txt
 django-cors-headers==4.7.0
     # via -r requirements/base.txt
@@ -178,7 +178,7 @@ django-dynamic-fixture==4.0.1
     # via -r requirements/test.in
 django-extensions==3.2.3
     # via -r requirements/base.txt
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
@@ -243,13 +243,13 @@ edx-opaque-keys==2.11.0
     #   edx-drf-extensions
 edx-rbac==1.10.0
     # via -r requirements/base.txt
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via -r requirements/base.txt
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via -r requirements/base.txt
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==35.2.0
+faker==36.1.1
     # via factory-boy
 filelock==3.17.0
     # via
@@ -323,7 +323,7 @@ newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -363,7 +363,7 @@ prompt-toolkit==3.0.50
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -403,7 +403,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.11
+pymongo==4.11.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -419,14 +419,13 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.in
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   analytics-python
     #   celery
-    #   faker
 python-slugify==8.0.4
     # via
     #   -r requirements/base.txt
@@ -469,7 +468,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 responses==0.25.6
     # via -r requirements/test.in
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -478,7 +477,7 @@ rules==3.5
     # via -r requirements/base.txt
 scikit-learn==1.6.1
     # via -r requirements/base.txt
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   -r requirements/base.txt
     #   scikit-learn
@@ -486,7 +485,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -502,11 +501,11 @@ sniffio==1.3.1
     #   -r requirements/base.txt
     #   anyio
     #   openai
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -515,7 +514,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -546,7 +545,6 @@ typing-extensions==4.12.2
     #   -r requirements/base.txt
     #   anyio
     #   edx-opaque-keys
-    #   faker
     #   openai
     #   pydantic
     #   pydantic-core
@@ -555,6 +553,7 @@ tzdata==2025.1
     # via
     #   -r requirements/base.txt
     #   celery
+    #   faker
     #   kombu
 uritemplate==4.1.1
     # via
@@ -572,7 +571,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via tox
 wcwidth==0.2.13
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -57,7 +57,7 @@ billiard==4.2.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-cachetools==5.5.1
+cachetools==5.5.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -132,11 +132,11 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coverage[toml]==7.6.11
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -208,7 +208,7 @@ django-clearcache==1.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-config-models==2.7.0
+django-config-models==2.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -229,7 +229,7 @@ django-extensions==3.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-import-export==4.3.5
+django-import-export==4.3.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -323,17 +323,17 @@ edx-rbac==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-rest-api-client==6.0.0
+edx-rest-api-client==6.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==35.2.0
+faker==36.1.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -436,7 +436,7 @@ newrelic==10.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -486,7 +486,7 @@ prompt-toolkit==3.0.50
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -547,7 +547,7 @@ pymemcache==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pymongo==4.11
+pymongo==4.11.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -568,7 +568,7 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -576,7 +576,6 @@ python-dateutil==2.9.0.post0
     #   -r requirements/test.txt
     #   analytics-python
     #   celery
-    #   faker
 python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
@@ -628,7 +627,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 responses==0.25.6
     # via -r requirements/test.txt
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -642,7 +641,7 @@ scikit-learn==1.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -652,7 +651,7 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.3
+simplejson==3.20.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -676,12 +675,12 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -692,7 +691,7 @@ sqlparse==0.5.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -732,7 +731,6 @@ typing-extensions==4.12.2
     #   -r requirements/test.txt
     #   anyio
     #   edx-opaque-keys
-    #   faker
     #   openai
     #   pydantic
     #   pydantic-core
@@ -742,6 +740,7 @@ tzdata==2025.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
+    #   faker
     #   kombu
 uritemplate==4.1.1
     # via
@@ -762,7 +761,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via
     #   -r requirements/test.txt
     #   tox


### PR DESCRIPTION
**Ticket: [ENT-10079](https://2u-internal.atlassian.net/browse/ENT-10079)**

Adds a new API `GET /api/v1/enterprise-customer/<enterprise_uuid>/secured-algolia-api-key/` to return the following response structure:

```json
{
  "algolia": {
    "secured_api_key": "...",
    "valid_until": "2025-02-28T12:00:00Z"
  },
  "catalog_uuids_to_catalog_query_uuids": {
    "catalog_uuid_1": "catalog_query_uuid_1",
    "catalog_uuid_2": "catalog_query_uuid_2"
  }
}
```

When using this secured Algolia API key to filter Algolia search results for all content available to an enterprise customer, no additional client-side `filters` are needed to be passed as the generated secured Algolia API key itself baked in filtering search results by any `CatalogQuery` associated with the customers' `EnterpriseCatalog` records.

By default, this secured Algolia API key is valid for 1 hour, though it is configurable via the Django setting `SECURED_ALGOLIA_API_KEY_EXPIRATION`. The expiration is returned as an ISO timestamp.

Also included in this API response is a mapping of `EnterpriseCatalog` uuids to their associated `CatalogQuery` uuids. These mappings would be used by frontends when further filtering down all content available to the enterprise customer to a specific catalog, i.e.:
* Determine enterprise catalog UUID associated with a subsidy (e.g., subscription license).
* Find catalog query UUID associated with the above enterprise catalog UUID (discerned through these mappings).
* Add additional `filter` on the frontend for the found catalog query UUID.

![image](https://github.com/user-attachments/assets/14358200-9f7d-4ce7-9ac4-e0a4d28a4857)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
