### PR TITLE
Exclude unpublished courses from catalog content metadata API,ENT-11150

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -240,12 +240,12 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
         queryset = self.filter_queryset(self.get_queryset(content_keys_filter=content_keys_filter))
         logger.debug(f'[get_content_metadata]: Original queryset length: {len(queryset)}, {self.enterprise_catalog}')
 
-        # Only filter out archived courses if content_keys_filter is not provided,
-        # to ensure active content is always returned
-        if not content_keys_filter:
-            queryset = [item for item in queryset if self.is_active(item)]
-            filtered_queryset_length = len(queryset)
-            logger.debug(f'[get_content_metadata]: Filtered queryset length: {filtered_queryset_length}, '
+        # Always filter out inactive courses,
+        # to ensure only active content is always returned via API
+        
+        queryset = [item for item in queryset if self.is_active(item)]
+        filtered_queryset_length = len(queryset)
+        logger.debug(f'[get_content_metadata]: Filtered queryset length: {filtered_queryset_length}, '
                          f'{self.enterprise_catalog}')
         context = self.get_serializer_context()
         context['enterprise_catalog'] = self.enterprise_catalog


### PR DESCRIPTION
Root cause:-
The active status filtering was conditionally applied only when no [content_keys_filter] was provided. When specific content keys were requested, the filtering was skipped, allowing inactive courses to slip through.

Changes:-
-Removed the conditional check: Eliminated the if not content_keys_filter: block
to ensure filtering runs unconditionally.
-Unindented the filtering logic: Moved the queryset = [item for item in queryset if self.is_active(item)]
and related debug logging outside the conditional, so it's executed for all requests.
-Updated the comment: Changed to # Always filter out inactive courses to ensure only active content is always returned via API.

Tests:-
-Added unit tests to verify inactive courses are filtered out, and all the test cases were successful.
-Verified locally using mocked catalog content metadata.
-Mocking was used due to lack of real LMS data and was unable to create test courses after lot of trials.
-confirmed courses without active runs are excluded.

<img width="1280" height="622" alt="Screenshot" src="https://github.com/user-attachments/assets/0626d391-7eca-4be1-89ff-b0b51fecafcb" />

