### PR TITLE
[ENT-10198] - fix: don't filter out courses if content_keys are provided

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -158,8 +158,14 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         """
         queryset = self.filter_queryset(self.get_queryset(content_keys_filter=content_keys_filter))
         logger.debug(f'[get_content_metadata]: Original queryset length: {len(queryset)}, {self.enterprise_catalog}')
-        queryset = [item for item in queryset if self.is_active(item)]
-        logger.debug(f'[get_content_metadata]: Filtered queryset length: {len(queryset)}, {self.enterprise_catalog}')
+
+        # Only filter out archived courses if content_keys_filter is not provided,
+        # to ensure active content is always returned
+        if not content_keys_filter:
+            queryset = [item for item in queryset if self.is_active(item)]
+            filtered_queryset_length = len(queryset)
+            logger.debug(f'[get_content_metadata]: Filtered queryset length: {filtered_queryset_length}, '
+                         f'{self.enterprise_catalog}')
         context = self.get_serializer_context()
         context['enterprise_catalog'] = self.enterprise_catalog
         page = self.paginate_queryset(queryset)

--- a/enterprise_catalog/apps/api/v2/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v2/tests/test_views.py
@@ -374,7 +374,7 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
             {'content_keys': filtered_content_keys}
         )
 
-        self.assertEqual(response.data.get('count'), 0)
+        self.assertEqual(response.data.get('count'), 1)
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
     @ddt.data(


### PR DESCRIPTION
## Problem
The `get_content_metadata` endpoint in the Enterprise Catalog API is currently filtering out courses that have no active course runs, even when those courses are specifically requested by content key. This is causing issues with the integrated_channels exporter, which relies on this endpoint to retrieve complete metadata regardless of course run status.
When a specific course is requested using the `content_keys_filter` parameter but has no active course runs, the endpoint returns no data, breaking the expected functionality of the integrated_channels export process.

## Solution
Modify the filtering logic in `get_content_metadata` to only filter out inactive courses when no specific content keys are requested. When specific content keys are provided through the `content_keys_filter` parameter, we will return the full metadata for those courses regardless of whether they have active course runs.

## Post-review

* [x] Squash commits into discrete sets of changes
* [x] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
