### PR TITLE
feat: create worker readiness and liveness files on celery signal

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -1335,7 +1335,16 @@ def create_content_metadata(metadata, catalog_query=None, dry_run=False):
     retry_count = 0
     retry_max = getattr(settings, 'CATALOG_CONTENT_METADATA_RETRY_MAX', 1000)
 
-    LOGGER.info('Starting retry loop for keys %s', retry_list)
+    if not retry_list:
+        return metadata_list
+
+    retry_keys = [get_content_key(entry) for entry in retry_list]
+    LOGGER.info(
+        'Starting retry loop for %s keys: %s',
+        len(retry_list),
+        retry_keys,
+    )
+
     while retry_list and (retry_count < retry_max):
         # in this second pass, we'll update one existing record at a time to avoid deadlocks
         retry_count += 1
@@ -1346,7 +1355,11 @@ def create_content_metadata(metadata, catalog_query=None, dry_run=False):
             content_keys, filtered_batched_metadata, dry_run, metadata_list, retry_list,
         )
 
-    LOGGER.info('End retry loop with remaining keys %s, retry_count %s', retry_list, retry_count)
+    LOGGER.info(
+        'End retry loop with remaining keys %s, retry_count %s',
+        retry_keys,
+        retry_count,
+    )
 
     return metadata_list
 

--- a/enterprise_catalog/celery.py
+++ b/enterprise_catalog/celery.py
@@ -1,7 +1,36 @@
 """
 Defines the Celery application for the enterprise_catalog project
 """
+import logging
+from pathlib import Path
+
 from celery import Celery
+from celery.signals import heartbeat_sent, worker_ready, worker_shutdown
+
+
+HEARTBEAT_FILE = Path("/tmp/worker_heartbeat")
+READINESS_FILE = Path("/tmp/worker_ready")
+
+
+logger = logging.getLogger(__name__)
+
+
+@worker_ready.connect
+def worker_ready(**_):
+    logger.info('worker_ready signal received, touching the readiness file')
+    READINESS_FILE.touch()
+
+
+@worker_shutdown.connect
+def worker_shutdown(**_):
+    logger.info('worker_shutdown signal received, unlinking readiness and heartbeat files')
+    READINESS_FILE.unlink(missing_ok=True)
+    HEARTBEAT_FILE.unlink(missing_ok=True)
+
+
+@heartbeat_sent.connect
+def heartbeat(**_):
+    HEARTBEAT_FILE.touch()
 
 
 app = Celery('enterprise_catalog', )


### PR DESCRIPTION
This PR helps implement a better approach to liveness and readiness checks for celery workers running in kubernetes. 
Based on several responses in this issue: https://github.com/celery/celery/issues/4079#issuecomment-112895428

Here's the current issue:
`celery -A apps.config.celery_settings inspect ping` is our liveness check. This seems fine, but actually, the command won't respond if all the worker child processes are busy. This is common for us - the content-metadata syncing tasks can be long-running.
Because the liveness check fails, k8s ends up frequently restarting the worker pods. Those restarts can leave running tasks stuck in a `STARTED` state, which will end up blocking their parent task (usually a celery chord).

Approach:
* Add some celery signal handlers to (periodically) mark some files on the worker container.
* Modify the livenessProbe to look for those files and observe their modified time (done in private config repo).

See also: https://medium.com/ambient-innovation/health-checks-for-celery-in-kubernetes-cf3274a3e106

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
