### PR TITLE
feat: try to avoid deadlocks

### DIFF
--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -115,9 +115,10 @@ class TestModels(TestCase):
         mock_client.assert_called_once()
         self.assertEqual(ContentMetadata.objects.count(), 3)
 
+    @ddt.data(True, False)
     @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
     @mock.patch('enterprise_catalog.apps.api_client.discovery.DiscoveryApiClient')
-    def test_contentmetadata_update_from_discovery(self, mock_client):
+    def test_contentmetadata_update_from_discovery(self, try_avoid_deadlock, mock_client):
         """
         update_contentmetadata_from_discovery should update or create ContentMetadata
         objects from the discovery service /search/all api call.
@@ -145,7 +146,8 @@ class TestModels(TestCase):
         catalog = factories.EnterpriseCatalogFactory()
 
         self.assertEqual(ContentMetadata.objects.count(), 0)
-        update_contentmetadata_from_discovery(catalog.catalog_query)
+        with override_settings(TRY_AVOID_DEADLOCK=try_avoid_deadlock):
+            update_contentmetadata_from_discovery(catalog.catalog_query)
         mock_client.assert_called_once()
         self.assertEqual(ContentMetadata.objects.count(), 3)
 

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -466,6 +466,13 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
 # value of the setting below.
 UPDATE_EXISTING_CONTENT_METADATA_BATCH_SIZE = 4
 
+# We can go slightly bigger for selecting existing metadata, but should still
+# remain somewhat small to avoid deadlocks.
+SELECT_EXISTING_CONTENT_METADATA_BATCH_SIZE = 20
+
+# Allows us to opt into experimental deadlock mitigation strategy
+TRY_AVOID_DEADLOCK = False
+
 USE_DEPRECATED_PYTZ = True
 
 # (ENT-5968) This is temporary until offers are implemented in the learner portal


### PR DESCRIPTION
Google [suggests](https://www.google.com/search?q=django+deadlocks+during+bulk_update) the following to avoid deadlocks in django:
### Enforce Consistent Locking Order:
- Sort Records: Before performing a `bulk_update()`, explicitly sort the list of objects by a consistent criterion (e.g., primary key) to ensure all transactions attempt to acquire locks in the same order.
- select_for_update with order_by: If you are fetching records before updating them, use `select_for_update()` within a transaction and ensure you include an `order_by()` clause to specify the locking order.
### Retry Logic: 
[I don't think we want to pursue this strategy]

### Reduce Transaction Scope: 
If possible, break down large `bulk_update` operations into smaller, more focused transactions to minimize the duration of locks and reduce the chances of contention.

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
