### PR TITLE
chore: Allow logging format to be overridden

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -297,8 +297,11 @@ LOGIN_REDIRECT_URL = '/api-docs/'
 PLATFORM_NAME = 'Your Platform Name Here'
 # END OPENEDX-SPECIFIC CONFIGURATION
 
+# Override the default logging format string (default defined within utils.py).
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", None)
+
 # Set up logging for development use (logging to stdout)
-LOGGING = get_logger_config(debug=DEBUG, dev_env=True)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 EXTRA_APPS = []
 CERTIFICATE_LANGUAGES = {

--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -19,8 +19,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 ALLOWED_HOSTS = ['*']
 
-LOGGING = get_logger_config()
-
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)
@@ -50,6 +48,9 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
     vars().update(FILE_STORAGE_BACKEND)
     vars().update(MEDIA_STORAGE_BACKEND)
 
+# Must be generated after loading config YAML because LOGGING_FORMAT_STRING might be overridden.
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
+
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),
     ENGINE=environ.get('DB_MIGRATION_ENGINE', DATABASES['default']['ENGINE']),
@@ -59,8 +60,8 @@ DB_OVERRIDES = dict(
     PORT=environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
 )
 
+# BEGIN CELERY
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
-
 CELERY_BROKER_URL = "{}://{}:{}@{}/{}".format(
     CELERY_BROKER_TRANSPORT,
     CELERY_BROKER_USER,
@@ -69,6 +70,7 @@ CELERY_BROKER_URL = "{}://{}:{}@{}/{}".format(
     CELERY_BROKER_VHOST
 )
 CELERY_RESULT_BACKEND = 'django-db'
+# END CELERY
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value

--- a/enterprise_catalog/settings/utils.py
+++ b/enterprise_catalog/settings/utils.py
@@ -14,18 +14,24 @@ def get_env_setting(setting):
         error_msg = "Set the [%s] env variable!" % setting
         raise ImproperlyConfigured(error_msg)
 
-def get_logger_config(log_dir='/var/tmp',
-                      logging_env="no_env",
-                      edx_filename="edx.log",
-                      dev_env=False,
-                      debug=False,
-                      service_variant='enterprise-catalog'):
+
+def get_logger_config(
+    logging_env: str = "no_env",
+    debug: bool = False,
+    service_variant: str = 'enterprise-catalog',
+    format_string: str = None,
+):
     """
-    Return the appropriate logging config dictionary. You should assign the
-    result of this to the LOGGING var in your settings.
-    If dev_env is set to true logging will not be done via local rsyslogd,
-    instead, application logs will be dropped in log_dir.
-    "edx_filename" is ignored unless dev_env is set to true since otherwise logging is handled by rsyslogd.
+    Return the appropriate logging config dictionary, to be assigned to the LOGGING var in settings.
+
+    Arguments:
+        logging_env (str): Environment name.
+        debug (bool): Debug logging enabled.
+        service_variant (str): Name of the service.
+        format_string (str): Override format string for your logfiles.
+
+    Returns:
+        dict(string): Returns a dictionary of config values
     """
 
     hostname = platform.node().split(".")[0]
@@ -41,13 +47,17 @@ def get_logger_config(log_dir='/var/tmp',
 
     handlers = ['console']
 
+    standard_format = format_string or (
+        '%(asctime)s %(levelname)s %(process)d '
+        '[request_id %(request_id)s] [%(name)s] %(filename)s:%(lineno)d - %(message)s'
+    )
+
     logger_config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
             'standard': {
-                'format': '%(asctime)s %(levelname)s %(process)d '
-                          '[request_id %(request_id)s] [%(name)s] %(filename)s:%(lineno)d - %(message)s',
+                'format': standard_format,
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},


### PR DESCRIPTION
Allow logging format to be overridden via LOGGING_FORMAT_STRING.

ENT-10092