### PR TITLE
feat: add toggle-favorite-highlight api method

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -6,6 +6,7 @@ from enterprise_catalog.apps.api.v1.utils import (
     get_archived_content_count,
     get_most_recent_modified_time,
     is_course_run_active,
+    strtobool,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
@@ -132,3 +133,13 @@ class ApiUtilsTests(TestCase):
             'is_marketable': False
         }
         assert is_course_run_active(marketable_external_course_run) is True
+
+    def test_strtobool(self):
+        assert strtobool('true') is True
+        assert strtobool('TRUE') is True
+        assert strtobool('false') is False
+        with self.assertRaises(TypeError) as context:
+            strtobool('neithertruenorfalse')
+        with self.assertRaises(TypeError) as context:
+            strtobool(0)
+        assert isinstance(context.exception.__context__, AttributeError)

--- a/enterprise_catalog/apps/api/v1/tests/test_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_utils.py
@@ -6,7 +6,7 @@ from enterprise_catalog.apps.api.v1.utils import (
     get_archived_content_count,
     get_most_recent_modified_time,
     is_course_run_active,
-    strtobool,
+    str_to_bool,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
     ContentMetadataFactory,
@@ -135,11 +135,13 @@ class ApiUtilsTests(TestCase):
         assert is_course_run_active(marketable_external_course_run) is True
 
     def test_strtobool(self):
-        assert strtobool('true') is True
-        assert strtobool('TRUE') is True
-        assert strtobool('false') is False
+        assert str_to_bool('true') is True
+        assert str_to_bool('TRUE') is True
+        assert str_to_bool('false') is False
+        assert str_to_bool(True) is True
+        assert str_to_bool(False) is False
         with self.assertRaises(TypeError) as context:
-            strtobool('neithertruenorfalse')
+            str_to_bool('neithertruenorfalse')
         with self.assertRaises(TypeError) as context:
-            strtobool(0)
+            str_to_bool(0)
         assert isinstance(context.exception.__context__, AttributeError)

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -103,10 +103,19 @@ def get_archived_content_count(highlighted_content):
     return archived_content_count
 
 
-def strtobool(s):
+def str_to_bool(s):
     """
     Convert string value to boolean (case insensitive)
+
+    Returns:
+        (boolean): Boolean value that the passed in boolean/string argument represents
+
+    Raises:
+        (TypeError): If not a string/boolean type, or an invalid boolean string representation
     """
+    if isinstance(s, bool):
+        # If already a boolen then just return it
+        return s
     try:
         strlower = s.lower()
         if strlower == 'true':
@@ -116,4 +125,4 @@ def strtobool(s):
         else:
             raise TypeError(f'Invalid boolean string: {str}')
     except AttributeError as exc:
-        raise TypeError('Argument is not a string') from exc
+        raise TypeError('Argument is not boolean nor string') from exc

--- a/enterprise_catalog/apps/api/v1/utils.py
+++ b/enterprise_catalog/apps/api/v1/utils.py
@@ -101,3 +101,19 @@ def get_archived_content_count(highlighted_content):
         if course_run_statuses and all(status in ('archived', 'unpublished') for status in course_run_statuses):
             archived_content_count += 1
     return archived_content_count
+
+
+def strtobool(s):
+    """
+    Convert string value to boolean (case insensitive)
+    """
+    try:
+        strlower = s.lower()
+        if strlower == 'true':
+            return True
+        elif strlower == 'false':
+            return False
+        else:
+            raise TypeError(f'Invalid boolean string: {str}')
+    except AttributeError as exc:
+        raise TypeError('Argument is not a string') from exc

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -27,9 +27,7 @@ from enterprise_catalog.apps.api.v1.serializers import (
     EnterpriseCurationConfigSerializer,
     HighlightSetSerializer,
 )
-from enterprise_catalog.apps.api.v1.utils import (
-    str_to_bool,
-)
+from enterprise_catalog.apps.api.v1.utils import str_to_bool
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
 from enterprise_catalog.apps.api.v1.views.curation import utils
 from enterprise_catalog.apps.catalog.constants import (

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -27,7 +27,9 @@ from enterprise_catalog.apps.api.v1.serializers import (
     EnterpriseCurationConfigSerializer,
     HighlightSetSerializer,
 )
-from enterprise_catalog.apps.api.v1.utils import strtobool
+from enterprise_catalog.apps.api.v1.utils import (
+    str_to_bool,
+)
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
 from enterprise_catalog.apps.api.v1.views.curation import utils
 from enterprise_catalog.apps.catalog.constants import (
@@ -539,7 +541,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         if not favorite_param:
             return Response({'Error': 'Missing favorite parameter'}, status=status.HTTP_400_BAD_REQUEST)
         try:
-            favorite_toggle = strtobool(favorite_param)
+            favorite_toggle = str_to_bool(favorite_param)
             if not content_uuid:
                 return Response({'Error': 'Missing content_uuid parameter'}, status=status.HTTP_400_BAD_REQUEST)
             highlighted_content = HighlightedContent.objects.get(uuid=content_uuid)

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -13,7 +13,6 @@ from rest_framework.exceptions import ParseError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework_xml.renderers import XMLRenderer
-from enterprise_catalog.apps.api.v1.utils import strtobool
 
 from enterprise_catalog.apps.api.constants import (
     CURATION_CONFIG_READ_ONLY_VIEW_CACHE_TIMEOUT_SECONDS,
@@ -28,6 +27,7 @@ from enterprise_catalog.apps.api.v1.serializers import (
     EnterpriseCurationConfigSerializer,
     HighlightSetSerializer,
 )
+from enterprise_catalog.apps.api.v1.utils import strtobool
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
 from enterprise_catalog.apps.api.v1.views.curation import utils
 from enterprise_catalog.apps.catalog.constants import (


### PR DESCRIPTION
This change adds api method for favoriting/unfavoriting `HighlightedContent` items, to support upcoming work in Admin Portal.

[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10576)

## Testing Instructions
- Set up Highlights locally according to instructions in [Runbook](https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/2153807886/Edit+Highlights+Runbook)
- Get local highlight set uuid
- Execute POST request `http://localhost:18160/api/v1/highlight-sets-admin/:highlight-set-uuid/toggle-favorite-highlight/`, replacing `:highlight-set-uuid` with uuid, with `{"content_uuid":"{highlighted content uuid}", "favorite": "true"}` in the body ([Postman](https://democracylab-here.postman.co/workspace/Personal-Workspace~e052ec32-0605-4b2f-81d7-c8af5538341d/request/7433047-31d5e8b5-b857-40a7-9233-ac2134f4d9d5?action=share&source=copy-link&creator=7433047))
- Verify Highlight Set favorite statues was updated


## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed