### PR TITLE
chore: remove deprecated CSRF_TRUSTED_ORIGINS_WITH_SCHEME variable 

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -234,7 +234,6 @@ LANGUAGE_COOKIE_NAME = 'openedx-language-preference'
 
 CSRF_COOKIE_SECURE = False
 CSRF_TRUSTED_ORIGINS = []
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = [] # just for Django 4.2 upgrade
 
 # AUTHENTICATION CONFIGURATION
 LOGIN_URL = '/login/'

--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -94,6 +94,3 @@ CORS_ALLOW_HEADERS = (
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
**Description**
As part of the Django 4.2 upgrade, the temporary variable `CSRF_TRUSTED_ORIGINS_WITH_SCHEME` was introduced to maintain compatibility across Django versions (see [#459](https://github.com/edx/edx-arch-experiments/issues/459)). Since the service is now fully on Django 4.2, we can remove the deprecated `CSRF_TRUSTED_ORIGINS_WITH_SCHEME` variable and related conditional logic.

**Changes**

* Removed the `CSRF_TRUSTED_ORIGINS_WITH_SCHEME` variable from `base.py`
* Removed the conditional assignment logic from `production.py`

**Private 2U JIRA Ticket**
[BOMS-90](https://2u-internal.atlassian.net/browse/BOMS-90)

**Private 2U config change PR**
[Link](https://github.com/edx/edx-internal/pull/13155)
