### PR TITLE
feat: add API endpoint to retrieve secured Algolia API key for an EnterpriseCustomer

### DIFF
--- a/.github/workflows/mysql-migrations-check.yml
+++ b/.github/workflows/mysql-migrations-check.yml
@@ -36,7 +36,7 @@ jobs:
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/pip_tools.txt') }}

--- a/enterprise_catalog/apps/api/base/tests/enterprise_customer_views.py
+++ b/enterprise_catalog/apps/api/base/tests/enterprise_customer_views.py
@@ -64,10 +64,24 @@ class BaseEnterpriseCustomerViewSetTests(APITestMixin):
         )
 
     def _get_content_metadata_base_url(self, enterprise_uuid, content_identifier):
+        """
+        Helper to construct the base url for the customer content metadata endpoint
+        """
         return reverse(
             f'api:{self.VERSION}:customer-content-metadata-retrieve',
             kwargs={
                 'enterprise_uuid': enterprise_uuid,
                 'content_identifier': content_identifier,
+            },
+        )
+
+    def _get_secured_algolia_api_key_base_url(self, enterprise_uuid):
+        """
+        Helper to construct the base url for the secured Algolia API key endpoint
+        """
+        return reverse(
+            f'api:{self.VERSION}:enterprise-customer-secured-algolia-api-key',
+            kwargs={
+                'enterprise_uuid': enterprise_uuid,
             },
         )

