### PR TITLE
chore: remove tmp indices task should include non-empty

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -668,20 +668,6 @@ def _get_all_indices(client):
     return indices
 
 
-def _is_empty_index(index):
-    """
-    Returns whether the index has any entries.
-    """
-    res = index.get('entries', None)
-    index_name = index.get('name', '')
-    if res == 0:
-        logger.info('Index %s meets condition: has 0 entries', index_name)
-        return True
-
-    logger.info('Index %s does not meet condition: has 0 entries, because entries: %s', index_name, res)
-    return False
-
-
 def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
     def _is_inactive_tmp_index(index, min_days_ago, max_days_ago):
         """
@@ -690,7 +676,7 @@ def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
         logger.info(index)
         return (
             _is_tmp_index(index) and (
-                _last_updated_between(index, min_days_ago, max_days_ago) and _is_empty_index(index)
+                _last_updated_between(index, min_days_ago, max_days_ago)
             )
         )
 

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1319,7 +1319,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                         'updatedAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                         'entries': 0
                     },
-                    # # Should not be included (has entries)
+                    # # Should be included (has entries)
                     {
                         'name': f'{index_name}_tmp_6',
                         'updatedAt': (now - timedelta(days=15)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
@@ -1370,7 +1370,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 )
 
                 # Verify the correct indices were identified
-                expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2']
+                expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2', f'{index_name}_tmp_6']
 
                 # Verify SearchClient was created with correct credentials
                 mock_search_client.create.assert_called_once()


### PR DESCRIPTION
Followup to #1069 : 

Non-empty temporary indices should also be deleted with this task, because they are not needed and still take up space on Algolia.

Internal reference link:
https://twou.slack.com/archives/C049C2JGH3L/p1748556349442109