### PR TITLE
fix: normalized course price should never fallback to None

### DIFF
--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -595,7 +595,7 @@ class UpdateFullContentMetadataTaskTests(TestCase):
             'end_date': None,
             'enroll_by_date': None,
             'enroll_start_date': None,
-            'content_price': None,
+            'content_price': DEFAULT_NORMALIZED_PRICE,
         }
 
         # make sure course associated program metadata has been created and linked correctly


### PR DESCRIPTION
This fixes a bug where enterprise-access can-redeem returns 422 for an ExecEd course without an advertised course run because it could not tolerate a null price from enterprise-catalog. To solve that case, the fix in this commit is to set the normalized price to the ExecEd entitlement price instead of null. If the course is not an ExecEd course, then fallback to 0.0 dollars instead of null.

[ENT-10866](https://2u-internal.atlassian.net/browse/ENT-10866)