### PR TITLE
Fix  add task deleting old tmp indices

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -6,7 +6,7 @@ import re
 import sys
 import time
 from collections import defaultdict
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from operator import itemgetter
 
 from algoliasearch.exceptions import AlgoliaException
@@ -32,9 +32,9 @@ from enterprise_catalog.apps.catalog.algolia_utils import (
     get_initialized_algolia_client,
     get_pathway_course_keys,
     get_pathway_program_uuids,
+    new_search_client_or_error,
     partition_course_keys_for_indexing,
     partition_program_keys_for_indexing,
-    new_search_client_or_error,
 )
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -650,7 +650,7 @@ def _delete_indices(client, indices, dry_run=True):
 
     if dry_run:
         logger.info('dry_run=true, not deleting old tmp indices from Algolia')
-        return indices
+        return
 
     for index_name in indices:
         try:
@@ -664,7 +664,6 @@ def _delete_indices(client, indices, dry_run=True):
             raise exep
 
         logger.info('Finished deleting indices from Algolia')
-    return indices
 
 
 @shared_task(base=LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -627,10 +627,10 @@ def _created_between(datestring, min_days_ago, max_days_ago):
 
 
 def _retrieve_inactive_tmp_indices(client):
-        indices = client.list_indices().get('items', [])
-        tmp_indices = filter(lambda x: x.get('name', '').startswith(f'{settings.ALGOLIA["INDEX_NAME"]}_tmp_'), indices)
-        inactive_tmp_indices = filter(lambda x: _created_between(x.get('createdAt', None), 10, 60), tmp_indices)
-        return list(map(lambda x: x.get('name', ''), inactive_tmp_indices))
+    indices = client.list_indices().get('items', [])
+    tmp_indices = filter(lambda x: x.get('name', '').startswith(f'{settings.ALGOLIA["INDEX_NAME"]}_tmp_'), indices)
+    inactive_tmp_indices = filter(lambda x: _created_between(x.get('createdAt', None), 10, 60), tmp_indices)
+    return list(map(lambda x: x.get('name', ''), inactive_tmp_indices))
 
 
 def _delete_indices(client, indices, dry_run=True):

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -616,7 +616,7 @@ def index_enterprise_catalog_in_algolia_task(self, force=False, dry_run=False): 
 
 @shared_task(base=LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
 @expiring_task_semaphore()
-def remove_old_temporary_catalog_indices(self, force=False, dry_run=False):  # pylint: disable=unused-argument
+def remove_old_temporary_catalog_indices_task(self, force=False, dry_run=False):  # pylint: disable=unused-argument
     """
     Remove old temporary catalog indices from Algolia.
 

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -669,7 +669,9 @@ def _delete_indices(client, indices, dry_run=True):
 
 @shared_task(base=LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
 @expiring_task_semaphore()
-def remove_old_temporary_catalog_indices_task(self, min_days_ago, max_days_ago, force=False, dry_run=True):  # pylint: disable=unused-argument
+def remove_old_temporary_catalog_indices_task(
+    self, force=False, dry_run=True, min_days_ago=10, max_days_ago=60   # pylint: disable=unused-argument
+):
     """
     Remove old temporary catalog indices from Algolia.
 

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -2,7 +2,6 @@ import copy
 import functools
 import json
 import logging
-import re
 import sys
 import time
 from collections import defaultdict
@@ -621,7 +620,7 @@ def _created_between(datestring, min_days_ago, max_days_ago):
         return False
     created_timestamp = datetime.strptime(datestring, '%Y-%m-%dT%H:%M:%S.%fZ').timestamp()
     difference_in_days = (time.time() - created_timestamp) / (60 * 60 * 24)
-    if difference_in_days > min_days_ago and difference_in_days < max_days_ago:
+    if min_days_ago < difference_in_days < max_days_ago:
         return True
     return False
 
@@ -652,6 +651,7 @@ def _delete_indices(client, indices, dry_run=True):
             raise exep
 
         logger.info('Finished deleting indices from Algolia')
+    return indices
 
 
 @shared_task(base=LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1320,7 +1320,9 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
 
             with self.assertLogs(level='INFO') as log_context:
                 # Call the task with the bound task object
-                tasks.remove_old_temporary_catalog_indices_task(bound_task_object, dry_run=False)
+                tasks.remove_old_temporary_catalog_indices_task(
+                    bound_task_object, min_days_ago=10, max_days_ago=60, dry_run=False
+                )
 
                 # Verify the correct indices were identified
                 expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2']
@@ -1378,7 +1380,9 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
 
             with self.assertLogs(level='INFO') as log_context:
                 # Call the task with the bound task object
-                tasks.remove_old_temporary_catalog_indices_task(bound_task_object)
+                tasks.remove_old_temporary_catalog_indices_task(
+                    bound_task_object, min_days_ago=10, max_days_ago=60
+                )
 
                 log_message = [msg for msg in log_context.output if 'Index names to delete' in msg][0]
                 self.assertIn(f'{index_name}_tmp_1', log_message)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -3,9 +3,10 @@ Tests for the enterprise_catalog API celery tasks
 """
 import json
 import uuid
-from datetime import timedelta
+from datetime import timedelta, datetime
 from operator import itemgetter
 from unittest import mock
+
 
 import ddt
 from celery import states
@@ -1259,6 +1260,89 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             {'key': 'course-v1:edX+testX+3', 'foo': 'bar'},
             {'key': 'course-v1:edX+testX+4', 'foo': 'bar'},
         ]
+
+    # Test remove_old_temporary_catalog_indices_task
+    @mock.patch('enterprise_catalog.apps.api.tasks.SearchClient')
+    def test_remove_old_temporary_catalog_indices(self, mock_search_client):
+        """
+        Test that temporary indices between 10 and 60 days old are selected for deletion.
+        """
+        # Setup mock data
+        now = datetime.now()
+        index_name = 'enterprise_catalog_new'
+        # Mock django conf settings.ALGOLIA['INDEX_NAME'] to be 'enterprise_catalog_new'
+        with self.settings(ALGOLIA={'INDEX_NAME': index_name}):
+
+            mock_indices = {
+                'items': [
+                    # Should be included (30 days old)
+                    {
+                        'name': f'{index_name}_tmp_1',
+                        'createdAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                    },
+                    # Should be included (15 days old)
+                    {
+                        'name': f'{index_name}_tmp_2',
+                        'createdAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                    },
+                    # Should not be included (5 days old)
+                    {
+                        'name': f'{index_name}_tmp_3',
+                        'createdAt': (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                    },
+                    # Should not be included (65 days old)
+                    {
+                        'name': f'{index_name}_tmp_4',
+                        'createdAt': (now - timedelta(days=65)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                    },
+                    # Should not be included (not a tmp index)
+                    {
+                        'name': f'{index_name}_production',
+                        'createdAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                    },
+                    # Should not be included (no creation date)
+                    {
+                        'name': f'{index_name}_tmp_5',
+                    },
+                ]
+            }
+
+            # Configure mock
+            mock_client = mock.MagicMock()
+            mock_client.list_indices.return_value = mock_indices
+            mock_search_client.create.return_value = mock_client
+
+            # Create a mock task instance (similar to other tests in the file)
+            mock_task_id = uuid.uuid4()
+            bound_task_object = mock.MagicMock()
+            bound_task_object.request.id = mock_task_id
+            bound_task_object.request.args = ()
+            bound_task_object.request.kwargs = {}
+
+            with self.assertLogs(level='INFO') as log_context:
+                # Call the task with the bound task object
+                tasks.remove_old_temporary_catalog_indices_task(bound_task_object)
+
+                # Verify the correct indices were identified
+                expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2']
+
+                log_message = [msg for msg in log_context.output if 'Index names to delete' in msg][0]
+                self.assertIn(str(expected_indices_to_delete), log_message)
+
+                # Verify SearchClient was created with correct credentials
+                mock_search_client.create.assert_called_once()
+
+                # Test that mock_search_client.init_index was called with the index names to be deleted and none other
+
+                mock_client.init_index.assert_has_calls(
+                    [mock.call(index_name) for index_name in expected_indices_to_delete],
+                    any_order=True
+                )
+
+                # Test that each index `.delete` was called for those
+                for index_name in expected_indices_to_delete:
+                    mock_client.init_index.return_value.delete.assert_any_call()
+
 
     @mock.patch('enterprise_catalog.apps.api.tasks.get_initialized_algolia_client', return_value=mock.MagicMock())
     @override_settings(SHOULD_INDEX_COURSES_WITH_RESTRICTED_RUNS=True)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1375,9 +1375,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
 
                 assert mock_client.init_index.called
 
-                # Test that each index `.delete` was called for those
-                for index_name in expected_indices_to_delete:
-                    mock_client.init_index.return_value.delete.assert_any_call()
+                assert mock_client.init_index.return_value.delete.call_count == len(expected_indices_to_delete)
 
     # Test remove_old_temporary_catalog_indices_task
     @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -3,10 +3,9 @@ Tests for the enterprise_catalog API celery tasks
 """
 import json
 import uuid
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from operator import itemgetter
 from unittest import mock
-
 
 import ddt
 from celery import states

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1345,7 +1345,6 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 for index_name in expected_indices_to_delete:
                     mock_client.init_index.return_value.delete.assert_any_call()
 
-
     # Test remove_old_temporary_catalog_indices_task
     @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
     def test_remove_old_temporary_catalog_indices_should_not_delete_on_dry_run(self, mock_search_client):
@@ -1390,7 +1389,6 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
 
                 assert not mock_client.init_index.called
                 assert not mock_client.init_index.return_value.delete.called
-
 
     @mock.patch('enterprise_catalog.apps.api.tasks.get_initialized_algolia_client', return_value=mock.MagicMock())
     @override_settings(SHOULD_INDEX_COURSES_WITH_RESTRICTED_RUNS=True)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1262,7 +1262,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         ]
 
     # Test remove_old_temporary_catalog_indices_task
-    @mock.patch('enterprise_catalog.apps.api.tasks.SearchClient')
+    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
     def test_remove_old_temporary_catalog_indices(self, mock_search_client):
         """
         Test that temporary indices between 10 and 60 days old are selected for deletion.

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -160,23 +160,6 @@ class AlgoliaSearchClient:
             )
             raise exc
 
-    def list_indices(self):
-        """
-        Returns a list of all index names in Algolia.
-        """
-        if not self.algolia_index:
-            logger.error('Algolia index does not exist. Did you initialize it?')
-            return []
-
-        try:
-            indices = self._client.list_indices()
-            return [index['name'] for index in indices['items']]
-        except AlgoliaException as exc:
-            logger.exception(
-                'Could not list indices in Algolia due to an exception.',
-            )
-            raise exc
-
     def get_all_objects_associated_with_aggregation_key(self, aggregation_key):
         """
         Returns an array of Algolia object IDs associated with the given aggregation key.

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -160,6 +160,23 @@ class AlgoliaSearchClient:
             )
             raise exc
 
+    def list_indices(self):
+        """
+        Returns a list of all index names in Algolia.
+        """
+        if not self.algolia_index:
+            logger.error('Algolia index does not exist. Did you initialize it?')
+            return []
+
+        try:
+            indices = self._client.list_indices()
+            return [index['name'] for index in indices['items']]
+        except AlgoliaException as exc:
+            logger.exception(
+                'Could not list indices in Algolia due to an exception.',
+            )
+            raise exc
+
     def get_all_objects_associated_with_aggregation_key(self, aggregation_key):
         """
         Returns an array of Algolia object IDs associated with the given aggregation key.

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -386,7 +386,10 @@ def new_search_client_or_error():
         settings.ALGOLIA.get('API_KEY', None)
     )
     if not client:
-        raise TypeError(f'client should be an Algolia search client, but was type {type(client)}.')
+        raise TypeError(
+            'Failed to create Algolia search client.' \
+            f'The client should be an Algolia search client, but was {client} of type {type(client)}.'
+        )
     return client
 
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import time
 
+from algoliasearch.search_client import SearchClient
 from dateutil import parser
 from django.conf import settings
 from django.core.cache import cache
@@ -11,7 +12,6 @@ from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext as _
 from pytz import UTC
 
-from algoliasearch.search_client import SearchClient
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.api_client.constants import (
     COURSE_REVIEW_BASE_AVG_REVIEW_SCORE,
@@ -50,6 +50,7 @@ from enterprise_catalog.apps.video_catalog.models import (
     VideoSkill,
     VideoTranscriptSummary,
 )
+
 
 logger = logging.getLogger(__name__)
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -387,7 +387,8 @@ def new_search_client_or_error():
     )
     if not client:
         raise TypeError(
-            f'Failed to create Algolia search client. The client should be an Algolia search client, but was {client}.'  # pylint: disable=line-too-long
+            'Failed to create Algolia search client.'
+            f'The client should be an Algolia search client, but was {client}.'
         )
     return client
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -387,8 +387,7 @@ def new_search_client_or_error():
     )
     if not client:
         raise TypeError(
-            'Failed to create Algolia search client.' \
-            f'The client should be an Algolia search client, but was {client} of type {type(client)}.'
+            f'Failed to create Algolia search client. The client should be an Algolia search client, but was {client} of type {type(client)}.'  # pylint: disable=line-too-long
         )
     return client
 

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -11,6 +11,7 @@ from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext as _
 from pytz import UTC
 
+from algoliasearch.search_client import SearchClient
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.api_client.constants import (
     COURSE_REVIEW_BASE_AVG_REVIEW_SCORE,
@@ -49,7 +50,6 @@ from enterprise_catalog.apps.video_catalog.models import (
     VideoSkill,
     VideoTranscriptSummary,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -374,6 +374,19 @@ def get_initialized_algolia_client():
     algolia_client = AlgoliaSearchClient()
     algolia_client.init_index()
     return algolia_client
+
+
+def new_search_client_or_error():
+    """
+    Returns a new Algolia search client that is not initialized to any specific index.
+    """
+    client = SearchClient.create(
+        settings.ALGOLIA.get('APPLICATION_ID', None),
+        settings.ALGOLIA.get('API_KEY', None)
+    )
+    if not client:
+        raise TypeError(f'client should be an Algolia search client, but was type {type(client)}.')
+    return client
 
 
 def configure_algolia_index(algolia_client):

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -387,7 +387,7 @@ def new_search_client_or_error():
     )
     if not client:
         raise TypeError(
-            f'Failed to create Algolia search client. The client should be an Algolia search client, but was {client} of type {type(client)}.'  # pylint: disable=line-too-long
+            f'Failed to create Algolia search client. The client should be an Algolia search client, but was {client}.'  # pylint: disable=line-too-long
         )
     return client
 

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -38,7 +38,9 @@ class Command(BaseCommand):
         try:
             force_task_execution = options.get('force', False)
             dry_run = options.get('dry_run', False)
-            remove_old_temporary_catalog_indices_task.apply()
+            remove_old_temporary_catalog_indices_task.apply_async(
+                kwargs={'force': force_task_execution, 'dry_run': dry_run}
+            )
             logger.info(
                 'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia' \
                 'finished successfully.'

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -6,6 +6,7 @@ from enterprise_catalog.apps.api.tasks import (
     remove_old_temporary_catalog_indices_task,
 )
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -34,14 +34,14 @@ class Command(BaseCommand):
             dest='min_days',
             default=10,
             type=int,
-            help='List algolia indices to be removed, but do not actually remove them.',
+            help='Minimum number of days ago that an index must have been created to be removed.',
         )
         parser.add_argument(
             '--max-days',
             dest='max_days',
             default=60,
             type=int,
-            help='List algolia indices to be removed, but do not actually remove them.',
+            help='Maximum number of days ago that an index must have been created to be removed.',
         )
 
     def handle(self, *_args, **options):

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = (
-        'Reindex course data in Algolia, adding on enterprise-specific metadata'
+        'Remove old temporary catalog indices from Algolia'
     )
 
     def add_arguments(self, parser):

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -29,6 +29,22 @@ class Command(BaseCommand):
             default=False,
             help='List algolia indices to be removed, but do not actually remove them.',
         )
+        parser.add_argument(
+            '--min-days',
+            dest='min_days',
+            action='store_true',
+            default=10,
+            type=int,
+            help='List algolia indices to be removed, but do not actually remove them.',
+        )
+        parser.add_argument(
+            '--max-days',
+            dest='max_days',
+            action='store_true',
+            default=60,
+            type=int,
+            help='List algolia indices to be removed, but do not actually remove them.',
+        )
 
     def handle(self, *_args, **options):
         """
@@ -38,8 +54,15 @@ class Command(BaseCommand):
         try:
             force_task_execution = options.get('force', False)
             dry_run = options.get('dry_run', False)
+            min_days = options.get('min_days', 10)
+            max_days = options.get('max_days', 60)
             remove_old_temporary_catalog_indices_task.apply_async(
-                kwargs={'force': force_task_execution, 'dry_run': dry_run}
+                kwargs={
+                    'force': force_task_execution,
+                    'dry_run': dry_run,
+                    'min_days_ago': min_days,
+                    'max_days_ago': max_days
+                }
             )
             logger.info(
                 'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia'

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -6,7 +6,6 @@ from enterprise_catalog.apps.api.tasks import (
     remove_old_temporary_catalog_indices_task,
 )
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -42,7 +41,7 @@ class Command(BaseCommand):
                 kwargs={'force': force_task_execution, 'dry_run': dry_run}
             )
             logger.info(
-                'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia' \
+                'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia'
                 'finished successfully.'
             )
         except Exception as exc:  # pylint: disable=broad-except

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -1,0 +1,58 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from enterprise_catalog.apps.api.tasks import (
+    remove_old_temporary_catalog_indices_task,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        'Reindex course data in Algolia, adding on enterprise-specific metadata'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force',
+            default=False,
+            action='store_true',
+            help='Force execution of celery task, ignoring time since last execution.',
+        )
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            action='store_true',
+            default=False,
+            help='List algolia indices to be removed, but do not actually remove them.',
+        )
+
+    def handle(self, *_args, **options):
+        """
+        Runs a celery task to remove leftover catalog `_tmp_` indices
+        that have a creation date between 60 and 10 days ago.
+        """
+        try:
+            force_task_execution = options.get('force', False)
+            dry_run = options.get('dry_run', False)
+            remove_old_temporary_catalog_indices_task.apply_async(
+                kwargs={'force': force_task_execution, 'dry_run': dry_run}
+            ).get()
+            logger.info(
+                'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia' \
+                'finished successfully.'
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            # celery weirdly hijacks and prefixes the path of the below Exception
+            # with `celery.backends.base` when it's raised.
+            # So this block still catches only a specific error, just in a roundabout way.
+            if type(exc).__name__ != 'TaskRecentlyRunError':
+                raise
+            else:
+                logger.info(
+                    'remove_old_temporary_catalog_indices_task was recently run prior to this command, '
+                    'and was thus skipped during the execution of this command.'
+                )

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -38,9 +38,7 @@ class Command(BaseCommand):
         try:
             force_task_execution = options.get('force', False)
             dry_run = options.get('dry_run', False)
-            remove_old_temporary_catalog_indices_task.apply_async(
-                kwargs={'force': force_task_execution, 'dry_run': dry_run}
-            ).get()
+            remove_old_temporary_catalog_indices_task.apply()
             logger.info(
                 'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia' \
                 'finished successfully.'

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -32,7 +32,6 @@ class Command(BaseCommand):
         parser.add_argument(
             '--min-days',
             dest='min_days',
-            action='store_true',
             default=10,
             type=int,
             help='List algolia indices to be removed, but do not actually remove them.',
@@ -40,7 +39,6 @@ class Command(BaseCommand):
         parser.add_argument(
             '--max-days',
             dest='max_days',
-            action='store_true',
             default=60,
             type=int,
             help='List algolia indices to be removed, but do not actually remove them.',

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
@@ -20,7 +20,9 @@ class RemoveOldTemporaryCatalogIndicesCommandTests(TestCase):
         Verify that the job spins off the correct number of remove_old_temporary_catalog_indices_task
         """
         call_command(self.command_name)
-        mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': False})
+        mock_task.apply_async.assert_called_once_with(
+            kwargs={'force': False, 'dry_run': False, 'min_days_ago': 10, 'max_days_ago': 60}
+        )
 
     @mock.patch(PATH_PREFIX + 'remove_old_temporary_catalog_indices_task')
     def test_remove_old_temporary_catalog_indices_dry_run(self, mock_task):
@@ -28,4 +30,6 @@ class RemoveOldTemporaryCatalogIndicesCommandTests(TestCase):
         Verify that the job spins off the correct number of remove_old_temporary_catalog_indices_task
         """
         call_command(self.command_name, dry_run=True)
-        mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': True})
+        mock_task.apply_async.assert_called_once_with(
+            kwargs={'force': False, 'dry_run': True, 'min_days_ago': 10, 'max_days_ago': 60}
+        )

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
@@ -1,0 +1,32 @@
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+
+PATH_PREFIX = 'enterprise_catalog.apps.catalog.management.commands.remove_old_temporary_catalog_indices.'
+
+
+class RemoveOldTemporaryCatalogIndicesCommandTests(TestCase):
+    command_name = 'remove_old_temporary_catalog_indices'
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+    @mock.patch(PATH_PREFIX + 'remove_old_temporary_catalog_indices_task')
+    def test_remove_old_temporary_catalog_indices(self, mock_task):
+        """
+        Verify that the job spins off the correct number of remove_old_temporary_catalog_indices_task
+        """
+        call_command(self.command_name)
+        mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': False})
+
+    @mock.patch(PATH_PREFIX + 'remove_old_temporary_catalog_indices_task')
+    def test_remove_old_temporary_catalog_indices_dry_run(self, mock_task):
+        """
+        Verify that the job spins off the correct number of remove_old_temporary_catalog_indices_task
+        """
+        call_command(self.command_name, dry_run=True)
+        mock_task.apply_async.assert_called_once_with(kwargs={'force': False, 'dry_run': True})

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
@@ -4,7 +4,6 @@ from django.core.management import call_command
 from django.test import TestCase
 
 
-
 PATH_PREFIX = 'enterprise_catalog.apps.catalog.management.commands.remove_old_temporary_catalog_indices.'
 
 

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -1819,3 +1819,25 @@ class AlgoliaUtilsTests(TestCase):
         advertised_course_run = get_advertised_course_run(searchable_course)
         transformed_advertised_course_run = _get_course_run(searchable_course, advertised_course_run)
         assert transformed_advertised_course_run == expected_course_run
+
+    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
+    def test_new_search_client_or_error(self, mock_search_client):
+        """
+        Test that new_search_client_or_error returns a valid search client or raises an error.
+        """
+        mock_client = mock.MagicMock()
+        # Test successful client creation
+        mock_search_client.create.return_value = mock_client
+        client = utils.new_search_client_or_error()
+
+        assert client is mock_client
+        assert mock_search_client.create.call_count == 1
+
+        # Test error case when client creation fails
+        mock_search_client.create.return_value = None
+        with self.assertRaises(TypeError) as context:
+            utils.new_search_client_or_error()
+
+        # Verify the error message
+        self.assertIn('Failed to create Algolia search client', str(context.exception))
+        self.assertIn('should be an Algolia search client', str(context.exception))


### PR DESCRIPTION
## Internal JIRA (2U):

https://2u-internal.atlassian.net/browse/ENT-9872

## Description:

Algolia gets more and more catalog tmp indices over time. This is due to Algolia's behavior to keep tmp indices when running `replace_all_objects` and encountering errors, which happens sometimes. This method is used by us when reindexing.

These tmp indices take up a large space in Algolia, and therefore should be regularly deleted.

This adds a management task that can delete these tmp indices. It filters for them by name to ensure only catalog tmp indices are deleted, and also only deletes tmp indices that are between 10 and 60 days old, to ensure that no indices that are new and in use are deleted.

## To Do:

Add Jenkins command to allow us to manually run this task (including dry run)

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
