### PR TITLE
fix: allow periods in pk lookup_value_regex for ContentMetadataView

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2321,6 +2321,25 @@ class ContentMetadataViewTests(APITestMixin):
         )
         assert response_json.get('key') == expected_object_to_receive.content_key
 
+    def test_retrieve_success_with_content_key_containing_period(self):
+        """
+        Test a successful, expected api response for the metadata fetch endpoint given a content key containing
+        a period.
+        """
+        content_key_with_period = 'foo.bar'
+        ContentMetadataFactory(
+            content_type=COURSE,
+            content_key=content_key_with_period,
+            json_metadata={'key': content_key_with_period},
+        )
+        url = reverse(
+            'api:v1:content-metadata-detail',
+            kwargs={'pk': content_key_with_period}
+        )
+        response = self.client.get(url)
+        response_json = response.json()
+        assert response_json.get('key') == content_key_with_period
+
 
 @ddt.ddt
 class CatalogQueryViewTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/views/content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/content_metadata.py
@@ -43,6 +43,7 @@ class ContentMetadataView(viewsets.ReadOnlyModelViewSet):
     """
     View for retrieving and listing base content metadata.
     """
+    lookup_value_regex = r'[^/]+'  # Allow any non-slash character in the pk (including periods).
     serializer_class = ContentMetadataSerializer
     authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-10109

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
