### PR TITLE
docs: add schema documentation for GET /enterprise-catalogs/{catalog_id}

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
 from rest_framework.renderers import JSONRenderer
@@ -73,6 +74,25 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         response.data['enterprise_customer'] = self.enterprise_catalog.enterprise_uuid
         return response
 
+    @extend_schema(
+        description="GET calls to the `enterprise-catalogs/{catalog_id}` endpoint return a list of all of the active courses in a specified course catalog."
+        "You can then make a GET call to the `/enterprise-catalogs/{catalog_id}/courses/{course_key}` endpoint to return details about a single course.",
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="A page number within the paginated result.",
+            ),
+            OpenApiParameter(
+                name="page_size",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="Number of results to return per page.",
+            ),
+        ],
+        responses={200: ContentMetadataSerializer(many=True)},
+    )
     @action(detail=True)
     def get(self, request, **kwargs):
         """

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from edx_rest_framework_extensions.paginators import DefaultPagination
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
 from rest_framework.renderers import JSONRenderer
@@ -82,6 +83,12 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         ),
         parameters=[
             OpenApiParameter(
+                name="content_keys",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description="A list of content keys to filter the results. If not provided, all content metadata is returned.",
+            ),
+            OpenApiParameter(
                 name="page",
                 type=int,
                 location=OpenApiParameter.QUERY,
@@ -91,7 +98,8 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
                 name="page_size",
                 type=int,
                 location=OpenApiParameter.QUERY,
-                description="Number of results to return per page.",
+                description=f"Number of results to return per page. Defaults to {DefaultPagination.page_size}. "
+                f"Maximum value is {DefaultPagination.max_page_size}.",
             ),
         ],
         responses={200: ContentMetadataSerializer(many=True)},

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -12,9 +12,6 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework_xml.renderers import XMLRenderer
 
-from enterprise_catalog.apps.api.v1.pagination import (
-    PageNumberWithSizePagination,
-)
 from enterprise_catalog.apps.api.v1.serializers import ContentMetadataSerializer
 from enterprise_catalog.apps.api.v1.utils import is_any_course_run_active
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -86,7 +86,10 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
                 name="content_keys",
                 type=str,
                 location=OpenApiParameter.QUERY,
-                description="A list of content keys to filter the results. If not provided, all content metadata is returned.",
+                description=(
+                    "A list of content keys to filter the results. "
+                    "If not provided, all content metadata is returned."
+                ),
             ),
             OpenApiParameter(
                 name="page",

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -29,7 +29,7 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
     serializer_class = ContentMetadataSerializer
     renderer_classes = [JSONRenderer, XMLRenderer]
     lookup_field = 'uuid'
-    pagination_class = PageNumberWithSizePagination
+    pagination_class = DefaultPagination
     MAX_GET_CONTENT_KEYS = 100
 
     @cached_property

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -75,8 +75,11 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         return response
 
     @extend_schema(
-        description="GET calls to the `enterprise-catalogs/{catalog_id}` endpoint return a list of all of the active courses in a specified course catalog."
-        "You can then make a GET call to the `/enterprise-catalogs/{catalog_id}/courses/{course_key}` endpoint to return details about a single course.",
+        description=(
+            "GET calls to the `enterprise-catalogs/{catalog_id}` endpoint return a list of all of the active courses "
+            "in a specified course catalog. You can then make a GET call to the "
+            "`/enterprise-catalogs/{catalog_id}/courses/{course_key}` endpoint to return details about a single course."
+        ),
         parameters=[
             OpenApiParameter(
                 name="page",


### PR DESCRIPTION
Improves documentation for the GET /enterprise/v2/enterprise-catalogs/{uuid} endpoint. This change enhances the OpenAPI schema by:
-   Explicitly documenting the 'page' and 'page_size' query parameters via the @extend_schema decorator.


#### Jira:
[limit parameter is not working on the catalog discovery query](https://2u-internal.atlassian.net/browse/ENT-10015)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
