### PR TITLE
fix remove tmp indices date check

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -627,7 +627,7 @@ def _last_updated_between(index, min_days_ago, max_days_ago):
 
     min_days_ago_date = (datetime.today() - timedelta(days=min_days_ago)).date()
     max_days_ago_date = (datetime.today() - timedelta(days=max_days_ago)).date()
-    if max_days_ago_date < datetime.fromisoformat(datestring).date() < min_days_ago_date:
+    if max_days_ago_date < datetime.fromisoformat(datestring).date() <= min_days_ago_date:
         logger.info(
             'Index %s meets condition: min_days %s and max_days %s, because updatedAt: %s', index_name,
             min_days_ago,

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1313,6 +1313,12 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                         'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                         'entries': 0
                     },
+                    # Should be included (10 days old)
+                    {
+                        'name': f'{index_name}_tmp_7',
+                        'updatedAt': (now - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                        'entries': 0
+                    },
                     # Should be included (15 days old)
                     {
                         'name': f'{index_name}_tmp_2',
@@ -1370,7 +1376,7 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 )
 
                 # Verify the correct indices were identified
-                expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2', f'{index_name}_tmp_6']
+                expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2', f'{index_name}_tmp_6', f'{index_name}_tmp_7']
 
                 # Verify SearchClient was created with correct credentials
                 mock_search_client.create.assert_called_once()

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -1376,7 +1376,12 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 )
 
                 # Verify the correct indices were identified
-                expected_indices_to_delete = [f'{index_name}_tmp_1', f'{index_name}_tmp_2', f'{index_name}_tmp_6', f'{index_name}_tmp_7']
+                expected_indices_to_delete = [
+                    f'{index_name}_tmp_1',
+                    f'{index_name}_tmp_2',
+                    f'{index_name}_tmp_6',
+                    f'{index_name}_tmp_7'
+                ]
 
                 # Verify SearchClient was created with correct credentials
                 mock_search_client.create.assert_called_once()


### PR DESCRIPTION
## Description

Minor fix to the date check of the remove-tmp-indices task.
Since the index date was < task min_days_ago, that didn't include the day specified.
For example, if you set min_days_ago to 0, that won't include today.
That makes it difficult to test index deletion on stage, so I'm fixing it here.

## Testing instructions

Correct unit tests are sufficient, so no need for further manual testing.