### PR TITLE
chore: replace enterprise.catalog.app with edx.devstack.enterprise-catalog

### DIFF
--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -11,7 +11,7 @@ services:
 
   app:
     image: edxops/enterprise-catalog-dev
-    container_name: enterprise.catalog.app
+    container_name: edx.devstack.enterprise-catalog
     volumes:
       - ..:/edx/app/enterprise_catalog/enterprise_catalog
     # Use the Django devserver, so that we can hot-reload code changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         docker compose -f .github/docker-compose-github.yml up -d
     - name: Install test dependencies and run validation
       run: |
-        docker exec -e TOXENV=py312-${{ matrix.django-version }} -u root enterprise.catalog.app /edx/app/enterprise_catalog/enterprise_catalog/validate.sh
+        docker exec -e TOXENV=py312-${{ matrix.django-version }} -u root edx.devstack.enterprise-catalog /edx/app/enterprise_catalog/enterprise_catalog/validate.sh
     - name: Code Coverage
       if: matrix.python-version == '3.12' && matrix.django-version=='django52'
       uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,10 @@ dev.provision:
 dev.init: dev.up dev.migrate # start the docker container and run migrations
 
 dev.makemigrations:
-	docker exec -it enterprise.catalog.app bash -c 'cd /edx/app/enterprise-catalog && python3 manage.py makemigrations'
+	docker exec -it edx.devstack.enterprise-catalog bash -c 'cd /edx/app/enterprise-catalog && python3 manage.py makemigrations'
 
 dev.migrate: # Migrates databases. Application and DB server must be up for this to work.
-	docker exec -it enterprise.catalog.app bash -c 'cd /edx/app/enterprise-catalog && make migrate'
+	docker exec -it edx.devstack.enterprise-catalog bash -c 'cd /edx/app/enterprise-catalog && make migrate'
 
 dev.up: dev.up.redis # Starts all containers
 	docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   app:
     image: edxops/enterprise-catalog-dev
-    container_name: enterprise.catalog.app
+    container_name: edx.devstack.enterprise-catalog
     hostname: app.catalog.enterprise
     working_dir: /edx/app/enterprise-catalog
     volumes:

--- a/provision-catalog.sh
+++ b/provision-catalog.sh
@@ -15,11 +15,11 @@ sleep 5
 
 # Run migrations
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker exec -t enterprise.catalog.app bash -c "cd /edx/app/${directory}/ && make migrate"
+docker exec -t edx.devstack.enterprise-catalog bash -c "cd /edx/app/${directory}/ && make migrate"
 
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker exec -t enterprise.catalog.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${directory}/manage.py shell"
+docker exec -t edx.devstack.enterprise-catalog bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${directory}/manage.py shell"
 
 # Provision IDA User in LMS
 echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"


### PR DESCRIPTION
This PR replaces references to the old dev host/container name `enterprise.catalog.app` with `edx.devstack.enterprise-catalog` so Devstack uses a standardized container/hostname. This is a mechanical hostname replacement only; ports and other values are unchanged.