### PR TITLE
chore: delete tmp indices task should depend on updated_at field

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -629,7 +629,7 @@ def _last_updated_between(index, min_days_ago, max_days_ago):
     max_days_ago_date = (datetime.today() - timedelta(days=max_days_ago)).date()
     if max_days_ago_date < datetime.fromisoformat(datestring).date() < min_days_ago_date:
         logger.info(
-            'Index %s meets condition: min_days %s and max_days %s, because updatedAt: %s', index.get('name', ''),
+            'Index %s meets condition: min_days %s and max_days %s, because updatedAt: %s', index_name,
             min_days_ago,
             max_days_ago,
             datestring
@@ -638,7 +638,7 @@ def _last_updated_between(index, min_days_ago, max_days_ago):
 
     logger.info(
         'Index %s does not meet condition: min_days %s and max_days %s, because updatedAt: %s',
-        index.get('name', ''),
+        index_name,
         min_days_ago,
         max_days_ago,
         datestring
@@ -673,23 +673,23 @@ def _is_empty_index(index):
     Returns whether the index has any entries.
     """
     res = index.get('entries', None)
+    index_name = index.get('name', '')
     if res == 0:
-        logger.info('Index %s meets condition: has 0 entries', index.get('name', ''))
+        logger.info('Index %s meets condition: has 0 entries', index_name)
         return True
 
-    logger.info('Index %s does not meet condition: has 0 entries, because entries: %s', index.get('name', ''), res)
+    logger.info('Index %s does not meet condition: has 0 entries, because entries: %s', index_name, res)
     return False
 
 
-def _is_inactive_tmp_index(index, min_days_ago, max_days_ago):
-    """
-    Returns whether the index is a temporary index that was last updated between min_days_ago and max_days_ago.
-    """
-    logger.info(index)
-    return _is_tmp_index(index) and _last_updated_between(index, min_days_ago, max_days_ago) and _is_empty_index(index)
-
-
 def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
+    def _is_inactive_tmp_index(index, min_days_ago, max_days_ago):
+        """
+        Returns whether the index is a temporary index that was last updated between min_days_ago and max_days_ago.
+        """
+        logger.info(index)
+        return _is_tmp_index(index) and _last_updated_between(index, min_days_ago, max_days_ago) and _is_empty_index(index)
+
     indices = _get_all_indices(client)
     logger.info('Retrieved %d indices from Algolia', len(indices))
     logger.info('Processing indices: \n')

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -666,12 +666,25 @@ def _get_all_indices(client):
     return indices
 
 
+def _is_empty_index(index):
+    """
+    Returns whether the index has any entries.
+    """
+    res = index.get('entries', None)
+    if res == 0:
+        logger.info('Index %s meets condition: has 0 entries, because entries: %s', index.get('name', ''), res)
+        return True
+
+    logger.info('Index %s does not meet condition: has 0 entries, because entries: %s', index.get('name', ''), res)
+    return False
+
+
 def _is_inactive_tmp_index(index, min_days_ago, max_days_ago):
     """
     Returns whether the index is a temporary index that was last updated between min_days_ago and max_days_ago.
     """
     logger.info(index)
-    return _is_tmp_index(index) and _last_updated_between(index, min_days_ago, max_days_ago)
+    return _is_tmp_index(index) and _last_updated_between(index, min_days_ago, max_days_ago) and _is_empty_index(index)
 
 
 def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -688,7 +688,11 @@ def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
         Returns whether the index is a temporary index that was last updated between min_days_ago and max_days_ago.
         """
         logger.info(index)
-        return _is_tmp_index(index) and _last_updated_between(index, min_days_ago, max_days_ago) and _is_empty_index(index)
+        return (
+            _is_tmp_index(index) and
+            _last_updated_between(index, min_days_ago, max_days_ago) and 
+            _is_empty_index(index)
+        )
 
     indices = _get_all_indices(client)
     logger.info('Retrieved %d indices from Algolia', len(indices))

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -619,9 +619,10 @@ def _last_updated_between(index, min_days_ago, max_days_ago):
     """
     Returns whether the index was created between min_days_ago and max_days_ago.
     """
+    index_name = index.get('name', '')
     datestring = index.get('updatedAt', None)
     if not datestring:
-        logger.error('Index %s does not have an updatedAt field.', index.get('name', ''))
+        logger.error('Index %s does not have an updatedAt field.', index_name)
         return False
 
     min_days_ago_date = (datetime.today() - timedelta(days=min_days_ago)).date()

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -689,9 +689,9 @@ def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
         """
         logger.info(index)
         return (
-            _is_tmp_index(index) and
-            _last_updated_between(index, min_days_ago, max_days_ago) and 
-            _is_empty_index(index)
+            _is_tmp_index(index) and (
+                _last_updated_between(index, min_days_ago, max_days_ago) and _is_empty_index(index)
+            )
         )
 
     indices = _get_all_indices(client)

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -639,7 +639,8 @@ def _last_updated_between(index, min_days_ago, max_days_ago):
         'Index %s does not meet condition: min_days %s and max_days %s, because updatedAt: %s',
         index.get('name', ''),
         min_days_ago,
-        max_days_ago, datestring
+        max_days_ago, 
+        datestring
     )
     return False
 

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -639,7 +639,7 @@ def _last_updated_between(index, min_days_ago, max_days_ago):
         'Index %s does not meet condition: min_days %s and max_days %s, because updatedAt: %s',
         index.get('name', ''),
         min_days_ago,
-        max_days_ago, 
+        max_days_ago,
         datestring
     )
     return False

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -615,18 +615,32 @@ def index_enterprise_catalog_in_algolia_task(self, force=False, dry_run=False): 
         raise exep
 
 
-def _created_between(index, min_days_ago, max_days_ago):
+def _last_updated_between(index, min_days_ago, max_days_ago):
     """
     Returns whether the index was created between min_days_ago and max_days_ago.
     """
-    datestring = index.get('createdAt', None)
+    datestring = index.get('updatedAt', None)
     if not datestring:
+        logger.error('Index %s does not have an updatedAt field.', index.get('name', ''))
         return False
 
-    created_timestamp = datetime.strptime(datestring, '%Y-%m-%dT%H:%M:%S.%fZ').timestamp()
-    difference_in_days = (time.time() - created_timestamp) / (60 * 60 * 24)
-    if min_days_ago < difference_in_days < max_days_ago:
+    min_days_ago_date = (datetime.today() - timedelta(days=min_days_ago)).date()
+    max_days_ago_date = (datetime.today() - timedelta(days=max_days_ago)).date()
+    if max_days_ago_date < datetime.fromisoformat(datestring).date() < min_days_ago_date:
+        logger.info(
+            'Index %s meets condition: min_days %s and max_days %s, because updatedAt: %s', index.get('name', ''),
+            min_days_ago,
+            max_days_ago,
+            datestring
+        )
         return True
+
+    logger.info(
+        'Index %s does not meet condition: min_days %s and max_days %s, because updatedAt: %s',
+        index.get('name', ''),
+        min_days_ago,
+        max_days_ago, datestring
+    )
     return False
 
 
@@ -635,13 +649,36 @@ def _is_tmp_index(index):
     Returns whether the index is a temporary index.
     """
     index_name = index.get('name', '')
-    return index_name.startswith(f'{settings.ALGOLIA["INDEX_NAME"]}_tmp_')
+    match = f"{settings.ALGOLIA.get('INDEX_NAME', '')}_tmp_"
+    result = index_name.startswith(match)
+    if result:
+        logger.info('Index %s meets condition: match temporary index name %s', index_name, match)
+    else:
+        logger.info('Index %s does not meet condition: match temporary index name %s', index_name, match)
+    return result
+
+
+def _get_all_indices(client):
+    """
+    Returns a list of indices from the Algolia client.
+    """
+    indices = client.list_indices().get('items', [])
+    return indices
+
+
+def _is_inactive_tmp_index(index, min_days_ago, max_days_ago):
+    """
+    Returns whether the index is a temporary index that was last updated between min_days_ago and max_days_ago.
+    """
+    logger.info(index)
+    return _is_tmp_index(index) and _last_updated_between(index, min_days_ago, max_days_ago)
 
 
 def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
-    indices = client.list_indices().get('items', [])
-    tmp_indices = filter(_is_tmp_index, indices)
-    inactive_tmp_indices = filter(lambda index: _created_between(index, min_days_ago, max_days_ago), tmp_indices)
+    indices = _get_all_indices(client)
+    logger.info('Retrieved %d indices from Algolia', len(indices))
+    logger.info('Processing indices: \n')
+    inactive_tmp_indices = filter(lambda index: _is_inactive_tmp_index(index, min_days_ago, max_days_ago), indices)
     return list(map(lambda index: index.get('name', ''), inactive_tmp_indices))
 
 

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -672,7 +672,7 @@ def _is_empty_index(index):
     """
     res = index.get('entries', None)
     if res == 0:
-        logger.info('Index %s meets condition: has 0 entries, because entries: %s', index.get('name', ''), res)
+        logger.info('Index %s meets condition: has 0 entries', index.get('name', ''))
         return True
 
     logger.info('Index %s does not meet condition: has 0 entries, because entries: %s', index.get('name', ''), res)

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1363,7 +1363,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             bound_task_object.request.args = ()
             bound_task_object.request.kwargs = {}
 
-            with self.assertLogs(level='INFO') as log_context:
+            with self.assertLogs(level='INFO'):
                 # Call the task with the bound task object
                 tasks.remove_old_temporary_catalog_indices_task(
                     bound_task_object, min_days_ago=10, max_days_ago=60, dry_run=False

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1310,27 +1310,27 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                     # Should be included (30 days old)
                     {
                         'name': f'{index_name}_tmp_1',
-                        'createdAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                     },
                     # Should be included (15 days old)
                     {
                         'name': f'{index_name}_tmp_2',
-                        'createdAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                     },
                     # Should not be included (5 days old)
                     {
                         'name': f'{index_name}_tmp_3',
-                        'createdAt': (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                     },
                     # Should not be included (65 days old)
                     {
                         'name': f'{index_name}_tmp_4',
-                        'createdAt': (now - timedelta(days=65)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=65)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                     },
                     # Should not be included (not a tmp index)
                     {
                         'name': index_name,
-                        'createdAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                     },
                     # Should not be included (no creation date)
                     {
@@ -1392,7 +1392,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 'items': [
                     {
                         'name': f'{index_name}_tmp_1',
-                        'createdAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                     }
                 ]
             }

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1310,31 +1310,43 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                     # Should be included (30 days old)
                     {
                         'name': f'{index_name}_tmp_1',
-                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
                     },
                     # Should be included (15 days old)
                     {
                         'name': f'{index_name}_tmp_2',
-                        'updatedAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
+                    },
+                    # # Should not be included (has entries)
+                    {
+                        'name': f'{index_name}_tmp_6',
+                        'updatedAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 1
                     },
                     # Should not be included (5 days old)
                     {
                         'name': f'{index_name}_tmp_3',
-                        'updatedAt': (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=5)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
                     },
                     # Should not be included (65 days old)
                     {
                         'name': f'{index_name}_tmp_4',
-                        'updatedAt': (now - timedelta(days=65)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=65)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
                     },
                     # Should not be included (not a tmp index)
                     {
                         'name': index_name,
-                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
                     },
                     # Should not be included (no creation date)
                     {
                         'name': f'{index_name}_tmp_5',
+                        'entries': 0
                     },
                 ]
             }
@@ -1360,18 +1372,24 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 # Verify the correct indices were identified
                 expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2']
 
-                log_message = [msg for msg in log_context.output if 'Index names to delete' in msg][0]
-                self.assertIn(str(expected_indices_to_delete), log_message)
-
                 # Verify SearchClient was created with correct credentials
                 mock_search_client.create.assert_called_once()
 
                 # Test that mock_search_client.init_index was called with the index names to be deleted and none other
-
                 mock_client.init_index.assert_has_calls(
                     [mock.call(index_name) for index_name in expected_indices_to_delete],
                     any_order=True
                 )
+
+                indexes_not_to_delete = [
+                    index['name'] for index in mock_indices['items']
+                    if index['name'] not in expected_indices_to_delete
+                ]
+
+                # Test that mock_search_client.init_index has no calls for indices that should not be deleted
+                for call in mock_client.init_index.call_args_list:
+                    index_name = call[0][0]
+                    assert index_name not in indexes_not_to_delete, f"Unexpected call to delete index: {index_name}"
 
                 assert mock_client.init_index.called
 
@@ -1392,7 +1410,8 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 'items': [
                     {
                         'name': f'{index_name}_tmp_1',
-                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
                     }
                 ]
             }

--- a/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
+++ b/enterprise_catalog/apps/catalog/management/commands/remove_old_temporary_catalog_indices.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
                     }
                 )
             logger.info(
-                'index_enterprise_catalog_in_algolia_task from command index_enterprise_catalog_in_algolia'
+                'remove_old_temporary_catalog_indices_task from command remove_old_temporary_catalog_indices'
                 'finished successfully.'
             )
         except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
## Description

- Testing deleting tmp indices on prod didn't work. An investigation showed that `created_at` for these tmp indices was set to the creation date of the original index they were copying, in 2020.
- I changed the selection of date range for which indices to delete to use the `updated_at` field. As far as I can see, that corresponds to the `Last Active` display on the Algolia dashboard.
- I introduced logging for each index including its metadata and added logging to track why it becomes marked for deletion or not. That way when testing on prod with dry run, we can exactly trace what is happening.
- I added one more safeguard, just in case, that makes sure the index's `entry` field is 0 (telling us that the index is empty).

## Testing Instructions

- If you don't have Algolia stage set up for enterprise-catalog, edit or create your `enterprise_catalog/settings/private.py`
- Add your Algolia stage credentials like this:

```
ALGOLIA = {
    'INDEX_NAME': 'enterprise_catalog_new',
    'REPLICA_INDEX_NAME': 'enterprise_catalog_new_duration_desc',
    'APPLICATION_ID': <secret>,
    'API_KEY': <secret>,
}
```

- `make dev.up`
- `make app-shell`
- `./manage.py remove_old_temporary_catalog_indices --dry-run`
- Search log output for `"Index names to delete"` to see dry run result

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
