### PR TITLE
fix: Convert UUIDField columns to uuid type for MariaDB

### DIFF
--- a/enterprise_catalog/apps/academy/migrations/0003_mariadb_uuid_conversion.py
+++ b/enterprise_catalog/apps/academy/migrations/0003_mariadb_uuid_conversion.py
@@ -1,0 +1,56 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE academy_academy MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE academy_historicalacademy MODIFY uuid uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE academy_academy MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE academy_historicalacademy MODIFY uuid char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('academy', '0002_tag_content_metadata'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/enterprise_catalog/apps/catalog/migrations/0044_mariadb_uuid_conversion.py
+++ b/enterprise_catalog/apps/catalog/migrations/0044_mariadb_uuid_conversion.py
@@ -1,0 +1,66 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE catalog_catalogquery MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE catalog_enterprisecatalog MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE catalog_enterprisecatalog MODIFY enterprise_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE catalog_historicalenterprisecatalog MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE catalog_historicalenterprisecatalog MODIFY enterprise_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE catalog_contentmetadata MODIFY content_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE catalog_enterprisecatalogroleassignment MODIFY enterprise_id uuid NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE catalog_catalogquery MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE catalog_enterprisecatalog MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE catalog_enterprisecatalog MODIFY enterprise_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE catalog_historicalenterprisecatalog MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE catalog_historicalenterprisecatalog MODIFY enterprise_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE catalog_contentmetadata MODIFY content_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE catalog_enterprisecatalogroleassignment MODIFY enterprise_id char(32) NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalog', '0043_restricted_course_m2m_field'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/enterprise_catalog/apps/curation/migrations/0005_mariadb_uuid_conversion.py
+++ b/enterprise_catalog/apps/curation/migrations/0005_mariadb_uuid_conversion.py
@@ -1,0 +1,68 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE curation_enterprisecurationconfig MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_enterprisecurationconfig MODIFY enterprise_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalenterprisecurationconfig MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalenterprisecurationconfig MODIFY enterprise_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_highlightset MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalhighlightset MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_highlightedcontent MODIFY uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalhighlightedcontent MODIFY uuid uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE curation_enterprisecurationconfig MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_enterprisecurationconfig MODIFY enterprise_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalenterprisecurationconfig MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalenterprisecurationconfig MODIFY enterprise_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_highlightset MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalhighlightset MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_highlightedcontent MODIFY uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE curation_historicalhighlightedcontent MODIFY uuid char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('curation', '0004_highlightedcontent_is_favorite_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/enterprise_catalog/apps/jobs/migrations/0002_mariadb_uuid_conversion.py
+++ b/enterprise_catalog/apps/jobs/migrations/0002_mariadb_uuid_conversion.py
@@ -1,0 +1,56 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE jobs_jobenterprise MODIFY enterprise_uuid uuid NOT NULL")
+        cursor.execute("ALTER TABLE jobs_historicaljobenterprise MODIFY enterprise_uuid uuid NOT NULL")
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    connection = schema_editor.connection
+    
+    if connection.vendor != 'mysql':
+        return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER TABLE jobs_jobenterprise MODIFY enterprise_uuid char(32) NOT NULL")
+        cursor.execute("ALTER TABLE jobs_historicaljobenterprise MODIFY enterprise_uuid char(32) NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]


### PR DESCRIPTION
## Description
The behavior of the MariaDB backend has changed for UUIDField from a `CharField(32)` to an actual `uuid` type in Django 5. This migration converts affected columns to prevent data insertion errors.

## Supporting information
https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-uuidfield

Related PR: https://github.com/openedx/edx-platform/pull/37494