### PR TITLE
chore: make remove algolia tmp indices synchronous for dry runs

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -54,14 +54,24 @@ class Command(BaseCommand):
             dry_run = options.get('dry_run', False)
             min_days = options.get('min_days', 10)
             max_days = options.get('max_days', 60)
-            remove_old_temporary_catalog_indices_task.apply_async(
-                kwargs={
-                    'force': force_task_execution,
-                    'dry_run': dry_run,
-                    'min_days_ago': min_days,
-                    'max_days_ago': max_days
-                }
-            )
+            if not dry_run:
+                remove_old_temporary_catalog_indices_task.apply_async(
+                    kwargs={
+                        'force': force_task_execution,
+                        'dry_run': dry_run,
+                        'min_days_ago': min_days,
+                        'max_days_ago': max_days
+                    }
+                )
+            else:
+                remove_old_temporary_catalog_indices_task.apply(
+                    kwargs={
+                        'force': force_task_execution,
+                        'dry_run': dry_run,
+                        'min_days_ago': min_days,
+                        'max_days_ago': max_days
+                    }
+                )
             logger.info(
                 'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia'
                 'finished successfully.'

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_remove_old_temporary_catalog_indices.py
@@ -30,6 +30,6 @@ class RemoveOldTemporaryCatalogIndicesCommandTests(TestCase):
         Verify that the job spins off the correct number of remove_old_temporary_catalog_indices_task
         """
         call_command(self.command_name, dry_run=True)
-        mock_task.apply_async.assert_called_once_with(
+        mock_task.apply.assert_called_once_with(
             kwargs={'force': False, 'dry_run': True, 'min_days_ago': 10, 'max_days_ago': 60}
         )


### PR DESCRIPTION
## Description

The task to remove old algolia tmp indices was added previously. If performed as a dry run, there should be logs displaying which indices will be deleted. However, since the task was async, the logs didn't show up in the CI environment. Thus, I'm changing the dry run only to be synchronous.

## Testing Instructions

- Tests should be green

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
