### PR TITLE
fix: fix task-locking bug related to django-celery-results and protocol 2

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -112,8 +112,8 @@ class TestTaskResultFunctions(TestCase):
 
         self.mock_task_result = TaskResult.objects.create(
             task_name=mock_task.name,
-            task_args=json.dumps(self.test_args),
-            task_kwargs=json.dumps(self.test_kwargs),
+            task_args=json.dumps(repr(self.test_args)),
+            task_kwargs=json.dumps(repr(self.test_kwargs)),
             status=states.SUCCESS,
             # Default to a state where the only recorded task result is for some "other" task
             task_id=self.other_task_id,
@@ -133,14 +133,14 @@ class TestTaskResultFunctions(TestCase):
         return mock_task(bound_task_object, *args, **kwargs)
 
     def test_semaphore_raises_recent_run_error_for_same_args(self):
-        self.mock_task_result.task_kwargs = '{}'
+        self.mock_task_result.task_kwargs = json.dumps(repr({}))
         self.mock_task_result.save()
 
         with self.assertRaises(tasks.TaskRecentlyRunError):
             self.mock_task_instance(*self.test_args)
 
     def test_semaphore_raises_recent_run_error_for_same_kwargs(self):
-        self.mock_task_result.task_args = '[]'
+        self.mock_task_result.task_args = json.dumps(repr(()))
         self.mock_task_result.save()
 
         with self.assertRaises(tasks.TaskRecentlyRunError):


### PR DESCRIPTION
ENT-10143: fixes TaskResult query inside task_recently_run(). We recently switched to celery protocol 2, and django-celery-results gives preference to `kwargsrepr` over `kwargs` (and similar for args/argsrepr) when persisting results. So we have to json-serialize the repr() of the task args/kwargs in order for our lookup of recent tasks with the same name and input. This is ok to do because none of the task invocations in this code repo specify a custom args/kwargsrepr when submitting tasks, and celery uses the repr() function as the default.
https://2u-internal.atlassian.net/browse/ENT-10143
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