--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -87,6 +87,25 @@ def find_and_modify_catalog_query(
         return content_filter_from_hash
 
 
+class BaseSerializer(serializers.Serializer):
+    """
+    Base serializer.
+    """
+    def create(self, *args, **kwargs):
+        return None  # pragma: no cover
+
+    def update(self, *args, **kwargs):
+        return None  # pragma: no cover
+
+
+class BaseErrorSerializer(BaseSerializer):
+    """
+    Base error serializer.
+    """
+    user_message = serializers.CharField()
+    developer_message = serializers.CharField()
+
+
 class CatalogQuerySerializer(serializers.ModelSerializer):
     """
     Serializer for the `CatalogQuery` model
@@ -525,3 +544,28 @@ class JobSerializer(serializers.ModelSerializer):
             "external_id",
             "title"
         ]
+
+
+class SecuredAlgoliaAPIKeySerializer(BaseSerializer):
+    """
+    Serializer for the secured Algolia API key and expiration.
+    """
+    secured_api_key = serializers.CharField()
+    valid_until = serializers.DateTimeField()
+
+
+class SecuredAlgoliaAPIKeyResponseSerializer(BaseSerializer):
+    """
+    Serializer for the response of the secured Algolia API key endpoint.
+    """
+    algolia = SecuredAlgoliaAPIKeySerializer(help_text='Secured Algolia API key and expiration.')
+    catalog_uuids_to_catalog_query_uuids = serializers.DictField(
+        child=serializers.UUIDField(),
+        help_text='Mapping of catalog UUIDs to catalog query UUIDs.',
+    )
+
+
+class SecuredAlgoliaAPIKeyErrorResponseSerializer(BaseErrorSerializer):
+    """
+    Serializer for the error response of the secured Algolia API key endpoint.
+    """

--- a/enterprise_catalog/apps/api/v1/tests/mixins.py
+++ b/enterprise_catalog/apps/api/v1/tests/mixins.py
@@ -96,7 +96,7 @@ class APITestMixin(JwtMixin, APITestCase):
         self.assign_catalog_admin_feature_role()
         self.assign_catalog_admin_jwt_role()
 
-    def set_up_catalog_learner(self):
+    def set_up_catalog_learner(self, enterprise_uuid=None):
         """
         Helper for setting up tests as a catalog learner
         """
@@ -106,7 +106,7 @@ class APITestMixin(JwtMixin, APITestCase):
         self.role_assignment = EnterpriseCatalogRoleAssignmentFactory(
             role=self.role,
             user=self.user,
-            enterprise_id=self.enterprise_uuid
+            enterprise_id=(enterprise_uuid or self.enterprise_uuid)
         )
         self.set_jwt_cookie([(ENTERPRISE_CATALOG_LEARNER_ROLE, self.enterprise_uuid)])
 

--- a/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
@@ -515,7 +515,7 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
         """
         url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         expected_error_response = {
             'user_message': 'Error generating secured Algolia API key.',
             'developer_message': (
@@ -535,7 +535,7 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
         """
         url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         expected_error_response = {
             'user_message': 'Error generating secured Algolia API key.',
             'developer_message': 'Mocked exception',
@@ -550,7 +550,7 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
         self.set_up_catalog_learner(enterprise_uuid=fake_enterprise_uuid)
         url = self._get_secured_algolia_api_key_base_url(enterprise_uuid=fake_enterprise_uuid)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         expected_error_response = {
             'user_message': 'Error generating secured Algolia API key.',
             'developer_message': 'No enterprise catalogs found for the specified enterprise customer.',
@@ -569,7 +569,7 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
         self.set_up_catalog_learner(enterprise_uuid=fake_enterprise_uuid)
         url = self._get_secured_algolia_api_key_base_url(enterprise_uuid=fake_enterprise_uuid)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         expected_error_response = {
             'user_message': 'Error generating secured Algolia API key.',
             'developer_message': 'No catalog queries found for the specified enterprise customer.',

--- a/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytz
+from algoliasearch.exceptions import AlgoliaException
+from django.test import override_settings
 from rest_framework import status
 
 from enterprise_catalog.apps.api.base.tests.enterprise_customer_views import (
@@ -470,3 +472,106 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
 
         # response should only contain content keys found in the "second_catalog"
         self.assertEqual(response.get('filtered_content_keys'), [relevant_content_key])
+
+    @override_settings(
+        ALGOLIA={
+            'APPLICATION_ID': 'fake-app-id',
+            'API_KEY': 'fake-api-key',
+            'SEARCH_API_KEY': 'fake-search-api-key',
+            'INDEX_NAME': 'fake-index',
+            'REPLICA_INDEX_NAME': 'fake-replica-index',
+        },
+    )
+    def test_secured_algolia_api_key_generation(self):
+        """
+        Test that the secured Algolia API key is generated correctly.
+        """
+        url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_catalog_to_catalog_query_mappings = {
+            str(self.enterprise_catalog.uuid): str(self.enterprise_catalog.catalog_query.uuid),
+        }
+        self.assertIsInstance(response.data['algolia']['secured_api_key'], str)
+        self.assertTrue(bool(response.data['algolia']['secured_api_key']))  # Ensures the string isn't empty
+
+        # Validate ISO format for valid_until
+        valid_until = response.data['algolia']['valid_until']
+        try:
+            datetime.fromisoformat(valid_until)
+        except ValueError:  # pragma: no cover
+            self.fail(f"Invalid ISO format for valid_until: {valid_until}")
+
+        # Validate catalog uuids to catalog query uuids mapping
+        self.assertEqual(
+            response.data['catalog_uuids_to_catalog_query_uuids'],
+            expected_catalog_to_catalog_query_mappings,
+        )
+
+    @override_settings(ALGOLIA={})
+    def test_secured_algolia_api_key_missing_search_api_key(self):
+        """
+        Test that the secured Algolia API key is not generated if the search API key is missing.
+        """
+        url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': (
+                'Cannot generate secured Algolia API key without the ALGOLIA.SEARCH_API_KEY in settings.'
+            ),
+        }
+        self.assertEqual(response.data, expected_error_response)
+
+    @mock.patch(
+        "algoliasearch.search_client.SearchClient.generate_secured_api_key",
+        side_effect=AlgoliaException("Mocked exception"),
+    )
+    @override_settings(ALGOLIA={'SEARCH_API_KEY': 'fake-search-api-search'})
+    def test_secured_algolia_api_key_algolia_exception(self, mock_generate_key):  # pylint: disable=unused-argument
+        """
+        Test that the secured Algolia API key is not generated if an AlgoliaException occurs.
+        """
+        url = self._get_secured_algolia_api_key_base_url(self.enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': 'Mocked exception',
+        }
+        self.assertEqual(response.data, expected_error_response)
+
+    def test_secured_algolia_api_key_no_catalogs(self):
+        """
+        Test that the secured Algolia API key is not generated if there are no catalogs.
+        """
+        fake_enterprise_uuid = uuid.uuid4()
+        self.set_up_catalog_learner(enterprise_uuid=fake_enterprise_uuid)
+        url = self._get_secured_algolia_api_key_base_url(enterprise_uuid=fake_enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': 'No enterprise catalogs found for the specified enterprise customer.',
+        }
+        self.assertEqual(response.data, expected_error_response)
+
+    def test_secured_algolia_api_key_no_catalog_queries(self):
+        """
+        Test that the secured Algolia API key is not generated if there are no catalog queries.
+        """
+        fake_enterprise_uuid = uuid.uuid4()
+        EnterpriseCatalogFactory(
+            enterprise_uuid=fake_enterprise_uuid,
+            catalog_query=None,  # Ensure no catalog query is associated with the catalog
+        )
+        self.set_up_catalog_learner(enterprise_uuid=fake_enterprise_uuid)
+        url = self._get_secured_algolia_api_key_base_url(enterprise_uuid=fake_enterprise_uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        expected_error_response = {
+            'user_message': 'Error generating secured Algolia API key.',
+            'developer_message': 'No catalog queries found for the specified enterprise customer.',
+        }
+        self.assertEqual(response.data, expected_error_response)

--- a/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
@@ -6,10 +6,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from edx_rbac.utils import get_decoded_jwt
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.response import Response
-from rest_framework.status import HTTP_400_BAD_REQUEST
 
 from enterprise_catalog.apps.api.v1.decorators import (
     require_at_least_one_query_parameter,
@@ -119,7 +119,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             )
             return Response(
                 f'Error: invalid enterprice customer uuid: "{enterprise_uuid}" provided.',
-                status=HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST
             )
         customer_catalogs = EnterpriseCatalog.objects.filter(enterprise_uuid=enterprise_uuid)
 
@@ -268,7 +268,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             }
             return Response(
                 SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
-                status=HTTP_400_BAD_REQUEST,
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         catalog_query_uuids = [
@@ -286,7 +286,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             }
             return Response(
                 SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
-                status=HTTP_400_BAD_REQUEST,
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
 
         # Create a mapping of catalog UUIDs to their corresponding catalog query UUIDs
@@ -304,7 +304,8 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             )
         except ImproperlyConfigured as exc:
             logger.exception(
-                f'Secured Algolia API key generation failed for enterprise UUID {enterprise_uuid}'
+                f'Could not attempt generation of secured Algolia API key for '
+                f'enterprise UUID {enterprise_uuid} due to improper configuration.'
             )
             error_response = {
                 'user_message': algolia_api_key_error_message,
@@ -312,7 +313,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             }
             return Response(
                 SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
-                status=HTTP_400_BAD_REQUEST,
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
         except AlgoliaException as exc:
             logger.exception(
@@ -324,7 +325,7 @@ class EnterpriseCustomerViewSet(BaseViewSet):
             }
             return Response(
                 SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
-                status=HTTP_400_BAD_REQUEST,
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
 
         # Serialize the response data

--- a/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
@@ -1,7 +1,10 @@
 import logging
 import uuid
 
+from algoliasearch.exceptions import AlgoliaException
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import method_decorator
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from edx_rbac.utils import get_decoded_jwt
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied
@@ -11,9 +14,14 @@ from rest_framework.status import HTTP_400_BAD_REQUEST
 from enterprise_catalog.apps.api.v1.decorators import (
     require_at_least_one_query_parameter,
 )
-from enterprise_catalog.apps.api.v1.serializers import ContentMetadataSerializer
+from enterprise_catalog.apps.api.v1.serializers import (
+    ContentMetadataSerializer,
+    SecuredAlgoliaAPIKeyErrorResponseSerializer,
+    SecuredAlgoliaAPIKeyResponseSerializer,
+)
 from enterprise_catalog.apps.api.v1.utils import unquote_course_keys
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
+from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
 
 
@@ -209,3 +217,122 @@ class EnterpriseCustomerViewSet(BaseViewSet):
         """
         serializer = self.get_metadata_item_serializer()
         return Response(serializer.data)
+
+    @extend_schema(
+        summary='Get secured Algolia API key for enterprise customer',
+        description='Returns a secured Algolia API key for the given enterprise UUID. '
+                    'The key can be used within frontends to access Algolia search API, '
+                    'restricted with the enterprise\'s available catalog query UUIDs.',
+        responses={
+            200: SecuredAlgoliaAPIKeyResponseSerializer,
+            400: SecuredAlgoliaAPIKeyErrorResponseSerializer,
+        },
+        tags=['Enterprise Customer'],
+        examples=[
+            OpenApiExample(
+                'Secured Algolia API Key Response',
+                value={
+                    'algolia': {
+                        'secured_api_key': '...',
+                        'valid_until': '2025-02-28T12:00:00Z',
+                    },
+                    'catalog_uuids_to_catalog_query_uuids': {
+                        'catalog_uuid_1': 'catalog_query_uuid_1',
+                        'catalog_uuid_2': 'catalog_query_uuid_2',
+                    },
+                },
+            ),
+        ]
+    )
+    @action(detail=True, methods=['get'], url_path='secured-algolia-api-key')
+    def secured_algolia_api_key(self, request, enterprise_uuid, **kwargs):
+        """
+        Returns a secured Algolia API key for the given enterprise UUID.
+        The key can be used within frontends to access Algolia search API,
+        restricted with the enterprise's available catalog query UUIDs.
+        """
+        # Fetch all EnterpriseCatalogs associated with the given enterprise_uuid
+        enterprise_catalogs = EnterpriseCatalog.objects.filter(
+            enterprise_uuid=enterprise_uuid
+        ).select_related('catalog_query')
+        algolia_api_key_error_message = 'Error generating secured Algolia API key.'
+
+        # Return an error response if no EnterpriseCatalogs are found
+        if not enterprise_catalogs:
+            logger.error(
+                f'No enterprise catalogs found for the given enterprise UUID: {enterprise_uuid}.'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': 'No enterprise catalogs found for the specified enterprise customer.',
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        catalog_query_uuids = [
+            enterprise_catalog.catalog_query.uuid for enterprise_catalog in enterprise_catalogs
+            if enterprise_catalog.catalog_query
+        ]
+        # Return an error response if no CatalogQueries are found
+        if not catalog_query_uuids:
+            logger.error(
+                f'No catalog queries found for the given enterprise UUID: {enterprise_uuid}.'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': 'No catalog queries found for the specified enterprise customer.'
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        # Create a mapping of catalog UUIDs to their corresponding catalog query UUIDs
+        catalog_uuids_to_catalog_query_uuids = {
+            str(catalog.uuid): str(catalog.catalog_query.uuid) if catalog.catalog_query else None
+            for catalog in enterprise_catalogs
+        }
+
+        # Generate a secured Algolia API key using the AlgoliaSearchClient
+        algolia_client = AlgoliaSearchClient()
+        try:
+            result = algolia_client.generate_secured_api_key(
+                user_id=request.user.id,
+                enterprise_catalog_query_uuids=catalog_query_uuids,
+            )
+        except ImproperlyConfigured as exc:
+            logger.exception(
+                f'Secured Algolia API key generation failed for enterprise UUID {enterprise_uuid}'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': exc,
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+        except AlgoliaException as exc:
+            logger.exception(
+                f'Secured Algolia API key generation failed for enterprise UUID {enterprise_uuid}'
+            )
+            error_response = {
+                'user_message': algolia_api_key_error_message,
+                'developer_message': exc
+            }
+            return Response(
+                SecuredAlgoliaAPIKeyErrorResponseSerializer(error_response).data,
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        # Serialize the response data
+        response_data = {
+            'algolia': {
+                'secured_api_key': result.get('secured_api_key'),
+                'valid_until': result.get('valid_until'),
+            },
+            'catalog_uuids_to_catalog_query_uuids': catalog_uuids_to_catalog_query_uuids,
+        }
+        return Response(SecuredAlgoliaAPIKeyResponseSerializer(response_data).data)

--- a/enterprise_catalog/apps/api/v2/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v2/views/enterprise_customer.py
@@ -1,5 +1,7 @@
 import logging
 
+from rest_framework.decorators import action
+
 from enterprise_catalog.apps.api.v1.views.enterprise_customer import (
     EnterpriseCustomerViewSet,
 )
@@ -38,3 +40,10 @@ class EnterpriseCustomerViewSetV2(EnterpriseCustomerViewSet):
 
     def contains_content_keys(self, catalog, content_keys):
         return catalog.contains_content_keys(content_keys, include_restricted=True)
+
+    @action(detail=False, methods=['get'], url_path='secured-algolia-api-key')
+    def secured_algolia_api_key(self, request, enterprise_uuid, **kwargs):
+        """
+        There is no V2 version of this endpoint.
+        """
+        raise NotImplementedError('This endpoint is not available in V2.')  # pragma: no cover

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -226,7 +226,7 @@ class AlgoliaSearchClient:
                 'Cannot generate secured Algolia API key without the ALGOLIA.SEARCH_API_KEY in settings.'
             )
 
-        expiration_time = getattr(settings, 'SECURED_algolia_api_key_EXPIRATION', 3600)  # Default to 1 hour
+        expiration_time = getattr(settings, 'SECURED_ALGOLIA_API_KEY_EXPIRATION', 3600)  # Default to 1 hour
         valid_until = int(time.time()) + expiration_time
         iso_format = "%Y-%m-%dT%H:%M:%SZ"
         valid_until_iso = datetime.fromtimestamp(valid_until, tz=timezone.utc).strftime(iso_format)

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -3,13 +3,14 @@ Algolia api client code.
 """
 
 import logging
-import time
-from datetime import datetime, timezone
+from datetime import timedelta
 
 from algoliasearch.exceptions import AlgoliaException
 from algoliasearch.search_client import SearchClient
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
+from enterprise_catalog.apps.catalog.utils import localized_utcnow
 
 
 logger = logging.getLogger(__name__)
@@ -227,9 +228,9 @@ class AlgoliaSearchClient:
             )
 
         expiration_time = getattr(settings, 'SECURED_ALGOLIA_API_KEY_EXPIRATION', 3600)  # Default to 1 hour
-        valid_until = int(time.time()) + expiration_time
+        valid_until = localized_utcnow() + timedelta(seconds=expiration_time)
         iso_format = "%Y-%m-%dT%H:%M:%SZ"
-        valid_until_iso = datetime.fromtimestamp(valid_until, tz=timezone.utc).strftime(iso_format)
+        valid_until_iso = valid_until.strftime(iso_format)
         catalog_query_filter = ' OR '.join(
             [f'enterprise_catalog_query_uuids:{query_uuid}' for query_uuid in enterprise_catalog_query_uuids]
         )

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -3,10 +3,13 @@ Algolia api client code.
 """
 
 import logging
+import time
+from datetime import datetime, timezone
 
 from algoliasearch.exceptions import AlgoliaException
 from algoliasearch.search_client import SearchClient
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
 logger = logging.getLogger(__name__)
@@ -17,42 +20,69 @@ class AlgoliaSearchClient:
     Object builds an API client to make calls to an Algolia index.
     """
 
-    ALGOLIA_APPLICATION_ID = settings.ALGOLIA.get('APPLICATION_ID')
-    ALGOLIA_API_KEY = settings.ALGOLIA.get('API_KEY')
-    ALGOLIA_INDEX_NAME = settings.ALGOLIA.get('INDEX_NAME')
-    ALGOLIA_REPLICA_INDEX_NAME = settings.ALGOLIA.get('REPLICA_INDEX_NAME')
-
     def __init__(self):
         self._client = None
         self.algolia_index = None
         self.replica_index = None
 
+    @property
+    def algolia_application_id(self):
+        return settings.ALGOLIA.get('APPLICATION_ID')
+
+    @property
+    def algolia_api_key(self):
+        return settings.ALGOLIA.get('API_KEY')
+
+    @property
+    def algolia_search_api_key(self):
+        return settings.ALGOLIA.get('SEARCH_API_KEY')
+
+    @property
+    def algolia_index_name(self):
+        return settings.ALGOLIA.get('INDEX_NAME')
+
+    @property
+    def algolia_replica_index_name(self):
+        return settings.ALGOLIA.get('REPLICA_INDEX_NAME')
+
     def init_index(self):
         """
         Initializes an index within Algolia. Initializing an index will create it if it doesn't exist.
         """
-        if not self.ALGOLIA_INDEX_NAME or not self.ALGOLIA_REPLICA_INDEX_NAME:
+        if not self.algolia_index_name or not self.algolia_replica_index_name:
             logger.error('Could not initialize Algolia index due to missing index name.')
             return
 
-        if not self.ALGOLIA_APPLICATION_ID or not self.ALGOLIA_API_KEY:
+        if not self.algolia_application_id or not self.algolia_api_key:
             logger.error(
                 'Could not initialize Algolia\'s %s index due to missing Algolia settings: %s',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
                 ['APPLICATION_ID', 'API_KEY'],
             )
             return
 
-        self._client = SearchClient.create(self.ALGOLIA_APPLICATION_ID, self.ALGOLIA_API_KEY)
-        try:
-            self.algolia_index = self._client.init_index(self.ALGOLIA_INDEX_NAME)
-            self.replica_index = self._client.init_index(self.ALGOLIA_REPLICA_INDEX_NAME)
-        except AlgoliaException as exc:
-            logger.exception(
-                'Could not initialize %s index in Algolia due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
-            )
-            raise exc
+        # Create SearchClient
+        self._client = SearchClient.create(self.algolia_application_id, self.algolia_api_key)
+
+        # Initialize Algolia indices
+        if self.algolia_index_name:
+            try:
+                self.algolia_index = self._client.init_index(self.algolia_index_name)
+            except AlgoliaException as exc:
+                logger.exception(
+                    'Could not initialize %s index in Algolia due to an exception.',
+                    self.algolia_index_name,
+                )
+                raise exc
+        if self.algolia_replica_index_name:
+            try:
+                self.replica_index = self._client.init_index(self.algolia_replica_index_name)
+            except AlgoliaException as exc:
+                logger.exception(
+                    'Could not initialize %s index in Algolia due to an exception.',
+                    self.algolia_replica_index_name,
+                )
+                raise exc
 
     def set_index_settings(self, index_settings, primary_index=True):
         """
@@ -76,7 +106,7 @@ class AlgoliaSearchClient:
         except AlgoliaException as exc:
             logger.exception(
                 'Unable to set settings for Algolia\'s %s index due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
             raise exc
 
@@ -93,12 +123,12 @@ class AlgoliaSearchClient:
         if not primary_exists:
             logger.warning(
                 'Index with name %s does not exist in Algolia.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
         if not replica_exists:
             logger.warning(
                 'Index with name %s does not exist in Algolia.',
-                self.ALGOLIA_REPLICA_INDEX_NAME,
+                self.algolia_replica_index_name,
             )
 
         return primary_exists and replica_exists
@@ -121,11 +151,11 @@ class AlgoliaSearchClient:
             self.algolia_index.replace_all_objects(algolia_objects, {
                 'safe': True,  # wait for asynchronous indexing operations to complete
             })
-            logger.info('The %s Algolia index was successfully indexed.', self.ALGOLIA_INDEX_NAME)
+            logger.info('The %s Algolia index was successfully indexed.', self.algolia_index_name)
         except AlgoliaException as exc:
             logger.exception(
                 'Could not index objects in the %s Algolia index due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
             raise exc
 
@@ -164,12 +194,75 @@ class AlgoliaSearchClient:
             self.algolia_index.delete_objects(object_ids)
             logger.info(
                 'The following objects were successfully removed from the %s Algolia index: %s',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
                 object_ids,
             )
         except AlgoliaException as exc:
             logger.exception(
                 'Could not remove objects from the %s Algolia index due to an exception.',
-                self.ALGOLIA_INDEX_NAME,
+                self.algolia_index_name,
             )
             raise exc
+
+    def generate_secured_api_key(self, user_id, enterprise_catalog_query_uuids):
+        """
+        Generates a secured api key for the Algolia search API.
+        The secured api key will be used to restrict the search results to only those
+        that are associated with the given enterprise catalog query uuids.
+        The secured api key will also be restricted to the given user id.
+        Arguments:
+            user_id (str): The user id to restrict the api key to.
+            enterprise_catalog_query_uuids (list): The enterprise catalog query uuids to restrict the api key to.
+        Returns:
+            dict: A dictionary containing the secured api key and the expiration time.
+            The expiration time is in ISO format.
+        """
+        if not self.algolia_search_api_key:
+            logger.error(
+                'Could not generate secured Algolia API key due to missing Algolia settings: %s',
+                'SEARCH_API_KEY',
+            )
+            raise ImproperlyConfigured(
+                'Cannot generate secured Algolia API key without the ALGOLIA.SEARCH_API_KEY in settings.'
+            )
+
+        expiration_time = getattr(settings, 'SECURED_algolia_api_key_EXPIRATION', 3600)  # Default to 1 hour
+        valid_until = int(time.time()) + expiration_time
+        iso_format = "%Y-%m-%dT%H:%M:%SZ"
+        valid_until_iso = datetime.fromtimestamp(valid_until, tz=timezone.utc).strftime(iso_format)
+        catalog_query_filter = ' OR '.join(
+            [f'enterprise_catalog_query_uuids:{query_uuid}' for query_uuid in enterprise_catalog_query_uuids]
+        )
+
+        # Base secured API key restrictions
+        restrictions = {
+            'filters': catalog_query_filter,
+            'validUntil': valid_until,
+            'userToken': user_id,
+        }
+
+        # Determine indices to restrict
+        indices = []
+        if self.algolia_index_name:
+            indices.append(self.algolia_index_name)
+        if self.algolia_replica_index_name:
+            indices.append(self.algolia_replica_index_name)
+        if indices:
+            restrictions |= {'restrictIndices': indices}
+
+        # Generate secured api key
+        logger.info('[AlgoliaSearchClient.generate_secured_api_key] restrictions: %s', restrictions)
+        try:
+            secured_api_key = SearchClient.generate_secured_api_key(
+                self.algolia_search_api_key,
+                restrictions,
+            )
+        except AlgoliaException as exc:
+            logger.exception('Could not generate secured Algolia API key due to an AlgoliaException.')
+            raise exc
+
+        # Return secured api key and expiration time
+        return {
+            'secured_api_key': secured_api_key,
+            'valid_until': valid_until_iso,
+        }

--- a/enterprise_catalog/apps/catalog/utils.py
+++ b/enterprise_catalog/apps/catalog/utils.py
@@ -3,7 +3,7 @@ Utility functions for catalog app.
 """
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import getLogger
 from urllib.parse import urljoin
 
@@ -15,7 +15,6 @@ from edx_rest_framework_extensions.auth.jwt.authentication import (
 )
 from edx_rest_framework_extensions.auth.jwt.cookies import \
     get_decoded_jwt as get_decoded_jwt_from_cookie
-from pytz import UTC
 
 from enterprise_catalog.apps.catalog.constants import COURSE_RUN
 
@@ -107,7 +106,7 @@ def batch(iterable, batch_size=1):
 
 def localized_utcnow():
     """Helper function to return localized utcnow()."""
-    return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter
+    return datetime.now(timezone.utc)
 
 
 def enterprise_proxy_login_url(slug, next_url=None):


### PR DESCRIPTION
**Ticket: [ENT-10079](https://2u-internal.atlassian.net/browse/ENT-10079)**

Adds a new API `GET /api/v1/enterprise-customer/<enterprise_uuid>/secured-algolia-api-key/` to return the following response structure:

```json
{
  "algolia": {
    "secured_api_key": "...",
    "valid_until": "2025-02-28T12:00:00Z"
  },
  "catalog_uuids_to_catalog_query_uuids": {
    "catalog_uuid_1": "catalog_query_uuid_1",
    "catalog_uuid_2": "catalog_query_uuid_2"
  }
}
```

When using this secured Algolia API key to filter Algolia search results for all content available to an enterprise customer, no additional client-side `filters` are needed to be passed as the generated secured Algolia API key itself baked in filtering search results by any `CatalogQuery` associated with the customers' `EnterpriseCatalog` records.

By default, this secured Algolia API key is valid for 1 hour, though it is configurable via the Django setting `SECURED_ALGOLIA_API_KEY_EXPIRATION`. The expiration is returned as an ISO timestamp.

Also included in this API response is a mapping of `EnterpriseCatalog` uuids to their associated `CatalogQuery` uuids. These mappings would be used by frontends when further filtering down all content available to the enterprise customer to a specific catalog, i.e.:
* Determine enterprise catalog UUID associated with a subsidy (e.g., subscription license).
* Find catalog query UUID associated with the above enterprise catalog UUID (discerned through these mappings).
* Add additional `filter` on the frontend for the found catalog query UUID.

![image](https://github.com/user-attachments/assets/e2410867-c1a6-4dea-8ae2-be039e7dddc9)


## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
