### PR TITLE
feat: explicitly retry CM updates/creates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ tx
 .python-version
 
 .dev/
+CLAUDE.md


### PR DESCRIPTION
This PR implements explicit retry logic for content metadata updates and creates to handle database deadlock scenarios. The change introduces a retry mechanism that attempts to process failed metadata operations individually to avoid deadlocks.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
